### PR TITLE
Validate updates rank in TensorScatter ops to prevent CHECK failure crash

### DIFF
--- a/tensorflow/core/kernels/scatter_nd_op.cc
+++ b/tensorflow/core/kernels/scatter_nd_op.cc
@@ -216,6 +216,14 @@ class TensorScatterOp : public ScatterOpBase<Device> {
 
     const int64_t outer_dims = indices.shape().dims() - 1;
 
+    OP_REQUIRES(c, updates.shape().dims() >= outer_dims,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Updates must have rank of at least ", outer_dims,
+                    " to match the outer dimensions of indices. Indices "
+                    "shape: ",
+                    indices.shape().DebugString(),
+                    ", updates shape:", updates.shape().DebugString())));
+
     for (int i = 0; i < outer_dims; ++i) {
       OP_REQUIRES(c, indices.shape().dim_size(i) == updates.shape().dim_size(i),
                   absl::InvalidArgumentError(absl::StrCat(

--- a/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
@@ -893,6 +893,18 @@ class ScatterNdTensorTest(test.TestCase):
       self.assertAllEqual(max_result,
                           constant_op.constant([1, 1, 1, 2, 1, 1, 1, 2]))
 
+  def testUpdateMinUpdatesRankTooLow(self):
+    # Regression test for #94132: updates with fewer dimensions than
+    # indices' outer dimensions used to hit a fatal CHECK instead of
+    # raising InvalidArgumentError.
+    t = array_ops.ones([1, 10, 4], dtypes.float32)
+    indices = constant_op.constant([[[0]]], dtypes.int64)
+    updates = constant_op.constant([0.0], dtypes.float32)
+    with self.assertRaisesWithPredicateMatch(
+        (errors.InvalidArgumentError, ValueError),
+        r"Updates must have rank of at least"):
+      self.evaluate(array_ops.tensor_scatter_min(t, indices, updates))
+
   def testUpdateMinMaxGradients(self):
 
     # Loop body as a function to avoid go/gpylint-faq#cell-var-from-loop.


### PR DESCRIPTION
Fixes #94132.

`TensorScatterOp::Compute()` (backs `TensorScatterUpdate`/`Add`/`Sub`/`Min`/`Max`) computes `outer_dims = indices.shape().dims() - 1`, then loops over `outer_dims` calling `updates.shape().dim_size(i)` without checking that `updates` actually has that many dimensions. A malformed indices/updates pair (e.g. indices rank 3, updates rank 1) hits a fatal `CHECK failed: d < dims()` instead of a normal error.

Added a rank check before the loop, same `OP_REQUIRES`/`InvalidArgumentError` style already used for the indices/updates rank-at-least-one checks a few lines above. Added `testUpdateMinUpdatesRankTooLow` in the existing `ScatterNdTensorTest` class, matching this file's own `assertRaisesWithPredicateMatch` convention for invalid-shape tests.

Verified with `bazel test //tensorflow/python/kernel_tests/array_ops:scatter_nd_ops_test --test_filter=ScatterNdTensorTest.testUpdateMinUpdatesRankTooLow` (CPU and GPU variants both pass).