### PR TITLE
Fix host memory leak in tf.data.Dataset.from_generator during eager execution

### DIFF
--- a/tensorflow/python/ops/script_ops.py
+++ b/tensorflow/python/ops/script_ops.py
@@ -348,14 +348,23 @@ def _internal_py_func(func,
   # i.e., when the current graph is destroyed, we remove its py funcs.
   graph = ops.get_default_graph()
 
-  while True:
-    current_graph = graph
-    if isinstance(graph, function._FuncGraph):  # pylint: disable=protected-access
-      graph = graph._outer_graph  # pylint: disable=protected-access
-    elif isinstance(graph, func_graph.FuncGraph):
-      graph = graph.outer_graph
-    if graph is current_graph:
-      break
+  # If we are already inside a FuncGraph (e.g. during tf.function tracing or
+  # tf.data.Dataset.from_generator), keep the strong reference on that FuncGraph
+  # rather than walking up to the outermost ops.Graph.  The FuncGraph's lifetime
+  # is tied to its ConcreteFunction, so the py_func is released as soon as the
+  # dataset (or tf.function object) is garbage-collected.  Walking up to the
+  # outermost ops.Graph causes a memory leak in eager mode because that graph is
+  # a process-lifetime singleton: every py_func ever registered accumulates there
+  # and is never freed (GitHub #123269).
+  if not isinstance(graph, func_graph.FuncGraph):
+    while True:
+      current_graph = graph
+      if isinstance(graph, function._FuncGraph):  # pylint: disable=protected-access
+        graph = graph._outer_graph  # pylint: disable=protected-access
+      elif isinstance(graph, func_graph.FuncGraph):
+        graph = graph.outer_graph
+      if graph is current_graph:
+        break
 
   # TODO(zhifengc): Consider adding a Graph method to collect
   # `cleanup` objects in one of its member.

--- a/tensorflow/python/ops/script_ops.py
+++ b/tensorflow/python/ops/script_ops.py
@@ -348,7 +348,7 @@ def _internal_py_func(func,
   # i.e., when the current graph is destroyed, we remove its py funcs.
   graph = ops.get_default_graph()
 
-  # If we are already inside a FuncGraph (e.g. during tf.function tracing or
+  # When already inside a FuncGraph (e.g. during tf.function tracing or
   # tf.data.Dataset.from_generator), keep the strong reference on that FuncGraph
   # rather than walking up to the outermost ops.Graph.  The FuncGraph's lifetime
   # is tied to its ConcreteFunction, so the py_func is released as soon as the
@@ -356,13 +356,13 @@ def _internal_py_func(func,
   # outermost ops.Graph causes a memory leak in eager mode because that graph is
   # a process-lifetime singleton: every py_func ever registered accumulates there
   # and is never freed (GitHub #123269).
+  # For legacy _FuncGraph (TF1 graph mode), preserve the original walk-up
+  # behaviour so the py_func outlives the inner function graph.
   if not isinstance(graph, func_graph.FuncGraph):
     while True:
       current_graph = graph
       if isinstance(graph, function._FuncGraph):  # pylint: disable=protected-access
         graph = graph._outer_graph  # pylint: disable=protected-access
-      elif isinstance(graph, func_graph.FuncGraph):
-        graph = graph.outer_graph
       if graph is current_graph:
         break
 


### PR DESCRIPTION
## Bug fix: host RAM leak in `tf.data.Dataset.from_generator` (#123269)

**Reproduction:** Running `from_generator` in a loop leaks ~128 MB of host RSS over 500 iterations even after `del dataset` and `gc.collect()`. GPU VRAM is unaffected.

## Root cause

Every call to `from_generator` traces three closures via `StructuredFunctionWrapper` (`init_func`, `next_func`, `finalize_func`). During tracing those closures call `numpy_function` / `eager_py_func`, which routes through `_internal_py_func` in `script_ops.py`. There, a **strong reference** to each closure is stored:

```python
# script_ops.py – the leak
graph = ops.get_default_graph()
while True:          # walk up to outermost non-FuncGraph
    ...
graph._py_funcs_used_in_graph.append(func)   # ← accumulates forever
```

In eager mode the outermost non-FuncGraph is the **process-lifetime singleton** returned by `ops.get_default_graph()`. It is never destroyed, so `_py_funcs_used_in_graph` grows indefinitely. After 500 iterations, ~1 500 closures accumulate there (each capturing a `generator_state` object), accounting for the ~128 MB RSS growth.

## Fix

When `_internal_py_func` is called while already executing inside a `FuncGraph` (as happens during `StructuredFunctionWrapper` tracing), skip the walk-to-outermost-graph and keep the strong reference on the **FuncGraph itself**:

```python
if not isinstance(graph, func_graph.FuncGraph):
    while True:   # only walk up when NOT already in a FuncGraph
        ...
graph._py_funcs_used_in_graph.append(func)
```

The `FuncGraph`'s lifetime is tied to its `ConcreteFunction` → `StructuredFunctionWrapper` → `Dataset`. When `del dataset` runs and GC collects the chain, the `FuncGraph` is dismantled, `_py_funcs_used_in_graph` on it is released, and all three closures (and their `generator_state` captures) are freed.

In graph mode and in eager mode outside any `FuncGraph` the original behaviour is preserved unchanged.

Fixes #123269