### PR TITLE
Return empty tensors instead of uninitialized scalars for unused linalg outputs

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
@@ -15957,7 +15957,7 @@ are sorted in non-decreasing order.
 # e is a tensor of eigenvalues.
 # v is a tensor of eigenvectors.
 e, v = self_adjoint_eig(a)
-e = self_adjoint_eig(a, compute_v=False)
+e, _ = self_adjoint_eig(a, compute_v=False)
 ```
   }];
 
@@ -15969,7 +15969,8 @@ e = self_adjoint_eig(a, compute_v=False)
 
   let results = (outs
     Res<TensorOf<[TF_Complex128, TF_Complex64, TF_Float16, TF_Float32, TF_Float64]>, [{Eigenvalues. Shape is `[N]`.}]>:$e,
-    Res<TensorOf<[TF_Complex128, TF_Complex64, TF_Float16, TF_Float32, TF_Float64]>, [{Eigenvectors. Shape is `[N, N]`.}]>:$v
+    Res<TensorOf<[TF_Complex128, TF_Complex64, TF_Float16, TF_Float32, TF_Float64]>, [{Eigenvectors. Shape is `[N, N]` if `compute_v` is `True`. Otherwise `v` is
+an empty tensor.}]>:$v
   );
 
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;

--- a/tensorflow/core/api_def/base_api/api_def_SelfAdjointEigV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SelfAdjointEigV2.pbtxt
@@ -18,14 +18,16 @@ END
   out_arg {
     name: "v"
     description: <<END
-Eigenvectors. Shape is `[N, N]`.
+Eigenvectors. Shape is `[N, N]` if `compute_v` is `True`. Otherwise `v` is
+an empty tensor.
 END
   }
   attr {
     name: "compute_v"
     description: <<END
 If `True` then eigenvectors will be computed and returned in `v`.
-Otherwise, only the eigenvalues will be computed.
+Otherwise, only the eigenvalues will be computed and `v` will be an empty
+tensor.
 END
   }
   summary: "Computes the eigen decomposition of one or more square self-adjoint matrices."
@@ -39,7 +41,7 @@ are sorted in non-decreasing order.
 # e is a tensor of eigenvalues.
 # v is a tensor of eigenvectors.
 e, v = self_adjoint_eig(a)
-e = self_adjoint_eig(a, compute_v=False)
+e, _ = self_adjoint_eig(a, compute_v=False)
 ```
 END
 }

--- a/tensorflow/core/kernels/linalg/linalg_ops_common.cc
+++ b/tensorflow/core/kernels/linalg/linalg_ops_common.cc
@@ -199,7 +199,11 @@ void LinearAlgebraOp<InputScalar, OutputScalar>::PrepareOutputs(
     unused_inputs.insert(input_idx);
   }
   for (int output_idx = 0; output_idx < context->num_outputs(); ++output_idx) {
-    TensorShape output_tensor_shape({});
+    // Outputs the derived class does not produce (e.g. `v` for
+    // SelfAdjointEigV2 with compute_v=False) are allocated as empty tensors
+    // of shape [0], matching the op's shape function, so they never expose
+    // uninitialized memory.
+    TensorShape output_tensor_shape({0});
     if (output_idx < num_outputs) {
       // This output is used, set up output shape and allocate it.
       const TensorShape& output_matrix_shape =

--- a/tensorflow/core/kernels/linalg/self_adjoint_eig_v2_op_gpu.cc
+++ b/tensorflow/core/kernels/linalg/self_adjoint_eig_v2_op_gpu.cc
@@ -69,8 +69,11 @@ class SelfAdjointEigV2OpGpu : public AsyncOpKernel {
         context, context->allocate_output(0, eigenvalues_shape, &eigenvalues),
         done);
     Tensor* eigenvectors;
+    // When compute_v is false, allocate `v` as an empty tensor of shape [0],
+    // matching the op's shape function, so it never exposes uninitialized
+    // memory.
     TensorShape eigenvectors_shape =
-        compute_v_ ? input.shape() : TensorShape({});
+        compute_v_ ? input.shape() : TensorShape({0});
     OP_REQUIRES_OK_ASYNC(
         context, context->allocate_output(1, eigenvectors_shape, &eigenvectors),
         done);

--- a/tensorflow/python/kernel_tests/linalg/self_adjoint_eig_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/self_adjoint_eig_op_test.py
@@ -49,6 +49,7 @@ class SelfAdjointEigTest(test.TestCase):
     with self.assertRaises(ValueError):
       linalg_ops.self_adjoint_eig(vector)
 
+  @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testComputeVFalseReturnsEmptyV(self):
     # Regression test for GitHub issue 102352: with compute_v=False the raw
     # op used to return an uninitialized scalar in `v` instead of an empty

--- a/tensorflow/python/kernel_tests/linalg/self_adjoint_eig_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/self_adjoint_eig_op_test.py
@@ -20,6 +20,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes as dtypes_lib
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_linalg_ops
 from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import math_ops
@@ -47,6 +48,16 @@ class SelfAdjointEigTest(test.TestCase):
     vector = constant_op.constant([1., 2.])
     with self.assertRaises(ValueError):
       linalg_ops.self_adjoint_eig(vector)
+
+  def testComputeVFalseReturnsEmptyV(self):
+    # Regression test for GitHub issue 102352: with compute_v=False the raw
+    # op used to return an uninitialized scalar in `v` instead of an empty
+    # tensor.
+    matrix = constant_op.constant([[1., 2.], [2., 5.]])
+    e, v = gen_linalg_ops.self_adjoint_eig_v2(matrix, compute_v=False)
+    self.assertEqual([2], e.shape.as_list())
+    self.assertEqual([0], v.shape.as_list())
+    self.assertEqual(0, self.evaluate(v).size)
 
   @test_util.run_deprecated_v1
   def testConcurrentExecutesWithoutError(self):

--- a/tensorflow/python/kernel_tests/linalg/svd_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/svd_op_test.py
@@ -24,6 +24,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import gen_linalg_ops
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import gradients_impl
@@ -122,6 +123,18 @@ class SvdOpTest(test.TestCase):
     val = self.evaluate(all_ops)
     for i in range(0, len(val), 2):
       self.assertAllEqual(val[i], val[i + 1])
+
+  def testComputeUvFalseReturnsEmptyUv(self):
+    # Regression test for GitHub issue 102352: with compute_uv=False the raw
+    # op used to return uninitialized scalars in `u` and `v` on CPU instead
+    # of empty tensors.
+    matrix = constant_op.constant([[1., 2.], [2., 5.]])
+    s, u, v = gen_linalg_ops.svd(matrix, compute_uv=False)
+    self.assertEqual([2], s.shape.as_list())
+    self.assertEqual([0], u.shape.as_list())
+    self.assertEqual([0], v.shape.as_list())
+    self.assertEqual(0, self.evaluate(u).size)
+    self.assertEqual(0, self.evaluate(v).size)
 
   @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testEmptyBatches(self):

--- a/tensorflow/python/kernel_tests/linalg/svd_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/svd_op_test.py
@@ -124,6 +124,7 @@ class SvdOpTest(test.TestCase):
     for i in range(0, len(val), 2):
       self.assertAllEqual(val[i], val[i + 1])
 
+  @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testComputeUvFalseReturnsEmptyUv(self):
     # Regression test for GitHub issue 102352: with compute_uv=False the raw
     # op used to return uninitialized scalars in `u` and `v` on CPU instead

--- a/tensorflow/python/kernel_tests/linalg/svd_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/svd_op_test.py
@@ -66,7 +66,8 @@ class SvdOpTest(test.TestCase):
       if test_util.is_gpu_available(cuda_only=True):
         with self.assertRaisesRegex(
             errors_impl.UnimplementedError,
-            "Determinism is not yet supported for SVD of matrices with 1 column."
+            "Determinism is not yet supported for SVD of matrices with 1"
+            " column.",
         ):
           self.evaluate(linalg_ops.svd(matrix))
 


### PR DESCRIPTION
## Summary

Fixes #102352.

`tf.raw_ops.SelfAdjointEigV2(input=m, compute_v=False)` returned garbage in `v`:

```
SelfAdjointEigV2(e=<tf.Tensor: shape=(5,), ...>, v=<tf.Tensor: shape=(), dtype=float32, numpy=-8.247622141588684e+21>)
```

Root cause: the op always declares two outputs, but with `compute_v=False` the kernel reports only one output shape, so `LinearAlgebraOp::PrepareOutputs` allocated `v` as a scalar that was never written. The caller received uninitialized heap memory. The runtime shape `()` also contradicted the op's shape function, which infers `[0]` for the unused output. The same pattern affected `Eig` with `compute_v=False` and CPU `Svd` with `compute_uv=False`.

## Changes

- `LinearAlgebraOp::PrepareOutputs` allocates outputs not produced by the derived class as empty tensors of shape `[0]` instead of uninitialized scalars. This matches the shape function and fixes the CPU kernels for `SelfAdjointEigV2`, `Eig`, and `Svd`.
- The GPU `SelfAdjointEigV2` kernel allocates `v` with shape `[0]` when `compute_v` is false, matching what the GPU `Svd` kernel already does for `u`/`v` when `compute_uv` is false (precedent for this behavior).
- `api_def_SelfAdjointEigV2.pbtxt`: documents that `v` is an empty tensor when `compute_v` is `False` and fixes the usage example, which unpacked a single return value even though the op always returns two (the doc mismatch originally reported in the issue).
- Regression tests in `self_adjoint_eig_op_test.py` and `svd_op_test.py` asserting the unused outputs have shape `[0]`.

Notes for reviewers:
- The XLA kernel (`xla_self_adjoint_eig_op.cc`) always computes both outputs and is unaffected.
- The gradient function only reads `op.outputs[1]` when `compute_v` is true, so it is unaffected.
- No shape function changes: runtime now matches the existing inferred shapes.

Credit to @ILCSFNO for reporting and narrowing down the issue.