### PR TITLE
reject empty row_splits when decoding RaggedTensorVariant

### DIFF
--- a/tensorflow/core/kernels/ragged_tensor_from_variant_op.cc
+++ b/tensorflow/core/kernels/ragged_tensor_from_variant_op.cc
@@ -76,6 +76,12 @@ absl::Status RaggedComponentsFromVariant(
             "Ragged splits must have rank 1; encoded scalar element at index ",
             i, " has splits Tensor ", splits.DebugString()));
       }
+      if (splits.NumElements() < 1) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Ragged splits must have at least one element; encoded scalar "
+            "element at index ",
+            i, " has splits Tensor ", splits.DebugString()));
+      }
     }
   }
   return absl::OkStatus();

--- a/tensorflow/core/kernels/ragged_tensor_from_variant_op_test.cc
+++ b/tensorflow/core/kernels/ragged_tensor_from_variant_op_test.cc
@@ -548,6 +548,17 @@ TEST_F(RaggedTensorFromVariantKernelTest, RaggedSplitRankNotOne) {
                                "Ragged splits must have rank 1"));
 }
 
+TEST_F(RaggedTensorFromVariantKernelTest, RaggedSplitEmpty) {
+  RaggedTensorVariant encoded(Tensor(DT_INT32, {0}), {Tensor(DT_INT64, {0})});
+
+  int input_ragged_rank = 1;
+  int output_ragged_rank = 2;
+  BuildDecodeRaggedTensorGraph<int, int64_t>(
+      input_ragged_rank, output_ragged_rank, TensorShape({1}), {encoded});
+  EXPECT_TRUE(absl::StartsWith(RunOpKernel().message(),
+                               "Ragged splits must have at least one element"));
+}
+
 TEST_F(RaggedTensorFromVariantKernelTest, RaggedValuesTypeMismatch) {
   const std::vector<int64_t> component_split_1_1 = {0, 1};
   const std::vector<int> component_values_1 = {0};

--- a/tensorflow/core/kernels/ragged_tensor_from_variant_op_test.cc
+++ b/tensorflow/core/kernels/ragged_tensor_from_variant_op_test.cc
@@ -549,12 +549,17 @@ TEST_F(RaggedTensorFromVariantKernelTest, RaggedSplitRankNotOne) {
 }
 
 TEST_F(RaggedTensorFromVariantKernelTest, RaggedSplitEmpty) {
-  RaggedTensorVariant encoded(Tensor(DT_INT32, {0}), {Tensor(DT_INT64, {0})});
+  const std::vector<int64_t> component_split_1_1 = {};
+  const std::vector<int> component_values_1 = {0};
+
+  auto variant_component_1 = CreateVariantFromRagged<int, int64_t>(
+      {component_split_1_1}, TensorShape({1}), component_values_1);
 
   int input_ragged_rank = 1;
   int output_ragged_rank = 2;
   BuildDecodeRaggedTensorGraph<int, int64_t>(
-      input_ragged_rank, output_ragged_rank, TensorShape({1}), {encoded});
+      input_ragged_rank, output_ragged_rank, TensorShape({1}),
+      {variant_component_1});
   EXPECT_TRUE(absl::StartsWith(RunOpKernel().message(),
                                "Ragged splits must have at least one element"));
 }


### PR DESCRIPTION
RaggedComponentsFromVariant checks a decoded component's row_splits dtype and rank but never that the tensor is non-empty, so a variant carrying a row_splits of shape [0] gets through. NestedStackRaggedTensors then sizes the stacked splits tensor with `splits(i).NumElements() - 1` per component, which contributes -1 for that component while the write loop below it contributes no writes, so the allocation ends up one element short per empty component and the loop writes past the end with attacker-controlled values; two or more make split_size negative and TensorShape CHECK-fails. RaggedTensorVerifySplits in ragged_utils.h already rejects empty splits and RaggedTensorToVariant runs it on the encode side, so this only rejects inputs the encoder could never have produced.