### PR TITLE
Fix CHECK-fail crash in ScatterNd ops when updates rank is too small

### DIFF
--- a/tensorflow/core/kernels/scatter_nd_op.cc
+++ b/tensorflow/core/kernels/scatter_nd_op.cc
@@ -142,6 +142,14 @@ class ScatterNdOp : public ScatterOpBase<Device> {
 
     const int64_t outer_dims = indices.shape().dims() - 1;
 
+    OP_REQUIRES(c, updates.shape().dims() >= outer_dims,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Updates shape must have rank at least the number of "
+                    "outer dimensions of indices (", outer_dims,
+                    "). Found: updates shape=",
+                    updates.shape().DebugString(),
+                    ", indices shape=", indices.shape().DebugString())));
+
     for (int i = 0; i < outer_dims; ++i) {
       OP_REQUIRES(
           c, indices.shape().dim_size(i) == updates.shape().dim_size(i),
@@ -215,6 +223,14 @@ class TensorScatterOp : public ScatterOpBase<Device> {
                     "Indices and updates specified for empty output shape"));
 
     const int64_t outer_dims = indices.shape().dims() - 1;
+
+    OP_REQUIRES(c, updates.shape().dims() >= outer_dims,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Updates shape must have rank at least the number of "
+                    "outer dimensions of indices (", outer_dims,
+                    "). Found: updates shape=",
+                    updates.shape().DebugString(),
+                    ", indices shape=", indices.shape().DebugString())));
 
     for (int i = 0; i < outer_dims; ++i) {
       OP_REQUIRES(c, indices.shape().dim_size(i) == updates.shape().dim_size(i),

--- a/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
@@ -650,6 +650,19 @@ class ScatterNdTest(test.TestCase, parameterized.TestCase):
         r"Dimensions \[\d\,\d\) of input\[shape="):
       self.scatter_nd(indices, updates, shape)
 
+  def testUpdatesRankSmallerThanIndicesOuterDimsInvalid(self):
+    # Regression test for
+    # https://github.com/tensorflow/tensorflow/issues/93680: updates with
+    # rank smaller than the number of outer dimensions of indices used to
+    # crash with a CHECK failure instead of raising an error.
+    indices = array_ops.zeros([4, 1, 1], dtypes.int32)
+    updates = array_ops.zeros([4], dtypes.int32)
+    shape = np.array([8])
+    with self.assertRaisesWithPredicateMatch(
+        (errors.InvalidArgumentError, ValueError),
+        r"rank at least|must match"):
+      self.scatter_nd(indices, updates, shape)
+
   @parameterized.parameters(set((True, context.executing_eagerly())))
   def testGradientsRank2ElementUpdate(self, use_tape):
     for dtype in GRADIENT_TESTS_DTYPES:
@@ -829,6 +842,20 @@ class ScatterNdNonAliasingAddDeterminismTest(ScatterNdDeterminismTest,
 
 
 class ScatterNdTensorTest(test.TestCase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def testUpdatesRankSmallerThanIndicesOuterDimsInvalid(self):
+    # Regression test for
+    # https://github.com/tensorflow/tensorflow/issues/93680: updates with
+    # rank smaller than the number of outer dimensions of indices used to
+    # crash with a CHECK failure instead of raising an error.
+    indices = constant_op.constant([[[4]], [[3]], [[1]], [[7]]])
+    updates = constant_op.constant([9, 10, 11, 12])
+    t = array_ops.ones([8], dtype=dtypes.int32)
+    with self.assertRaisesWithPredicateMatch(
+        (errors.InvalidArgumentError, ValueError),
+        r"rank at least|must match"):
+      self.evaluate(array_ops.tensor_scatter_update(t, indices, updates))
 
   @test_util.run_in_graph_and_eager_modes
   def testUpdateAddSub(self):

--- a/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
@@ -650,6 +650,7 @@ class ScatterNdTest(test.TestCase, parameterized.TestCase):
         r"Dimensions \[\d\,\d\) of input\[shape="):
       self.scatter_nd(indices, updates, shape)
 
+  @test_util.run_in_graph_and_eager_modes
   def testUpdatesRankSmallerThanIndicesOuterDimsInvalid(self):
     # Regression test for
     # https://github.com/tensorflow/tensorflow/issues/93680: updates with
@@ -658,9 +659,12 @@ class ScatterNdTest(test.TestCase, parameterized.TestCase):
     indices = array_ops.zeros([4, 1, 1], dtypes.int32)
     updates = array_ops.zeros([4], dtypes.int32)
     shape = np.array([8])
+    # The message differs per path: the CPU/GPU kernel reports "rank at
+    # least", graph-mode shape inference reports "must match", and the
+    # tf2xla lowering reports "Must have updates.shape = ...".
     with self.assertRaisesWithPredicateMatch(
         (errors.InvalidArgumentError, ValueError),
-        r"rank at least|must match"):
+        r"rank at least|must match|Must have updates\.shape"):
       self.scatter_nd(indices, updates, shape)
 
   @parameterized.parameters(set((True, context.executing_eagerly())))
@@ -852,9 +856,12 @@ class ScatterNdTensorTest(test.TestCase):
     indices = constant_op.constant([[[4]], [[3]], [[1]], [[7]]])
     updates = constant_op.constant([9, 10, 11, 12])
     t = array_ops.ones([8], dtype=dtypes.int32)
+    # The message differs per path: the CPU/GPU kernel reports "rank at
+    # least", graph-mode shape inference reports "must match", and the
+    # tf2xla lowering reports "Must have updates.shape = ...".
     with self.assertRaisesWithPredicateMatch(
         (errors.InvalidArgumentError, ValueError),
-        r"rank at least|must match"):
+        r"rank at least|must match|Must have updates\.shape"):
       self.evaluate(array_ops.tensor_scatter_update(t, indices, updates))
 
   @test_util.run_in_graph_and_eager_modes


### PR DESCRIPTION
Fixes #93680

## Problem

`tf.scatter_nd` aborts the whole process with a fatal `CHECK` failure when the rank of `updates` is smaller than the number of outer dimensions of `indices`:

```python
import tensorflow as tf
indices = tf.constant([[4], [3], [1], [7]])
updates = tf.constant([9, 10, 11, 12])
shape = tf.constant([8])
tf.scatter_nd(tf.expand_dims(indices, axis=-1), updates, shape)
```

```
F0000 tensor_shape.cc:362] Check failed: d < dims() (1 vs. 1)
*** Check failure stack trace: ***
Aborted (core dumped)
```

Reproduced on TF 2.21.0 (pip). The same crash exists in the `TensorScatterUpdate`/`Add`/`Sub`/`Min`/`Max` kernels, e.g. `tf.tensor_scatter_nd_update(tf.ones([8]), tf.zeros([4,1,1], tf.int32), tf.zeros([4]))`.

## Root cause

In `ScatterNdOp::Compute` and `TensorScatterOp::Compute` (`tensorflow/core/kernels/scatter_nd_op.cc`), the outer-dimension matching loop calls `updates.shape().dim_size(i)` for every `i < outer_dims` without first validating that `updates` has at least `outer_dims` dimensions. With `indices` of shape `[4, 1, 1]` (`outer_dims = 2`) and `updates` of rank 1, `dim_size(1)` trips `CHECK(d < dims())` in `TensorShape::dim_size` and aborts.

The deeper kernel path already handles this correctly — `ValidateScatterNdUpdateShape` in `scatter_nd_util.cc` returns `InvalidArgumentError` for `updates_shape.dims() < batch_dim` — but the inline validation in `Compute` crashes before ever reaching it. Graph mode is likewise unaffected (shape inference raises a clean error); only the eager/kernel path aborts.

## Fix

Add a rank guard before the loop in both `Compute` methods so the ops return a regular `InvalidArgumentError` instead of crashing:

```
Updates shape must have rank at least the number of outer dimensions of
indices (2). Found: updates shape=[4], indices shape=[4,1,1]
```

No behavior change for any shapes that pass the guard.

## Tests

Added regression tests in `tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py`:
- `ScatterNdTest.testUpdatesRankSmallerThanIndicesOuterDimsInvalid` (also runs in the inherited `ScatterNdNonAliasingAddTest`, which exercises the already-safe `ScatterNdUpdateOp` path)
- `ScatterNdTensorTest.testUpdatesRankSmallerThanIndicesOuterDimsInvalid` for `tensor_scatter_nd_update`

Both assert `InvalidArgumentError`/`ValueError` is raised instead of a process abort, in graph and eager modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)