### PR TITLE
Fix segfault in tf.raw_ops.WriteScalarSummary for invalid value tensors

### DIFF
--- a/tensorflow/core/kernels/summary_kernels.cc
+++ b/tensorflow/core/kernels/summary_kernels.cc
@@ -224,6 +224,10 @@ class WriteScalarSummaryOp : public OpKernel {
 
     const Tensor* t;
     OP_REQUIRES_OK(ctx, ctx->input("value", &t));
+    OP_REQUIRES(ctx, t->NumElements() == 1,
+                errors::InvalidArgument(
+                    "value must contain exactly one element, got shape ",
+                    t->shape().DebugString()));
 
     OP_REQUIRES_OK(ctx, s->WriteScalar(step, *t, tag));
   }

--- a/tensorflow/python/kernel_tests/summary_ops/summary_ops_test.py
+++ b/tensorflow/python/kernel_tests/summary_ops/summary_ops_test.py
@@ -34,6 +34,7 @@ from tensorflow.python.framework import tensor_util
 from tensorflow.python.framework import test_util
 from tensorflow.python.lib.io import tf_record
 from tensorflow.python.module import module
+from tensorflow.python.ops import gen_summary_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import summary_ops_v2 as summary_ops
 from tensorflow.python.ops import variables
@@ -1568,6 +1569,50 @@ class SummaryOpsTest(test_util.TensorFlowTestCase):
         r'graph\(\) cannot be invoked inside a graph context.',
     ):
       self.exec_summary_op(summary_op_fn)
+
+
+class WriteScalarSummaryRawOpsTest(test_util.TensorFlowTestCase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def testValidScalarAndSingleElementInputs(self):
+    logdir = self.get_temp_dir()
+    writer = summary_ops.create_file_writer_v2(logdir)
+    self.evaluate(writer.init())
+    step = constant_op.constant(1, dtype=dtypes.int64)
+    tag = constant_op.constant("test_tag", dtype=dtypes.string)
+
+    for val in [2.5, [2.5], [[2.5]]]:
+      t = constant_op.constant(val, dtype=dtypes.float32)
+      self.evaluate(
+          gen_summary_ops.write_scalar_summary(
+              writer=writer._resource,  # pylint: disable=protected-access
+              step=step,
+              tag=tag,
+              value=t,
+          )
+      )
+
+  @test_util.run_in_graph_and_eager_modes
+  def testInvalidEmptyAndMultiElementInputs(self):
+    logdir = self.get_temp_dir()
+    writer = summary_ops.create_file_writer_v2(logdir)
+    self.evaluate(writer.init())
+    step = constant_op.constant(1, dtype=dtypes.int64)
+    tag = constant_op.constant("test_tag", dtype=dtypes.string)
+
+    for invalid_val in [[], [1.0, 2.0], [[1.0, 2.0]]]:
+      t = constant_op.constant(invalid_val, dtype=dtypes.float32)
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError, "must contain exactly one element"
+      ):
+        self.evaluate(
+            gen_summary_ops.write_scalar_summary(
+                writer=writer._resource,  # pylint: disable=protected-access
+                step=step,
+                tag=tag,
+                value=t,
+            )
+        )
 
 
 def events_from_file(filepath):


### PR DESCRIPTION
Add input validation in WriteScalarSummaryOp::Compute (summary_kernels.cc) to verify that the `value` tensor contains exactly one element before delegating to the summary writer.

For invalid inputs (such as empty or multi-element tensors), return `errors::InvalidArgument` instead of allowing the operation to dereference an invalid tensor, preventing a segmentation fault and surfacing a Python `tf.errors.InvalidArgumentError`.

This change preserves the existing behavior for valid inputs while preventing crashes caused by invalid `value` tensors.

Also add graph and eager mode regression tests in `summary_ops_test.py` covering valid inputs as well as empty and multi-element tensors.

Fixes #113060.