### PR TITLE
Fix NaN gradient of tf.math.igamma at a=1, x=0

### DIFF
--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -1166,7 +1166,12 @@ def _IgammaGrad(op: ops.Operation, grad):
     partial_a = gen_math_ops.igamma_grad_a(a, x)
     # Perform operations in log space before summing, because Gamma(a)
     # and Gamma'(a) can grow large.
-    partial_x = math_ops.exp(-x + (a - 1) * math_ops.log(x) -
+    # Use xlogy so that the (a - 1) * log(x) term evaluates to 0 (not NaN)
+    # when a == 1 and x == 0. The true derivative there is
+    # d/dx igamma(1, x) = e^-x = 1, so `(a - 1) * log(x)` computing
+    # `0 * -inf = NaN` is incorrect. This mirrors the neighboring Betainc
+    # gradient, which already uses xlogy for the same reason.
+    partial_x = math_ops.exp(-x + math_ops.xlogy(a - 1, x) -
                              math_ops.lgamma(a))
     return (array_ops.reshape(math_ops.reduce_sum(partial_a * grad, ra), sa),
             array_ops.reshape(math_ops.reduce_sum(partial_x * grad, rx), sx))

--- a/tensorflow/python/ops/math_grad_test.py
+++ b/tensorflow/python/ops/math_grad_test.py
@@ -834,5 +834,47 @@ class NextAfterTest(test.TestCase):
         self.assertLess(err, 1e-3)
 
 
+class IgammaGradTest(test.TestCase):
+
+  def _x_grad(self, op, a, x):
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = op(a, x)
+    return self.evaluate(tape.gradient(y, x))
+
+  @test_util.run_in_graph_and_eager_modes
+  def testIgammaGradXNonZero(self):
+    # Interior point: d/dx igamma(a, x) = x^(a-1) * e^-x / Gamma(a).
+    for dtype in [dtypes.float32, dtypes.float64]:
+      a = constant_op.constant(2.0, dtype=dtype)
+      x = constant_op.constant(1.5, dtype=dtype)
+      xgrad = self._x_grad(math_ops.igamma, a, x)
+      expected = np.array(1.5 * np.exp(-1.5), dtype=dtype.as_numpy_dtype)
+      self.assertAllClose(expected, xgrad)
+
+  @test_util.run_in_graph_and_eager_modes
+  def testIgammaGradXAtZero(self):
+    # igamma(1, x) = 1 - e^-x, so d/dx at (a=1, x=0) is e^0 = 1 (not NaN).
+    # For a > 1 the derivative is 0; for a < 1 it diverges to +inf.
+    for dtype in [dtypes.float32, dtypes.float64]:
+      a = constant_op.constant([0.5, 1.0, 1.5, 2.0], dtype=dtype)
+      x = constant_op.constant([0.0, 0.0, 0.0, 0.0], dtype=dtype)
+      xgrad = self._x_grad(math_ops.igamma, a, x)
+      self.assertAllClose(
+          np.array([np.inf, 1.0, 0.0, 0.0], dtype=dtype.as_numpy_dtype), xgrad)
+
+  @test_util.run_in_graph_and_eager_modes
+  def testIgammacGradXAtZero(self):
+    # igammac(a, x) = 1 - igamma(a, x), so its x-gradient is the negation;
+    # _IgammacGrad delegates to _IgammaGrad and inherits the same fix.
+    for dtype in [dtypes.float32, dtypes.float64]:
+      a = constant_op.constant([0.5, 1.0, 1.5, 2.0], dtype=dtype)
+      x = constant_op.constant([0.0, 0.0, 0.0, 0.0], dtype=dtype)
+      xgrad = self._x_grad(math_ops.igammac, a, x)
+      self.assertAllClose(
+          np.array([-np.inf, -1.0, 0.0, 0.0], dtype=dtype.as_numpy_dtype),
+          xgrad)
+
+
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
Fixes #123578

 _IgammaGrad computed partial_x = exp(-x + (a-1)*log(x) - lgamma(a)).
  
At a==1, x==0 the term (a-1)*log(x) is 0 * -inf = NaN, so the gradient of tf.math.igamma w.r.t. x is NaN there. The true derivative is d/dx igamma(1, x) = e^-x = 1. Use xlogy(a-1, x) instead, matching _BetaincGrad which already does this. Other regimes unchanged (a>1 -> 0, a<1 -> +inf, nonzero x identical). Adds IgammaGradTest.

Reproduced on tf-nightly 2.22.0-dev20260718.