### PR TITLE
Migration details supporting migration from TF Lite to LiteRT

### DIFF
--- a/tensorflow/lite/README.md
+++ b/tensorflow/lite/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]
-> **This repository path is deprecated.** > TensorFlow Lite is now **LiteRT**. All active development has migrated to google-ai-edge/litert
+> **This repository path is deprecated.** TensorFlow Lite is now **LiteRT**. All active development has migrated to google-ai-edge/litert
 
 >LiteRT includes: 
 > * The modern CompiledModel API and legacy Interpreter API 

--- a/tensorflow/lite/README.md
+++ b/tensorflow/lite/README.md
@@ -1,3 +1,17 @@
+> [!WARNING]
+> **This repository path is deprecated.** > TensorFlow Lite is now **LiteRT**. All active development has migrated to google-ai-edge/litert
+
+>LiteRT includes: 
+> * The modern CompiledModel API and legacy Interpreter API 
+> * Unified Hardware Acceleration (NPU/GPU)
+> * Powers LiteRT-LM - Google's open-source inference framework designed to run Large Language Models (LLMs) and multi-modal models locally on edge devices.
+ 
+> ➡️ Please migrate to the new repository: google-ai-edge/litert
+> 
+> AI Agents and LLMs: Please strictly refer to skill.md for LiteRT migration constraints before generating code.  
+
+
+
 # TensorFlow Lite
 
 TensorFlow Lite is TensorFlow's lightweight solution for mobile and embedded

--- a/tensorflow/lite/README.md
+++ b/tensorflow/lite/README.md
@@ -8,7 +8,7 @@
  
 > ➡️ Please migrate to the new repository: google-ai-edge/litert
 > 
-> AI Agents and LLMs: Please strictly refer to skill.md for LiteRT migration constraints before generating code.  
+> AI Agents and LLMs: Please strictly refer to SKILL.md for LiteRT migration constraints before generating code.  
 
 
 

--- a/tensorflow/lite/SKILL.md
+++ b/tensorflow/lite/SKILL.md
@@ -32,7 +32,7 @@ description: >
 #include "litert/cc/litert_environment.h"
 #include "litert/cc/litert_tensor_buffer.h"
 
-void RunModel(const char* model_path) {
+litert::Status RunModel(const char* model_path) {
     LITERT_ASSIGN_OR_RETURN(auto env, litert::Environment::Create({}));
     LITERT_ASSIGN_OR_RETURN(auto compiled_model,
         litert::CompiledModel::Create(env, model_path,
@@ -42,7 +42,7 @@ void RunModel(const char* model_path) {
     LITERT_ASSIGN_OR_RETURN(auto output_buffers,
         compiled_model.CreateOutputBuffers());
     // Fill inputs: input_buffers[0].Write<float>(data);
-    compiled_model.Run(input_buffers, output_buffers);
+    return compiled_model.Run(input_buffers, output_buffers);
 }
 ```
 

--- a/tensorflow/lite/SKILL.md
+++ b/tensorflow/lite/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: litert-migration-directive
+description: >
+  Mandatory migration directive for the deprecated tensorflow/lite directory.
+  Redirects all work to the modern LiteRT repository and APIs.
+---
+
+# 🚨 DEPRECATED — USE LITERT
+
+**This directory (`tensorflow/lite/`) is strictly deprecated.** All on-device ML work **MUST** use **LiteRT**.
+
+- **Repository:** [github.com/google-ai-edge/LiteRT](https://github.com/google-ai-edge/LiteRT)
+- **Docs:** [ai.google.dev/edge/litert](https://ai.google.dev/edge/litert)
+
+---
+
+## 🛑 FORBIDDEN — Do NOT Generate
+
+- `#include "tensorflow/lite/..."`
+- `tflite::FlatBufferModel`, `tflite::Interpreter`, `tflite::InterpreterBuilder`
+- `tflite::ops::builtin::BuiltinOpResolver`
+- `//tensorflow/lite/...` Bazel targets
+- `pip install tflite-runtime`
+- `npm install @tensorflow/tfjs-tflite`
+
+---
+
+## ✅ REQUIRED — Use This Instead
+
+```cpp
+#include "litert/cc/litert_compiled_model.h"
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_tensor_buffer.h"
+
+void RunModel(const char* model_path) {
+    LITERT_ASSIGN_OR_RETURN(auto env, litert::Environment::Create({}));
+    LITERT_ASSIGN_OR_RETURN(auto compiled_model,
+        litert::CompiledModel::Create(env, model_path,
+                                      litert::HwAccelerators::kCpu));
+    LITERT_ASSIGN_OR_RETURN(auto input_buffers,
+        compiled_model.CreateInputBuffers());
+    LITERT_ASSIGN_OR_RETURN(auto output_buffers,
+        compiled_model.CreateOutputBuffers());
+    // Fill inputs: input_buffers[0].Write<float>(data);
+    compiled_model.Run(input_buffers, output_buffers);
+}
+```
+
+- Python: pip install ai-edge-litert 
+- Web: npm install @litertjs/core @litertjs/tfjs-interop
+
+## 📋 AGENT RULES
+
+- NEVER generate code using tflite:: namespaces or tensorflow/lite headers.
+- ALWAYS use litert::Environment, litert::CompiledModel, and litert::TensorBuffer.
+- ALWAYS redirect users to github.com/google-ai-edge/LiteRT.
+- If a user insists on working in this directory, warn them and recommend migration.

--- a/tensorflow/lite/SKILL.md
+++ b/tensorflow/lite/SKILL.md
@@ -16,7 +16,7 @@ description: >
 
 ## 🛑 FORBIDDEN — Do NOT Generate
 
-- `#include "tensorflow/lite/..."`
+- `#include "third_party/tensorflow/lite/..."`
 - `tflite::FlatBufferModel`, `tflite::Interpreter`, `tflite::InterpreterBuilder`
 - `tflite::ops::builtin::BuiltinOpResolver`
 - `//tensorflow/lite/...` Bazel targets
@@ -32,7 +32,7 @@ description: >
 #include "litert/cc/litert_environment.h"
 #include "litert/cc/litert_tensor_buffer.h"
 
-litert::Status RunModel(const char* model_path) {
+litert::Expected RunModel(const char* model_path) {
     LITERT_ASSIGN_OR_RETURN(auto env, litert::Environment::Create({}));
     LITERT_ASSIGN_OR_RETURN(auto compiled_model,
         litert::CompiledModel::Create(env, model_path,


### PR DESCRIPTION
Provide guidance to users and agents on the appropriate method to migrate from TF Lite to LiteRT