### PR TITLE
Fix heap out-of-bounds write in CTC loss with empty target sequence

### DIFF
--- a/tensorflow/core/util/ctc/ctc_loss_calculator.h
+++ b/tensorflow/core/util/ctc/ctc_loss_calculator.h
@@ -396,9 +396,12 @@ void CTCLossCalculator<TT>::CalculateForwardVariables(
 
   // Initial alpha values in (GravesTh) Eq 7.5 and Eq 7.6.
   log_alpha->coeffRef(0, 0) = log(y(blank_index_, output_delay_));
-  // Below, l_prime[1] == labels[0]
-  auto label_0 = (l_prime.size() > 1) ? l_prime[1] : blank_index_;
-  log_alpha->coeffRef(1, 0) = log(y(label_0, output_delay_));
+  // Below, l_prime[1] == labels[0]. When the target sequence is empty the
+  // modified sequence l_prime is just a single blank (U == 1), so there is no
+  // second row to initialize; writing it would corrupt the heap.
+  if (U > 1) {
+    log_alpha->coeffRef(1, 0) = log(y(l_prime[1], output_delay_));
+  }
 
   for (int t = 1; t < T; ++t) {
     // If there is not enough time to output the remaining labels or
@@ -452,7 +455,10 @@ void CTCLossCalculator<TT>::CalculateBackwardVariables(
   CHECK_EQ(U, log_beta->rows());
 
   // Initial beta values in (GravesTh) Eq 7.13: log of probability 1.
-  for (int u = U - 2; u < U; ++u) log_beta->coeffRef(u, T - 1) = 0;
+  // Clamp the lower bound to 0 so an empty target sequence (U == 1) does not
+  // index row -1, which would corrupt the heap.
+  for (int u = std::max(0, U - 2); u < U; ++u)
+    log_beta->coeffRef(u, T - 1) = 0;
 
   for (int t = T - 1 - 1; t >= 0; --t) {
     // If there is not enough time to output the remaining labels or

--- a/tensorflow/python/kernel_tests/nn_ops/ctc_loss_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/ctc_loss_op_test.py
@@ -30,6 +30,7 @@ from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import ctc_ops
+from tensorflow.python.ops import gen_ctc_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
@@ -301,6 +302,39 @@ class CTCLossTest(test.TestCase):
       with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
                                   "batch_size must not be 0"):
         sess.run(_ctc_loss_v2(labels, inputs, sequence_lengths))
+
+  @test_util.run_in_graph_and_eager_modes
+  def testSingleClassBlankOnlyLabel(self):
+    # Regression test for a heap out-of-bounds write (reported as an
+    # AddressSanitizer bad-free) in the native CTC loss calculator.  With
+    # num_classes == 1 the only class is the blank label (index
+    # num_classes - 1 == 0), so the label value 0 collapses to an empty target
+    # sequence and the modified sequence l_prime is a single blank (U == 1).
+    # The forward/backward initialization used to unconditionally write the
+    # second row of the alpha/beta matrices, corrupting the heap.  This must
+    # instead compute a finite loss without crashing.
+    inputs = constant_op.constant([[[-1.0]]], dtype=dtypes.float32)
+    labels_indices = constant_op.constant([[0, 0]], dtype=dtypes.int64)
+    labels_values = constant_op.constant([0], dtype=dtypes.int32)
+    sequence_length = constant_op.constant([1], dtype=dtypes.int32)
+
+    loss, gradient = gen_ctc_ops.ctc_loss(
+        inputs=inputs,
+        labels_indices=labels_indices,
+        labels_values=labels_values,
+        sequence_length=sequence_length,
+        preprocess_collapse_repeated=False,
+        ctc_merge_repeated=False,
+        ignore_longer_outputs_than_inputs=False)
+
+    loss_value, gradient_value = self.evaluate((loss, gradient))
+    self.assertAllEqual(loss_value.shape, (1,))
+    self.assertAllEqual(gradient_value.shape, (1, 1, 1))
+    self.assertAllEqual(
+        np.ones_like(loss_value, dtype=np.bool_), np.isfinite(loss_value))
+    self.assertAllEqual(
+        np.ones_like(gradient_value, dtype=np.bool_),
+        np.isfinite(gradient_value))
 
 
 class CTCLossTestV2(test.TestCase, parameterized.TestCase):


### PR DESCRIPTION
### Summary

Fixes #123396 — a heap out-of-bounds write in the native CTC loss CPU
implementation that AddressSanitizer reports as a `bad-free` when calling
`tf.raw_ops.CTCLoss` with a minimal single-class configuration.

### Root cause

`CTCLossOp` hardcodes the blank label as `num_classes - 1`. With
`inputs` shape `[1, 1, 1]`, `num_classes == 1`, so the blank index is `0`.
A label value of `0` therefore equals the blank and is treated as a
"null/finished" label in `PopulateLPrimes`, collapsing the target to an
empty sequence. `GetLPrimeIndices` then produces `l_prime = [blank]`, so
`U = l_prime.size() == 1`.

Two initialization sites in `ctc_loss_calculator.h` assume `U >= 2` and
write outside the `U x T` (here `1 x 1`) alpha/beta matrices:

- `CalculateForwardVariables` unconditionally wrote `log_alpha->coeffRef(1, 0)`
  (row 1 of a 1-row matrix). The surrounding code already anticipated
  `U == 1` via the `l_prime.size() > 1 ? l_prime[1] : blank_index_` ternary,
  but the write itself was not guarded.
- `CalculateBackwardVariables` looped `for (int u = U - 2; u < U; ++u)`,
  starting at `u == -1` and writing `log_beta->coeffRef(-1, T - 1)`.

Both are heap out-of-bounds writes that corrupt the Eigen matrix
allocation metadata, later surfacing as the ASan `bad-free`.

### Fix

Complete the already-intended `U == 1` handling:

- Guard the second-row `log_alpha` initialization behind `if (U > 1)`.
- Clamp the `log_beta` initialization lower bound with `std::max(0, U - 2)`.

The degenerate empty-target case now computes a finite loss
(`-log P(all blanks)`) and gradient instead of corrupting the heap. The
`U > 1` path is unchanged.

### Test

Adds `testSingleClassBlankOnlyLabel` to `ctc_loss_op_test.py`, which
reproduces the exact minimal input from the issue and asserts a finite
loss and gradient of the expected shapes. Runs in both graph and eager
modes. Without the fix this test crashes the process under ASan; with it,
it passes.

### Notes

- No API or behavioral change for valid CTC inputs; only the previously
  crashing degenerate case is affected.
- CLA: signed.
