### PR TITLE
reject zero-element non-memcpyable components in UncompressElement

### DIFF
--- a/tensorflow/core/data/compression_utils.cc
+++ b/tensorflow/core/data/compression_utils.cc
@@ -250,6 +250,16 @@ absl::Status UncompressElement(const CompressedElement& compressed,
         compressed.component_metadata(i);
     if (!DataTypeCanUseMemcpy(metadata.dtype()) &&
         metadata.dtype() != DT_STRING) {
+      TensorShape shape(metadata.tensor_shape());
+      if (shape.num_elements() == 0) {
+        // The first two passes reserve and fill `nonmemcpyable` only for
+        // components with a non-zero element count, so there are no bytes
+        // here to deserialize from.
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Zero-element component ", i, " with non-memcpyable dtype ",
+            DataTypeString(metadata.dtype()),
+            " has no uncompressed bytes to deserialize"));
+      }
       TensorProto tp;
       if (!tp.ParseFromString(
               {nonmemcpyable_pos,

--- a/tensorflow/core/data/compression_utils.cc
+++ b/tensorflow/core/data/compression_utils.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/framework/variant_op_registry.h"
+#include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/snappy.h"
 #include "tensorflow/core/platform/status.h"
 #include "tensorflow/core/platform/tstring.h"
@@ -250,7 +251,9 @@ absl::Status UncompressElement(const CompressedElement& compressed,
         compressed.component_metadata(i);
     if (!DataTypeCanUseMemcpy(metadata.dtype()) &&
         metadata.dtype() != DT_STRING) {
-      TensorShape shape(metadata.tensor_shape());
+      TensorShape shape;
+      TF_RETURN_IF_ERROR(
+          TensorShape::BuildTensorShape(metadata.tensor_shape(), &shape));
       if (shape.num_elements() == 0) {
         // The first two passes reserve and fill `nonmemcpyable` only for
         // components with a non-zero element count, so there are no bytes

--- a/tensorflow/core/data/compression_utils.cc
+++ b/tensorflow/core/data/compression_utils.cc
@@ -164,7 +164,9 @@ absl::Status UncompressElement(const CompressedElement& compressed,
       ++num_string_tensors;
       num_string_tensor_strings += metadata.uncompressed_bytes_size();
     } else {
-      TensorShape shape(metadata.tensor_shape());
+      TensorShape shape;
+      TF_RETURN_IF_ERROR(
+          TensorShape::BuildTensorShape(metadata.tensor_shape(), &shape));
       int64_t num_elements = shape.num_elements();
       if (num_elements > 0 && metadata.uncompressed_bytes_size() == 0) {
         return absl::InvalidArgumentError(
@@ -188,7 +190,9 @@ absl::Status UncompressElement(const CompressedElement& compressed,
   char* nonmemcpyable_pos = nonmemcpyable.mdata();
   for (const auto& metadata : compressed.component_metadata()) {
     if (DataTypeCanUseMemcpy(metadata.dtype())) {
-      TensorShape shape(metadata.tensor_shape());
+      TensorShape shape;
+      TF_RETURN_IF_ERROR(
+          TensorShape::BuildTensorShape(metadata.tensor_shape(), &shape));
       int64_t num_elements = shape.num_elements();
       out->emplace_back(metadata.dtype(), metadata.tensor_shape());
       TensorBuffer* buffer = DMAHelper::buffer(&out->back());
@@ -214,7 +218,9 @@ absl::Status UncompressElement(const CompressedElement& compressed,
         iov.Add(flats.data()[i].mdata(), metadata.uncompressed_bytes(i));
       }
     } else {
-      TensorShape shape(metadata.tensor_shape());
+      TensorShape shape;
+      TF_RETURN_IF_ERROR(
+          TensorShape::BuildTensorShape(metadata.tensor_shape(), &shape));
       int64_t num_elements = shape.num_elements();
       out->emplace_back();
       if (num_elements > 0) {

--- a/tensorflow/core/data/compression_utils.cc
+++ b/tensorflow/core/data/compression_utils.cc
@@ -160,13 +160,13 @@ absl::Status UncompressElement(const CompressedElement& compressed,
   size_t num_string_tensor_strings = 0;
   size_t total_nonmemcpyable_size = 0;
   for (const auto& metadata : compressed.component_metadata()) {
+    TensorShape shape;
+    TF_RETURN_IF_ERROR(
+        TensorShape::BuildTensorShape(metadata.tensor_shape(), &shape));
     if (metadata.dtype() == DT_STRING) {
       ++num_string_tensors;
       num_string_tensor_strings += metadata.uncompressed_bytes_size();
     } else {
-      TensorShape shape;
-      TF_RETURN_IF_ERROR(
-          TensorShape::BuildTensorShape(metadata.tensor_shape(), &shape));
       int64_t num_elements = shape.num_elements();
       if (num_elements > 0 && metadata.uncompressed_bytes_size() == 0) {
         return absl::InvalidArgumentError(
@@ -194,7 +194,7 @@ absl::Status UncompressElement(const CompressedElement& compressed,
       TF_RETURN_IF_ERROR(
           TensorShape::BuildTensorShape(metadata.tensor_shape(), &shape));
       int64_t num_elements = shape.num_elements();
-      out->emplace_back(metadata.dtype(), metadata.tensor_shape());
+      out->emplace_back(metadata.dtype(), shape);
       TensorBuffer* buffer = DMAHelper::buffer(&out->back());
       if (buffer && num_elements > 0) {
         if (metadata.uncompressed_bytes(0) > buffer->size()) {
@@ -205,7 +205,10 @@ absl::Status UncompressElement(const CompressedElement& compressed,
         iov.Add(buffer->data(), metadata.uncompressed_bytes(0));
       }
     } else if (metadata.dtype() == DT_STRING) {
-      out->emplace_back(metadata.dtype(), metadata.tensor_shape());
+      TensorShape shape;
+      TF_RETURN_IF_ERROR(
+          TensorShape::BuildTensorShape(metadata.tensor_shape(), &shape));
+      out->emplace_back(metadata.dtype(), shape);
       const auto& flats = out->back().unaligned_flat<tstring>();
       if (metadata.uncompressed_bytes_size() > flats.size()) {
         return absl::InvalidArgumentError(absl::StrCat(

--- a/tensorflow/core/data/compression_utils_test.cc
+++ b/tensorflow/core/data/compression_utils_test.cc
@@ -44,6 +44,27 @@ TEST(CompressionUtilsTest, Exceeds4GB) {
                              HasSubstr("exceeding the 4GB Snappy limit")));
 }
 
+TEST(CompressionUtilsTest, ZeroElementNonMemcpyableComponent) {
+  // Compressing an empty element yields a `data` field holding zero
+  // uncompressed bytes, so the size reconciliation against the (empty) iovec
+  // succeeds and the third pass is reached.
+  std::vector<Tensor> empty_element;
+  CompressedElement compressed;
+  TF_ASSERT_OK(CompressElement(empty_element, &compressed));
+
+  CompressedComponentMetadata* metadata =
+      compressed.mutable_component_metadata()->Add();
+  metadata->set_dtype(DT_VARIANT);
+  TensorShape empty_shape({0});
+  empty_shape.AsProto(metadata->mutable_tensor_shape());
+  metadata->add_uncompressed_bytes(65536);
+
+  std::vector<Tensor> element;
+  EXPECT_THAT(UncompressElement(compressed, &element),
+              absl_testing::StatusIs(error::INVALID_ARGUMENT,
+                                     HasSubstr("Zero-element component")));
+}
+
 std::vector<std::vector<Tensor>> TestCases() {
   return {
       // Single int64.

--- a/tensorflow/core/data/compression_utils_test.cc
+++ b/tensorflow/core/data/compression_utils_test.cc
@@ -65,6 +65,23 @@ TEST(CompressionUtilsTest, ZeroElementNonMemcpyableComponent) {
                                      HasSubstr("Zero-element component")));
 }
 
+TEST(CompressionUtilsTest, MalformedTensorShape) {
+  // A malformed shape proto (negative dimension) must be rejected with a
+  // status instead of aborting the direct `TensorShape` constructor.
+  std::vector<Tensor> empty_element;
+  CompressedElement compressed;
+  TF_ASSERT_OK(CompressElement(empty_element, &compressed));
+
+  CompressedComponentMetadata* metadata =
+      compressed.mutable_component_metadata()->Add();
+  metadata->set_dtype(DT_INT64);
+  metadata->mutable_tensor_shape()->add_dim()->set_size(-1);
+
+  std::vector<Tensor> element;
+  EXPECT_THAT(UncompressElement(compressed, &element),
+              absl_testing::StatusIs(error::INVALID_ARGUMENT));
+}
+
 std::vector<std::vector<Tensor>> TestCases() {
   return {
       // Single int64.

--- a/tensorflow/core/data/compression_utils_test.cc
+++ b/tensorflow/core/data/compression_utils_test.cc
@@ -82,6 +82,24 @@ TEST(CompressionUtilsTest, MalformedTensorShape) {
               absl_testing::StatusIs(error::INVALID_ARGUMENT));
 }
 
+TEST(CompressionUtilsTest, MalformedTensorShapeString) {
+  // A `DT_STRING` component with a malformed shape proto (negative dimension)
+  // must also be rejected with a status rather than aborting the direct
+  // `TensorShape` constructor when the string tensor is built.
+  std::vector<Tensor> empty_element;
+  CompressedElement compressed;
+  TF_ASSERT_OK(CompressElement(empty_element, &compressed));
+
+  CompressedComponentMetadata* metadata =
+      compressed.mutable_component_metadata()->Add();
+  metadata->set_dtype(DT_STRING);
+  metadata->mutable_tensor_shape()->add_dim()->set_size(-1);
+
+  std::vector<Tensor> element;
+  EXPECT_THAT(UncompressElement(compressed, &element),
+              absl_testing::StatusIs(error::INVALID_ARGUMENT));
+}
+
 std::vector<std::vector<Tensor>> TestCases() {
   return {
       // Single int64.


### PR DESCRIPTION
UncompressElement sizes and fills the nonmemcpyable scratch buffer only for components with a non-zero element count, but the third pass walks it for every non-memcpyable non-string component regardless of shape. A CompressedElement carrying a DT_VARIANT component of shape [0] with a large uncompressed_bytes reserves no space and adds no iovec, so the size reconciliation against the snappy length still passes and ParseFromString then reads an attacker-chosen length past a zero-length heap buffer; this decodes straight from a Variant, so tf.data snapshot files and tf.raw_ops.UncompressElement reach it. Reject zero-element components there so the third pass walks exactly the bytes the first pass reserved.