### PR TITLE
Fix bfloat16 CPU Rsqrt length-dependent double rounding

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -844,6 +844,36 @@ struct functor_traits<scalar_erfinv_op<float>> {
   };
 };
 
+// Eigen's default scalar rsqrt for bfloat16 is `1 / sqrt(x)`, and both the
+// division and the sqrt cast back to bfloat16. That double-rounds, so results
+// depend on whether Eigen takes the scalar path (tensors shorter than the
+// packet width) or the packet path (which converts the whole packet to float,
+// computes float rsqrt, and casts once). Specialize the scalar path to match
+// the packet path: compute in float and cast back once.
+//
+// See https://github.com/tensorflow/tensorflow/issues/123551.
+template <>
+struct scalar_rsqrt_op<bfloat16> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE bfloat16 operator()(
+      const bfloat16& a) const {
+    return bfloat16(numext::rsqrt(static_cast<float>(a)));
+  }
+
+  template <typename Packet>
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(
+      const Packet& a) const {
+    return prsqrt(a);
+  }
+};
+
+template <>
+struct functor_traits<scalar_rsqrt_op<bfloat16>> {
+  enum {
+    Cost = 5 * NumTraits<bfloat16>::MulCost,
+    PacketAccess = packet_traits<bfloat16>::HasRsqrt,
+  };
+};
+
 }  // end namespace internal
 }  // end namespace Eigen
 

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -455,7 +455,7 @@ class UnaryOpTest(test.TestCase):
     self._compareCpu(z, compute_f32(np.log), math_ops.log)
     self._compareCpu(z, compute_f32(np.log1p), math_ops.log1p)
     self._compareBoth(y, np.sign, math_ops.sign)
-    self._compareCpu(z, self._rsqrt, math_ops.rsqrt)
+    self._compareCpu(z, compute_f32(self._rsqrt), math_ops.rsqrt)
     self._compareCpu(x, np.square, math_ops.square)
     self._compareBoth(x, compute_f32(np.sin), math_ops.sin)
     self._compareBoth(x, compute_f32(np.cos), math_ops.cos)
@@ -473,6 +473,23 @@ class UnaryOpTest(test.TestCase):
     self._compareBoth(x, compute_f32(np.vectorize(math.erf)), math_ops.erf)
     self._compareBoth(x, compute_f32(np.vectorize(math.erfc)), math_ops.erfc)
     self._compareBoth(x, compute_f32(np.square), math_ops.square)
+
+  def testBFloat16RsqrtLengthIndependent(self):
+    # Regression test for https://github.com/tensorflow/tensorflow/issues/123551
+    # Scalar and packet CPU paths must agree for the same bfloat16 value.
+    bfloat16 = dtypes_lib.bfloat16.as_numpy_dtype
+    value = np.array(0.53125, dtype=bfloat16)
+    # High-precision reference, rounded once to bfloat16 (matches the packet
+    # path and XLA).
+    reference = np.array(
+        1.0 / np.sqrt(np.float64(value)), dtype=bfloat16)
+
+    for length in (1, 7, 8, 9, 16, 32):
+      x = np.full([length], value, dtype=bfloat16)
+      y = self.evaluate(math_ops.rsqrt(x))
+      self.assertAllEqual(
+          y, np.full([length], reference, dtype=bfloat16),
+          msg="length=%d" % length)
 
   def testInt8Basic(self):
     x = np.arange(-6, 6, 2).reshape(1, 3, 2).astype(np.int8)


### PR DESCRIPTION
Fixes #123551

### Description

On CPU, `tf.math.rsqrt` with `bfloat16` returned different values for the same input depending on tensor length. For `0.53125`:

- lengths 1–7 (scalar Eigen path): `1.3671875`
- lengths ≥ 8 (AVX packet path): `1.375`
- XLA / correctly rounded reference: `1.375`

### Root cause

Eigen's default scalar `rsqrt` is `1 / sqrt(x)`. For bfloat16 both operations cast back to bfloat16, so the scalar path double-rounds. The packet path converts the packet to float, computes float `rsqrt`, and casts once — so results change at the SIMD packet boundary.

### Solution

Specialize `Eigen::internal::scalar_rsqrt_op<bfloat16>` in `cwise_ops.h` to compute `rsqrt` in float and cast to bfloat16 once.
Keep `packetOp` / `PacketAccess` so CPU vectorization is unchanged.

### Changes

- `tensorflow/core/kernels/cwise_ops.h` — bfloat16 `scalar_rsqrt_op`  specialization
- `tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py` —  compare bf16 rsqrt against float32 reference; add
  `testBFloat16RsqrtLengthIndependent` for lengths `1, 7, 8, 9, 16, 32`

### Tests

- `//tensorflow/python/kernel_tests/math_ops:cwise_ops_unary_test`