### PR TITLE
Update tf.data.Dataset.concatenate docstring error examples (doc-only)

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1102,13 +1102,16 @@ class DatasetV2(
     >>> c = tf.data.Dataset.zip((a, b))
     >>> a.concatenate(c)
     Traceback (most recent call last):
-    TypeError: Two datasets to concatenate have different types
-    <dtype: 'int64'> and (tf.int64, tf.int64)
+    TypeError: Incompatible dataset elements:
+      TensorSpec(shape=(), dtype=tf.int64, name=None) vs.
+      (TensorSpec(shape=(), dtype=tf.int64, name=None),
+      TensorSpec(shape=(), dtype=tf.int64, name=None))
     >>> d = tf.data.Dataset.from_tensor_slices(["a", "b", "c"])
     >>> a.concatenate(d)
     Traceback (most recent call last):
-    TypeError: Two datasets to concatenate have different types
-    <dtype: 'int64'> and <dtype: 'string'>
+    TypeError: Incompatible dataset elements:
+      TensorSpec(shape=(), dtype=tf.int64, name=None) vs.
+      TensorSpec(shape=(), dtype=tf.string, name=None)
 
     Args:
       dataset: `Dataset` to be concatenated.


### PR DESCRIPTION
## Summary

Doc-only change, no functional changes.

The docstring examples for `tf.data.Dataset.concatenate` still show the old error text:

```
TypeError: Two datasets to concatenate have different types
<dtype: 'int64'> and (tf.int64, tf.int64)
```

Since the implementation moved to `concatenate_op.py`, the actual error raised is:

```
TypeError: Incompatible dataset elements:
  TensorSpec(shape=(), dtype=tf.int64, name=None) vs.   (TensorSpec(shape=(), dtype=tf.int64, name=None), TensorSpec(shape=(), dtype=tf.int64, name=None))
```

This updates both doctest examples to match the current message (wrapped to fit line-length limits; the doctest runner uses `NORMALIZE_WHITESPACE` and `IGNORE_EXCEPTION_DETAIL`, so wrapping is safe).

Credit to @Abhishek-bytes for finding and reporting this in #123757.

Fixes #123757
