### PR TITLE
Fix internal CHECK failure in tf.raw_ops.EncodePng on empty images

### DIFF
--- a/tensorflow/core/kernels/image/encode_png_op.cc
+++ b/tensorflow/core/kernels/image/encode_png_op.cc
@@ -78,6 +78,12 @@ class EncodePngOp : public OpKernel {
     const int32_t channels =
         static_cast<int32_t>(image.dim_size(batch_dims + 2));
 
+    OP_REQUIRES(
+        context, height > 0 && width > 0,
+        absl::InvalidArgumentError(absl::StrCat(
+            "image height and width must be > 0, got shape ",
+            image.shape().DebugString())));
+
     // In some cases, we pass width*channels*2 to png.
     const int32_t max_row_width = std::numeric_limits<int32_t>::max() / 2;
 

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -4831,6 +4831,18 @@ class PngTest(test_util.TensorFlowTestCase):
         image = constant_op.constant(np.zeros(shape, dtype=np.uint8))
         image_ops.encode_png(image)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testRawOpsEmptyImage(self):
+    # Verifies that gen_image_ops.encode_png (tf.raw_ops.EncodePng) raises
+    # InvalidArgumentError on zero spatial dimensions rather than aborting with
+    # SIGABRT from CHECK_NOTNULL(image). See GitHub issue #113068.
+    for shape in [(0, 0, 1), (2, 0, 3), (0, 2, 3), (5, 0, 10, 3)]:
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError), "must be > 0"
+      ):
+        image = constant_op.constant(np.zeros(shape, dtype=np.uint8))
+        self.evaluate(gen_image_ops.encode_png(image))
+
   def testShape(self):
     # Shape function requires placeholders and a graph.
     with ops.Graph().as_default():


### PR DESCRIPTION
Validate the input image dimensions in `EncodePngOp::Compute` before invoking PNG encoding. Return `errors::InvalidArgument` when the image has zero height or width, preventing the internal CHECK failure and allowing Python to raise a recoverable `tf.errors.InvalidArgumentError` instead of aborting the process. Preserve the existing behavior for valid inputs, including zero-length batch encodings with valid spatial dimensions. Add graph and eager mode regression tests covering empty spatial dimensions for `tf.raw_ops.EncodePng`.

Fixes #113068.