### PR TITLE
Add message-specific regression test for AdagradDA grad-rank validation

### DIFF
--- a/tensorflow/python/training/training_ops_test.py
+++ b/tensorflow/python/training/training_ops_test.py
@@ -576,6 +576,35 @@ class TrainingOpsTest(TensorFlowTestCase):
       with self.assertRaises(errors.InvalidArgumentError):
         self.evaluate(apply_op())
 
+  @test_util.run_v2_only
+  def testResourceSparseApplyAdagradDAInvalidGradRank(self):
+    # A scalar `grad` with a higher-rank `var` used to hit a fatal CHECK
+    # instead of raising InvalidArgumentError (see GitHub issue #94130).
+    var = variables.Variable([[0.0, 0.0]] * 10, dtype=dtypes.float32)
+    gradient_accumulator = variables.Variable(
+        [[0.0, 0.0]] * 10, dtype=dtypes.float32)
+    gradient_squared_accumulator = variables.Variable(
+        [[0.0, 0.0]] * 10, dtype=dtypes.float32)
+    self.evaluate(variables.global_variables_initializer())
+
+    grad = constant_op.constant(0.0, dtype=dtypes.float32)  # wrong rank
+    indices = constant_op.constant([0, 0], dtype=dtypes.int32)
+
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError,
+        "grad must have the same number of dimensions as var"):
+      self.evaluate(
+          gen_training_ops.resource_sparse_apply_adagrad_da(
+              var.handle,
+              gradient_accumulator.handle,
+              gradient_squared_accumulator.handle,
+              grad,
+              indices,
+              constant_op.constant(0.0, dtype=dtypes.float32),
+              constant_op.constant(0.0, dtype=dtypes.float32),
+              constant_op.constant(0.0, dtype=dtypes.float32),
+              constant_op.constant(1, dtype=dtypes.int64)))
+
 
 if __name__ == '__main__':
   googletest.main()

--- a/tensorflow/python/training/training_ops_test.py
+++ b/tensorflow/python/training/training_ops_test.py
@@ -580,30 +580,33 @@ class TrainingOpsTest(TensorFlowTestCase):
   def testResourceSparseApplyAdagradDAInvalidGradRank(self):
     # A scalar `grad` with a higher-rank `var` used to hit a fatal CHECK
     # instead of raising InvalidArgumentError (see GitHub issue #94130).
-    var = variables.Variable([[0.0, 0.0]] * 10, dtype=dtypes.float32)
-    gradient_accumulator = variables.Variable(
-        [[0.0, 0.0]] * 10, dtype=dtypes.float32)
-    gradient_squared_accumulator = variables.Variable(
-        [[0.0, 0.0]] * 10, dtype=dtypes.float32)
-    self.evaluate(variables.global_variables_initializer())
+    # ResourceSparseApplyAdagradDA only has a CPU kernel, so pin the whole
+    # test to CPU rather than relying on default placement.
+    with ops.device("/cpu:0"):
+      var = variables.Variable([[0.0, 0.0]] * 10, dtype=dtypes.float32)
+      gradient_accumulator = variables.Variable(
+          [[0.0, 0.0]] * 10, dtype=dtypes.float32)
+      gradient_squared_accumulator = variables.Variable(
+          [[0.0, 0.0]] * 10, dtype=dtypes.float32)
+      self.evaluate(variables.global_variables_initializer())
 
-    grad = constant_op.constant(0.0, dtype=dtypes.float32)  # wrong rank
-    indices = constant_op.constant([0, 0], dtype=dtypes.int32)
+      grad = constant_op.constant(0.0, dtype=dtypes.float32)  # wrong rank
+      indices = constant_op.constant([0, 0], dtype=dtypes.int32)
 
-    with self.assertRaisesRegex(
-        errors.InvalidArgumentError,
-        "grad must have the same number of dimensions as var"):
-      self.evaluate(
-          gen_training_ops.resource_sparse_apply_adagrad_da(
-              var.handle,
-              gradient_accumulator.handle,
-              gradient_squared_accumulator.handle,
-              grad,
-              indices,
-              constant_op.constant(0.0, dtype=dtypes.float32),
-              constant_op.constant(0.0, dtype=dtypes.float32),
-              constant_op.constant(0.0, dtype=dtypes.float32),
-              constant_op.constant(1, dtype=dtypes.int64)))
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError,
+          "grad must have the same number of dimensions as var"):
+        self.evaluate(
+            gen_training_ops.resource_sparse_apply_adagrad_da(
+                var.handle,
+                gradient_accumulator.handle,
+                gradient_squared_accumulator.handle,
+                grad,
+                indices,
+                constant_op.constant(0.0, dtype=dtypes.float32),
+                constant_op.constant(0.0, dtype=dtypes.float32),
+                constant_op.constant(0.0, dtype=dtypes.float32),
+                constant_op.constant(1, dtype=dtypes.int64)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow-up to review feedback on this PR's original fix for #94130.

While addressing the suggestion to use `assertRaisesRegex` instead of `assertRaises`, a rebase revealed master had independently landed the same `grad.dims() == var.dims()` rank check across `SparseApplyAdagradDA` and eight sibling ops (see `35fd3492a4c`), along with a consolidated test (`testSparseApplyOpsRejectLowerRankGrad`). That already covers the crash from #94130, so this PR's original C++ change is dropped as redundant.

What's left: master's own new test only asserts on the exception type, not the message. Added `testResourceSparseApplyAdagradDAInvalidGradRank`, which pins the specific "grad must have the same number of dimensions as var" message via `assertRaisesRegex` for `ResourceSparseApplyAdagradDA`, so the test can only pass if the intended validation actually fired.