### PR TITLE
Reject malformed empty boxes and box_index in crop-and-resize kernels

### DIFF
--- a/tensorflow/core/kernels/image/crop_and_resize_op.cc
+++ b/tensorflow/core/kernels/image/crop_and_resize_op.cc
@@ -55,23 +55,24 @@ using Callback = std::function<void()>;
 static inline absl::Status ParseAndCheckBoxSizes(const Tensor& boxes,
                                                  const Tensor& box_index,
                                                  int* num_boxes) {
-  if (boxes.NumElements() == 0 && box_index.NumElements() == 0) {
-    *num_boxes = 0;
-    return absl::OkStatus();
-  }
-  // The shape of 'boxes' is [num_boxes, 4].
+  // The shape of 'boxes' is [num_boxes, 4] and the shape of 'box_index' is
+  // [num_boxes]. The ranks must be validated even when both tensors are
+  // empty, since the kernels later access them as rank-2 and rank-1 tensors.
   if (boxes.dims() != 2) {
     return absl::InvalidArgumentError(
         absl::StrCat("boxes must be 2-D", boxes.shape().DebugString()));
   }
-  *num_boxes = boxes.dim_size(0);
-  if (boxes.dim_size(1) != 4) {
-    return absl::InvalidArgumentError("boxes must have 4 columns");
-  }
-  // The shape of 'box_index' is [num_boxes].
   if (box_index.dims() != 1) {
     return absl::InvalidArgumentError(
         absl::StrCat("box_index must be 1-D", box_index.shape().DebugString()));
+  }
+  if (boxes.NumElements() == 0 && box_index.NumElements() == 0) {
+    *num_boxes = 0;
+    return absl::OkStatus();
+  }
+  *num_boxes = boxes.dim_size(0);
+  if (boxes.dim_size(1) != 4) {
+    return absl::InvalidArgumentError("boxes must have 4 columns");
   }
   if (box_index.dim_size(0) != *num_boxes) {
     return absl::InvalidArgumentError("box_index has incompatible shape");

--- a/tensorflow/core/kernels/image/crop_and_resize_op.cc
+++ b/tensorflow/core/kernels/image/crop_and_resize_op.cc
@@ -59,12 +59,12 @@ static inline absl::Status ParseAndCheckBoxSizes(const Tensor& boxes,
   // [num_boxes]. The ranks must be validated even when both tensors are
   // empty, since the kernels later access them as rank-2 and rank-1 tensors.
   if (boxes.dims() != 2) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("boxes must be 2-D", boxes.shape().DebugString()));
+    return absl::InvalidArgumentError(absl::StrCat(
+        "boxes must be 2-D, got ", boxes.shape().DebugString()));
   }
   if (box_index.dims() != 1) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("box_index must be 1-D", box_index.shape().DebugString()));
+    return absl::InvalidArgumentError(absl::StrCat(
+        "box_index must be 1-D, got ", box_index.shape().DebugString()));
   }
   if (boxes.NumElements() == 0 && box_index.NumElements() == 0) {
     *num_boxes = 0;

--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -3486,6 +3486,7 @@ py_library(
     srcs = ["image_grad_test_base.py"],
     strict_deps = True,
     deps = [
+        ":array_ops",
         ":array_ops_stack",
         ":gradient_checker_v2",
         ":image_ops",

--- a/tensorflow/python/ops/image_grad_test_base.py
+++ b/tensorflow/python/ops/image_grad_test_base.py
@@ -24,6 +24,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import test_util
+from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import array_ops_stack
 from tensorflow.python.ops import gen_image_ops
 from tensorflow.python.ops import gradient_checker_v2
@@ -446,6 +447,51 @@ class CropAndResizeOpTestBase(test.TestCase):
       self.assertEqual(crops_shape, list(crops.get_shape()))
       crops = self.evaluate(crops)
       self.assertEqual(crops_shape, list(crops.shape))
+
+  def testMalformedEmptyBoxesRaisesError(self):
+    # Regression test for GitHub issue 123397: rank-1 empty `boxes` or
+    # rank-2 empty `box_ind` used to pass validation and crash the process
+    # with a fatal CHECK failure instead of raising InvalidArgumentError.
+    grads = array_ops.zeros([0, 1, 1, 1], dtype=dtypes.float32)
+    image_size = constant_op.constant([2, 7, 7, 1], dtype=dtypes.int32)
+    valid_boxes = array_ops.zeros([0, 4], dtype=dtypes.float32)
+    valid_box_ind = array_ops.zeros([0], dtype=dtypes.int32)
+    with self.assertRaisesRegex(
+        (errors_impl.InvalidArgumentError, ValueError), "boxes must be 2-D"):
+      self.evaluate(
+          gen_image_ops.crop_and_resize_grad_image(
+              grads=grads,
+              boxes=array_ops.zeros([0], dtype=dtypes.float32),
+              box_ind=valid_box_ind,
+              image_size=image_size,
+              T=dtypes.float32))
+    with self.assertRaisesRegex(
+        (errors_impl.InvalidArgumentError, ValueError), "box_index must be 1-D"
+    ):
+      self.evaluate(
+          gen_image_ops.crop_and_resize_grad_image(
+              grads=grads,
+              boxes=valid_boxes,
+              box_ind=array_ops.zeros([0, 0], dtype=dtypes.int32),
+              image_size=image_size,
+              T=dtypes.float32))
+    with self.assertRaisesRegex(
+        (errors_impl.InvalidArgumentError, ValueError), "boxes must be 2-D"):
+      self.evaluate(
+          gen_image_ops.crop_and_resize_grad_boxes(
+              grads=grads,
+              image=array_ops.zeros([2, 7, 7, 1], dtype=dtypes.float32),
+              boxes=array_ops.zeros([0], dtype=dtypes.float32),
+              box_ind=valid_box_ind))
+    # Well-formed empty boxes must keep working.
+    output = self.evaluate(
+        gen_image_ops.crop_and_resize_grad_image(
+            grads=grads,
+            boxes=valid_boxes,
+            box_ind=valid_box_ind,
+            image_size=image_size,
+            T=dtypes.float32))
+    self.assertEqual((2, 7, 7, 1), output.shape)
 
   def _randomUniformAvoidAnchors(self, low, high, anchors, radius, num_samples):
     """Generate samples that are far enough from a set of anchor points.


### PR DESCRIPTION
## Summary

Fixes #123397.

`tf.raw_ops.CropAndResizeGradImage` with a rank-1 empty `boxes` tensor (shape `[0]` instead of `[0, 4]`) aborts the whole process with a fatal CHECK failure instead of raising a catchable error:

```
F ... tensor_shape.cc:47] Check failed: NDIMS == dims() (2 vs. 1) Asking for tensor of 2 dimensions from a tensor of 1 dimensions
```

## Root cause

`ParseAndCheckBoxSizes` returns early with `num_boxes = 0` when both `boxes` and `box_index` are empty, skipping all rank validation. The malformed tensor then reaches `boxes.tensor<float, 2>()` in the compute callback, which CHECK-fails on the rank mismatch and calls `abort()`.

I reproduced this on TF 2.21.0 and found the same defect is reachable through two more vectors sharing the same helper:

- `CropAndResizeGradBoxes` with rank-1 empty `boxes`: same fatal crash.
- `CropAndResizeGradImage` with rank-2 empty `box_ind` (shape `[0, 0]`): fatal crash at `box_index.tensor<int32_t, 1>()`.

The forward `CropAndResize` op already fails cleanly.

## Fix

Validate the ranks of `boxes` and `box_index` before the empty early return in `ParseAndCheckBoxSizes`. The element-count checks (4 columns, matching row counts) stay after the early return, so well-formed empty inputs (`boxes` of shape `[0, 4]`, `box_index` of shape `[0]`) keep working; I verified that path still returns a correctly shaped output.

Adds a regression test covering all three crash vectors plus the well-formed empty case.

Credit to @yyds1233 for the report and the clean reproducer.
