### PR TITLE
validate CSR component values when decoding CSRSparseMatrix variant

### DIFF
--- a/tensorflow/core/kernels/sparse/BUILD
+++ b/tensorflow/core/kernels/sparse/BUILD
@@ -40,6 +40,8 @@ cc_library(
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core/platform:errors",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
         "@eigen_archive//:eigen3",
     ],
     alwayslink = 1,
@@ -125,6 +127,7 @@ tf_cc_test(
     ],
     deps = [
         ":kernels",
+        ":sparse_matrix",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:test",

--- a/tensorflow/core/kernels/sparse/kernels_test.cc
+++ b/tensorflow/core/kernels/sparse/kernels_test.cc
@@ -24,6 +24,8 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_testutil.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/framework/variant_tensor_data.h"
+#include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/platform/test.h"
 #include "tsl/platform/errors.h"
@@ -165,6 +167,33 @@ TEST(SparseTensorToCSRSparseMatrix, InvalidRankIllegalArgument) {
       absl_testing::StatusIs(tsl::error::Code::INVALID_ARGUMENT,
                              ::testing::ContainsRegex(
                                  "Indices must have either 2 or 3 columns.")));
+}
+
+TEST(CSRSparseMatrix, DecodeRejectsOutOfBoundsColIndices) {
+  // A valid 1 x 3 CSR matrix with a single non-zero at column 1.
+  const auto dense_shape = test::AsTensor<int64_t>({1, 3}, TensorShape({2}));
+  const auto batch_pointers = test::AsTensor<int32_t>({0, 1}, TensorShape({2}));
+  const auto row_pointers = test::AsTensor<int32_t>({0, 1}, TensorShape({2}));
+  const auto col_indices = test::AsTensor<int32_t>({1}, TensorShape({1}));
+  const auto values = test::AsTensor<float>({1.0f}, TensorShape({1}));
+
+  CSRSparseMatrix matrix;
+  TF_ASSERT_OK(CSRSparseMatrix::CreateCSRSparseMatrix(
+      DT_FLOAT, dense_shape, batch_pointers, row_pointers, col_indices, values,
+      &matrix));
+
+  VariantTensorData data;
+  matrix.Encode(&data);
+
+  // The untouched encoding round-trips.
+  CSRSparseMatrix roundtrip;
+  EXPECT_TRUE(roundtrip.Decode(data));
+
+  // Column index 3 is outside the valid range [0, num_cols = 3); the shapes are
+  // unchanged so ValidateTypesAndShapes still passes, but Decode must reject it.
+  data.tensors_[3] = test::AsTensor<int32_t>({3}, TensorShape({1}));
+  CSRSparseMatrix tampered;
+  EXPECT_FALSE(tampered.Decode(data));
 }
 
 }  // namespace

--- a/tensorflow/core/kernels/sparse/kernels_test.cc
+++ b/tensorflow/core/kernels/sparse/kernels_test.cc
@@ -196,6 +196,32 @@ TEST(CSRSparseMatrix, DecodeRejectsOutOfBoundsColIndices) {
   EXPECT_FALSE(tampered.Decode(data));
 }
 
+TEST(CSRSparseMatrix, DecodeValidationOutOfBoundsColIndices) {
+  // A valid 4 x 5 CSR matrix with four non-zeros spread across the rows.
+  const auto dense_shape = test::AsTensor<int64_t>({4, 5}, TensorShape({2}));
+  const auto batch_pointers = test::AsTensor<int32_t>({0, 4}, TensorShape({2}));
+  const auto row_pointers =
+      test::AsTensor<int32_t>({0, 1, 1, 3, 4}, TensorShape({5}));
+  const auto col_indices =
+      test::AsTensor<int32_t>({0, 3, 4, 0}, TensorShape({4}));
+  const auto values =
+      test::AsTensor<float>({1.0f, 2.0f, 3.0f, 4.0f}, TensorShape({4}));
+
+  CSRSparseMatrix matrix;
+  TF_ASSERT_OK(CSRSparseMatrix::CreateCSRSparseMatrix(
+      DT_FLOAT, dense_shape, batch_pointers, row_pointers, col_indices, values,
+      &matrix));
+
+  VariantTensorData data;
+  matrix.Encode(&data);
+
+  // Push a single column index out of range (num_cols = 5) while leaving the
+  // shapes untouched, so only the value check can catch it.
+  data.tensors_[3].flat<int32_t>()(0) = 100;
+  CSRSparseMatrix tampered;
+  EXPECT_FALSE(tampered.Decode(data));
+}
+
 }  // namespace
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/sparse/sparse_matrix.cc
+++ b/tensorflow/core/kernels/sparse/sparse_matrix.cc
@@ -19,12 +19,96 @@ limitations under the License.
 #define EIGEN_USE_GPU
 #endif
 
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "tensorflow/core/framework/variant_op_registry.h"
 #include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 
 namespace tensorflow {
 
 constexpr const char CSRSparseMatrix::kTypeName[];
+
+absl::Status CSRSparseMatrix::ValidateComponentValues(
+    const Tensor& dense_shape, const Tensor& batch_pointers,
+    const Tensor& row_pointers, const Tensor& col_indices) {
+  // dense_shape has already been checked to be an int64 vector of size 2 or 3
+  // by ValidateTypesAndShapes, and the index arrays to be int32 vectors of the
+  // matching sizes: batch_pointers -> batch_size + 1,
+  // row_pointers -> batch_size * (num_rows + 1), col_indices -> total nnz.
+  const auto dense_shape_vec = dense_shape.vec<int64_t>();
+  const int rank = dense_shape.dim_size(0);
+  const int64_t batch_size = (rank == 2) ? 1 : dense_shape_vec(0);
+  const int64_t num_rows = (rank == 2) ? dense_shape_vec(0) : dense_shape_vec(1);
+  const int64_t num_cols = (rank == 2) ? dense_shape_vec(1) : dense_shape_vec(2);
+  if (batch_size < 0 || num_rows < 0 || num_cols < 0) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "CSRSparseMatrix::Validate: dense_shape has a negative dimension: ",
+        dense_shape.SummarizeValue(5)));
+  }
+
+  const int64_t total_nnz = col_indices.NumElements();
+  const auto batch_ptr = batch_pointers.vec<int32_t>();
+  const auto row_ptr = row_pointers.vec<int32_t>();
+  const auto col_ind = col_indices.vec<int32_t>();
+
+  // batch_pointers: 0, ..., total_nnz (non-decreasing offsets into the values).
+  if (batch_ptr(0) != 0) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "CSRSparseMatrix::Validate: batch_pointers[0] = ", batch_ptr(0),
+        " but should be 0"));
+  }
+  for (int64_t b = 0; b < batch_size; ++b) {
+    if (batch_ptr(b) < 0 || batch_ptr(b + 1) < batch_ptr(b)) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "CSRSparseMatrix::Validate: batch_pointers must be non-negative and "
+          "non-decreasing, saw ",
+          batch_ptr(b), " -> ", batch_ptr(b + 1), " at batch ", b));
+    }
+  }
+  if (batch_ptr(batch_size) != total_nnz) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "CSRSparseMatrix::Validate: batch_pointers[batch_size] = ",
+        batch_ptr(batch_size), " but should equal nnz = ", total_nnz));
+  }
+
+  // row_pointers: within each batch, 0, ..., nnz(batch) (non-decreasing).
+  for (int64_t b = 0; b < batch_size; ++b) {
+    const int64_t base = b * (num_rows + 1);
+    const int32_t batch_nnz = batch_ptr(b + 1) - batch_ptr(b);
+    if (row_ptr(base) != 0) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "CSRSparseMatrix::Validate: row_pointers for batch ", b,
+          " should start at 0, saw ", row_ptr(base)));
+    }
+    for (int64_t r = 0; r < num_rows; ++r) {
+      if (row_ptr(base + r) < 0 || row_ptr(base + r + 1) < row_ptr(base + r)) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "CSRSparseMatrix::Validate: row_pointers must be non-negative and "
+            "non-decreasing, saw ",
+            row_ptr(base + r), " -> ", row_ptr(base + r + 1), " in batch ", b));
+      }
+    }
+    if (row_ptr(base + num_rows) != batch_nnz) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "CSRSparseMatrix::Validate: last row_pointer for batch ", b, " = ",
+          row_ptr(base + num_rows), " but should equal the batch nnz = ",
+          batch_nnz));
+    }
+  }
+
+  // col_indices: every column index is in [0, num_cols).
+  for (int64_t i = 0; i < total_nnz; ++i) {
+    if (col_ind(i) < 0 || col_ind(i) >= num_cols) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "CSRSparseMatrix::Validate: column index ", col_ind(i),
+          " is outside of the valid range [0, ", num_cols, ")"));
+    }
+  }
+
+  return absl::OkStatus();
+}
 
 // Register variant decoding function for TF's RPC.
 REGISTER_UNARY_VARIANT_DECODE_FUNCTION(CSRSparseMatrix,

--- a/tensorflow/core/kernels/sparse/sparse_matrix.cc
+++ b/tensorflow/core/kernels/sparse/sparse_matrix.cc
@@ -33,21 +33,9 @@ constexpr const char CSRSparseMatrix::kTypeName[];
 absl::Status CSRSparseMatrix::ValidateComponentValues(
     const Tensor& dense_shape, const Tensor& batch_pointers,
     const Tensor& row_pointers, const Tensor& col_indices) {
-  // Decode operates on the tensors carried by a serialized variant, which are
-  // host-resident. Custom in-memory pipelines could still hand Decode
-  // device-resident tensors; reading those directly from host would crash, so
-  // reject them rather than dereference device memory.
-  auto on_device = [](const Tensor& t) {
-    return t.NumElements() > 0 && t.IsInitialized() &&
-           t.GetMemoryType() == AllocatorMemoryType::kDevice;
-  };
-  if (on_device(batch_pointers) || on_device(row_pointers) ||
-      on_device(col_indices)) {
-    return absl::InvalidArgumentError(
-        "CSRSparseMatrix::Validate: cannot validate device-resident CSR "
-        "components from host");
-  }
-
+  // Decode rejects device-resident dense_shape/index tensors before calling
+  // this, so every tensor read here is host-resident.
+  //
   // dense_shape has already been checked to be an int64 vector of size 2 or 3
   // by ValidateTypesAndShapes, and the index arrays to be int32 vectors of the
   // matching sizes: batch_pointers -> batch_size + 1,
@@ -64,8 +52,8 @@ absl::Status CSRSparseMatrix::ValidateComponentValues(
   }
 
   const int64_t total_nnz = col_indices.NumElements();
-  // The tensors are host-resident (checked above), so read them through raw
-  // pointers to keep these O(nnz) loops cheap and vectorizable.
+  // The tensors are host-resident (Decode rejects device tensors), so read
+  // them through raw pointers to keep these O(nnz) loops cheap and vectorizable.
   const int32_t* batch_ptr = batch_pointers.flat<int32_t>().data();
   const int32_t* row_ptr = row_pointers.flat<int32_t>().data();
   const int32_t* col_ind = col_indices.flat<int32_t>().data();

--- a/tensorflow/core/kernels/sparse/sparse_matrix.cc
+++ b/tensorflow/core/kernels/sparse/sparse_matrix.cc
@@ -33,6 +33,21 @@ constexpr const char CSRSparseMatrix::kTypeName[];
 absl::Status CSRSparseMatrix::ValidateComponentValues(
     const Tensor& dense_shape, const Tensor& batch_pointers,
     const Tensor& row_pointers, const Tensor& col_indices) {
+  // Decode operates on the tensors carried by a serialized variant, which are
+  // host-resident. Custom in-memory pipelines could still hand Decode
+  // device-resident tensors; reading those directly from host would crash, so
+  // reject them rather than dereference device memory.
+  auto on_device = [](const Tensor& t) {
+    return t.NumElements() > 0 && t.IsInitialized() &&
+           t.GetMemoryType() == AllocatorMemoryType::kDevice;
+  };
+  if (on_device(batch_pointers) || on_device(row_pointers) ||
+      on_device(col_indices)) {
+    return absl::InvalidArgumentError(
+        "CSRSparseMatrix::Validate: cannot validate device-resident CSR "
+        "components from host");
+  }
+
   // dense_shape has already been checked to be an int64 vector of size 2 or 3
   // by ValidateTypesAndShapes, and the index arrays to be int32 vectors of the
   // matching sizes: batch_pointers -> batch_size + 1,
@@ -49,60 +64,62 @@ absl::Status CSRSparseMatrix::ValidateComponentValues(
   }
 
   const int64_t total_nnz = col_indices.NumElements();
-  const auto batch_ptr = batch_pointers.vec<int32_t>();
-  const auto row_ptr = row_pointers.vec<int32_t>();
-  const auto col_ind = col_indices.vec<int32_t>();
+  // The tensors are host-resident (checked above), so read them through raw
+  // pointers to keep these O(nnz) loops cheap and vectorizable.
+  const int32_t* batch_ptr = batch_pointers.flat<int32_t>().data();
+  const int32_t* row_ptr = row_pointers.flat<int32_t>().data();
+  const int32_t* col_ind = col_indices.flat<int32_t>().data();
 
   // batch_pointers: 0, ..., total_nnz (non-decreasing offsets into the values).
-  if (batch_ptr(0) != 0) {
+  if (batch_ptr[0] != 0) {
     return absl::InvalidArgumentError(absl::StrCat(
-        "CSRSparseMatrix::Validate: batch_pointers[0] = ", batch_ptr(0),
+        "CSRSparseMatrix::Validate: batch_pointers[0] = ", batch_ptr[0],
         " but should be 0"));
   }
   for (int64_t b = 0; b < batch_size; ++b) {
-    if (batch_ptr(b) < 0 || batch_ptr(b + 1) < batch_ptr(b)) {
+    if (batch_ptr[b] < 0 || batch_ptr[b + 1] < batch_ptr[b]) {
       return absl::InvalidArgumentError(absl::StrCat(
           "CSRSparseMatrix::Validate: batch_pointers must be non-negative and "
           "non-decreasing, saw ",
-          batch_ptr(b), " -> ", batch_ptr(b + 1), " at batch ", b));
+          batch_ptr[b], " -> ", batch_ptr[b + 1], " at batch ", b));
     }
   }
-  if (batch_ptr(batch_size) != total_nnz) {
+  if (batch_ptr[batch_size] != total_nnz) {
     return absl::InvalidArgumentError(absl::StrCat(
         "CSRSparseMatrix::Validate: batch_pointers[batch_size] = ",
-        batch_ptr(batch_size), " but should equal nnz = ", total_nnz));
+        batch_ptr[batch_size], " but should equal nnz = ", total_nnz));
   }
 
   // row_pointers: within each batch, 0, ..., nnz(batch) (non-decreasing).
   for (int64_t b = 0; b < batch_size; ++b) {
     const int64_t base = b * (num_rows + 1);
-    const int32_t batch_nnz = batch_ptr(b + 1) - batch_ptr(b);
-    if (row_ptr(base) != 0) {
+    const int32_t batch_nnz = batch_ptr[b + 1] - batch_ptr[b];
+    if (row_ptr[base] != 0) {
       return absl::InvalidArgumentError(absl::StrCat(
           "CSRSparseMatrix::Validate: row_pointers for batch ", b,
-          " should start at 0, saw ", row_ptr(base)));
+          " should start at 0, saw ", row_ptr[base]));
     }
     for (int64_t r = 0; r < num_rows; ++r) {
-      if (row_ptr(base + r) < 0 || row_ptr(base + r + 1) < row_ptr(base + r)) {
+      if (row_ptr[base + r] < 0 || row_ptr[base + r + 1] < row_ptr[base + r]) {
         return absl::InvalidArgumentError(absl::StrCat(
             "CSRSparseMatrix::Validate: row_pointers must be non-negative and "
             "non-decreasing, saw ",
-            row_ptr(base + r), " -> ", row_ptr(base + r + 1), " in batch ", b));
+            row_ptr[base + r], " -> ", row_ptr[base + r + 1], " in batch ", b));
       }
     }
-    if (row_ptr(base + num_rows) != batch_nnz) {
+    if (row_ptr[base + num_rows] != batch_nnz) {
       return absl::InvalidArgumentError(absl::StrCat(
           "CSRSparseMatrix::Validate: last row_pointer for batch ", b, " = ",
-          row_ptr(base + num_rows), " but should equal the batch nnz = ",
+          row_ptr[base + num_rows], " but should equal the batch nnz = ",
           batch_nnz));
     }
   }
 
   // col_indices: every column index is in [0, num_cols).
   for (int64_t i = 0; i < total_nnz; ++i) {
-    if (col_ind(i) < 0 || col_ind(i) >= num_cols) {
+    if (col_ind[i] < 0 || col_ind[i] >= num_cols) {
       return absl::InvalidArgumentError(absl::StrCat(
-          "CSRSparseMatrix::Validate: column index ", col_ind(i),
+          "CSRSparseMatrix::Validate: column index ", col_ind[i],
           " is outside of the valid range [0, ", num_cols, ")"));
     }
   }

--- a/tensorflow/core/kernels/sparse/sparse_matrix.h
+++ b/tensorflow/core/kernels/sparse/sparse_matrix.h
@@ -352,6 +352,18 @@ class CSRSparseMatrix {
                                             row_pointers, col_indices, values);
     if (s.ok() != validated) return false;
 
+    // ValidateTypesAndShapes only checks the dtypes and sizes of the index
+    // arrays, not their contents. A matrix decoded from an untrusted variant
+    // can therefore carry out-of-range col_indices or non-monotonic
+    // batch/row pointers while still reporting validated == true, which the
+    // consuming ops use directly as read/write offsets. The tensors here are
+    // always host-resident, so validate the CSR structure before accepting it.
+    if (validated) {
+      absl::Status values_status = ValidateComponentValues(
+          dense_shape, batch_pointers, row_pointers, col_indices);
+      if (!values_status.ok()) return false;
+    }
+
     // Save to this object.
     metadata_ = metadata;
     dense_shape_ = std::move(dense_shape);
@@ -423,6 +435,16 @@ class CSRSparseMatrix {
     row_pointers_vec_.reset();
     col_indices_vec_.reset();
   }
+
+  // Validates the contents (not just the shapes) of the host-resident CSR
+  // index arrays: batch_pointers and per-batch row_pointers must start at 0,
+  // be non-decreasing, and end at the batch's non-zero count, and every
+  // col_indices entry must fall in [0, num_cols). Used by Decode() to reject
+  // structurally invalid matrices coming from untrusted variants.
+  static absl::Status ValidateComponentValues(const Tensor& dense_shape,
+                                              const Tensor& batch_pointers,
+                                              const Tensor& row_pointers,
+                                              const Tensor& col_indices);
 
   static absl::Status ValidateTypesAndShapes(DataType dtype,
                                              const Tensor& dense_shape,

--- a/tensorflow/core/kernels/sparse/sparse_matrix.h
+++ b/tensorflow/core/kernels/sparse/sparse_matrix.h
@@ -347,6 +347,20 @@ class CSRSparseMatrix {
     Tensor col_indices(p.tensors_[3]);
     Tensor values(p.tensors_[4]);
 
+    // ValidateTypesAndShapes and the value checks below read dense_shape and
+    // the index arrays directly on the host (e.g. dense_shape.vec<int64_t>()).
+    // A crafted or custom-pipeline variant could hand us device-resident
+    // tensors, so reject them up front rather than dereference device memory
+    // from host.
+    auto on_device = [](const Tensor& t) {
+      return t.NumElements() > 0 && t.IsInitialized() &&
+             t.GetMemoryType() == AllocatorMemoryType::kDevice;
+    };
+    if (on_device(dense_shape) || on_device(batch_pointers) ||
+        on_device(row_pointers) || on_device(col_indices)) {
+      return false;
+    }
+
     // Check that the validated bool is consistent with the data.
     absl::Status s = ValidateTypesAndShapes(dtype, dense_shape, batch_pointers,
                                             row_pointers, col_indices, values);


### PR DESCRIPTION
CSRSparseMatrix::Decode (tensorflow/core/kernels/sparse/sparse_matrix.h) runs ValidateTypesAndShapes, which checks the dtypes and sizes of dense_shape/batch_pointers/row_pointers/col_indices/values but never their contents. A variant carrying shape-consistent tensors with out-of-range col_indices, non-monotonic row_pointers, or bogus batch_pointers therefore decodes into a matrix reporting validated == true. The CPU consumers then use those values directly as offsets, e.g. CSRSparseMatrixToDense writes dense[dense_batch_offset + row_idx * num_cols + col_idx] where col_idx comes straight from col_indices, so a crafted matrix reached through the registered variant decoder (parse_tensor out_type=variant / checkpoint restore) drives a heap out-of-bounds write. The construction path (SparseTensorToCSRSparseMatrix) already rejects such indices; the decode path skipped them.

Decode always operates on host-resident tensors, so it validates the CSR structure directly: batch_pointers start at 0, are non-decreasing, and end at nnz; each batch row_pointers segment starts at 0, is non-decreasing, and ends at the batch nnz; and every col_indices entry lies in [0, num_cols). Keeping the check in Decode fixes every consumer at once without touching the shared shape validator, which also runs on device tensors. Adds a regression test that tampers a col index of an otherwise valid encoded matrix.