### PR TITLE
Apply rtol and atol to integer inputs in tf.experimental.numpy.isclose

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,6 +33,8 @@ In `tensorflow/c/experimental/filesystem/filesystem_interface.h`, removed `TF_Tr
     * Exports `__new__` in public API golden files for subclasses of `tuple` (like `tf.io.FixedLenFeature`) to fix false positives during static type checking.>
 * `tf.data`
     * Fixes a bug in `tf.data.Dataset.scan` where the shape of the state returned by `scan_func` was not strictly validated against the initial state.
+* `tf.experimental.numpy`
+    * `tf.experimental.numpy.isclose` and `tf.experimental.numpy.allclose` now apply `rtol` and `atol` to integer inputs, matching NumPy, instead of comparing with pure equality. The comparison stays in integer arithmetic; combining integer inputs with floating-point tolerances (including the defaults) now raises an error unless automatic type promotion is enabled, which keeps the cost of promotion opt-in.
 
 * <SIMILAR TO ABOVE SECTION, BUT FOR OTHER IMPORTANT CHANGES / BUG FIXES>
 * <IF A CHANGE CLOSES A GITHUB ISSUE, IT SHOULD BE DOCUMENTED HERE>

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -543,14 +543,25 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
       diff = math_ops.maximum(a, b) - math_ops.minimum(a, b)
       if np.issubdtype(dtype.as_numpy_dtype, np.unsignedinteger):
         abs_b = b
+        no_overflow = None
       else:
         abs_b = math_ops.abs(b)
+        # Signed subtraction overflow always produces a negative value, so a
+        # negative diff means the true difference is not representable in
+        # this dtype; such pairs are treated as not close rather than
+        # compared through the wrapped value. abs(b) can also overflow for
+        # the most negative value, which conservatively shrinks rtol-scaled
+        # tolerances.
+        no_overflow = diff >= 0
       rhs = atol + rtol * abs_b
       if rhs.dtype != diff.dtype:
         # Reachable only with type promotion enabled and float tolerances,
         # where the tolerance side has been promoted to floating point.
         diff = math_ops.cast(diff, rhs.dtype)
-      return diff <= rhs
+      result = diff <= rhs
+      if no_overflow is not None:
+        result = result & no_overflow
+      return result
     else:
       return math_ops.equal(a, b)
 

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -533,6 +533,24 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
       if equal_nan:
         result = result | (math_ops.is_nan(a) & math_ops.is_nan(b))
       return result
+    elif np.issubdtype(dtype.as_numpy_dtype, np.integer):
+      # Use the operands' own arithmetic instead of casting to float, so
+      # integer tolerances stay in integer arithmetic and float tolerances
+      # require automatic type promotion to be enabled, keeping the cost of
+      # promotion opt-in. The difference is computed as max - min so that
+      # unsigned inputs cannot wrap around, and tf.abs does not support
+      # unsigned dtypes.
+      diff = math_ops.maximum(a, b) - math_ops.minimum(a, b)
+      if np.issubdtype(dtype.as_numpy_dtype, np.unsignedinteger):
+        abs_b = b
+      else:
+        abs_b = math_ops.abs(b)
+      rhs = atol + rtol * abs_b
+      if rhs.dtype != diff.dtype:
+        # Reachable only with type promotion enabled and float tolerances,
+        # where the tolerance side has been promoted to floating point.
+        diff = math_ops.cast(diff, rhs.dtype)
+      return diff <= rhs
     else:
       return math_ops.equal(a, b)
 

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -550,8 +550,12 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
         # negative diff means the true difference is not representable in
         # this dtype; such pairs are treated as not close rather than
         # compared through the wrapped value. abs(b) can also overflow for
-        # the most negative value, which conservatively shrinks rtol-scaled
-        # tolerances.
+        # the most negative value, which flips the sign of rtol-scaled
+        # tolerances and makes the comparison impossible to satisfy: values
+        # near the minimum are then reported as not close where NumPy,
+        # computing in floating point, reports them close. Identical values
+        # are protected by the equality fallback below; for the rest,
+        # enabling type promotion with float tolerances gives NumPy results.
         no_overflow = diff >= 0
       rhs = atol + rtol * abs_b
       if rhs.dtype != diff.dtype:
@@ -559,6 +563,8 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
         # where the tolerance side has been promoted to floating point.
         diff = math_ops.cast(diff, rhs.dtype)
       result = diff <= rhs
+      # Identical values are always close, regardless of tolerance overflow.
+      result = result | math_ops.equal(a, b)
       if no_overflow is not None:
         result = result & no_overflow
       return result

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -540,15 +540,15 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
       # promotion opt-in. The difference is computed as max - min so that
       # unsigned inputs cannot wrap around, and tf.abs does not support
       # unsigned dtypes.
-      diff = math_ops.maximum(a, b) - math_ops.minimum(a, b)
+      diff_val = math_ops.maximum(a, b) - math_ops.minimum(a, b)
       if np.issubdtype(dtype.as_numpy_dtype, np.unsignedinteger):
         abs_b = b
         no_overflow = None
       else:
         abs_b = math_ops.abs(b)
         # Signed subtraction overflow always produces a negative value, so a
-        # negative diff means the true difference is not representable in
-        # this dtype; such pairs are treated as not close rather than
+        # negative difference means the true difference is not representable
+        # in this dtype; such pairs are treated as not close rather than
         # compared through the wrapped value. abs(b) can also overflow for
         # the most negative value, which flips the sign of rtol-scaled
         # tolerances and makes the comparison impossible to satisfy: values
@@ -556,13 +556,13 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
         # computing in floating point, reports them close. Identical values
         # are protected by the equality fallback below; for the rest,
         # enabling type promotion with float tolerances gives NumPy results.
-        no_overflow = diff >= 0
+        no_overflow = diff_val >= 0
       rhs = atol + rtol * abs_b
-      if rhs.dtype != diff.dtype:
+      if rhs.dtype != diff_val.dtype:
         # Reachable only with type promotion enabled and float tolerances,
         # where the tolerance side has been promoted to floating point.
-        diff = math_ops.cast(diff, rhs.dtype)
-      result = diff <= rhs
+        diff_val = math_ops.cast(diff_val, rhs.dtype)
+      result = diff_val <= rhs
       # Identical values are always close, regardless of tolerance overflow.
       result = result | math_ops.equal(a, b)
       if no_overflow is not None:

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -230,6 +230,46 @@ class MathTest(test.TestCase, parameterized.TestCase):
         np_math_ops.isclose(a, b, equal_nan=equal_nan),
         np.isclose(a, b, equal_nan=equal_nan))
 
+  @parameterized.parameters([np.int32, np.int64])
+  def testIsCloseIntegerTolerances(self, dtype):
+    # Regression test for GitHub issue 108657: integer inputs used to be
+    # compared with pure equality, ignoring rtol and atol.
+    a = np.array([[-13, -5, -12], [3, 17, -6], [5, 3, -8], [-18, 19, 10]],
+                 dtype)
+    b = np.array([-7], dtype)
+    self.match(
+        np_math_ops.isclose(a, b, rtol=9, atol=0),
+        np.isclose(a, b, rtol=9, atol=0))
+    self.assertEqual(
+        bool(np_math_ops.allclose(a, b, rtol=9, atol=0)),
+        np.allclose(a, b, rtol=9, atol=0))
+    c = np.array([100, 200, -300, 0], dtype)
+    d = np.array([105, 900, -300, 4], dtype)
+    self.match(
+        np_math_ops.isclose(c, d, rtol=0, atol=5),
+        np.isclose(c, d, rtol=0, atol=5))
+
+  def testIsCloseUnsignedNoWraparound(self):
+    # The difference must be computed as max - min: 1 - 2 wraps around to 255
+    # in uint8 arithmetic and would defeat the tolerance comparison.
+    a = np.array([1, 250, 7], np.uint8)
+    b = np.array([2, 5, 7], np.uint8)
+    self.match(
+        np_math_ops.isclose(a, b, rtol=0, atol=3),
+        np.isclose(a, b, rtol=0, atol=3))
+
+  def testIsCloseIntegerFloatTolerancePromotes(self):
+    # Integer inputs with floating-point tolerances (including the defaults)
+    # rely on type promotion, which this test environment enables, and the
+    # promoted results match NumPy. Without promotion this combination
+    # raises instead of silently casting.
+    a = np.array([1000000, 1000001, 5], np.int32)
+    b = np.array([1000001, 1000000, 900], np.int32)
+    self.match(np_math_ops.isclose(a, b), np.isclose(a, b))
+    self.match(
+        np_math_ops.isclose(a, b, rtol=1e-6, atol=0.5),
+        np.isclose(a, b, rtol=1e-6, atol=0.5))
+
   @parameterized.named_parameters(
       ('isclose_int32', np_math_ops.isclose, np.int32),
       ('allclose_int32', np_math_ops.allclose, np.int32),

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -249,6 +249,15 @@ class MathTest(test.TestCase, parameterized.TestCase):
         np_math_ops.isclose(c, d, rtol=0, atol=5),
         np.isclose(c, d, rtol=0, atol=5))
 
+  def testIsCloseSignedIntegerOverflow(self):
+    # max - min overflows int8 when the true difference exceeds 127; the
+    # wrapped negative difference must not compare as close.
+    a = np.array([127, -128, -128], np.int8)
+    b = np.array([-128, -128, -127], np.int8)
+    self.match(
+        np_math_ops.isclose(a, b, rtol=0, atol=5),
+        np.isclose(a, b, rtol=0, atol=5))
+
   def testIsCloseUnsignedNoWraparound(self):
     # The difference must be computed as max - min: 1 - 2 wraps around to 255
     # in uint8 arithmetic and would defeat the tolerance comparison.

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -258,6 +258,26 @@ class MathTest(test.TestCase, parameterized.TestCase):
         np_math_ops.isclose(a, b, rtol=0, atol=5),
         np.isclose(a, b, rtol=0, atol=5))
 
+  def testIsCloseMinIntIdenticalValues(self):
+    # Identical values are always close, even for the most negative value,
+    # where abs(b) overflows and wraps the rtol-scaled tolerance negative.
+    a = np.array([-128], np.int8)
+    b = np.array([-128], np.int8)
+    self.match(
+        np_math_ops.isclose(a, b, rtol=5, atol=0),
+        np.isclose(a, b, rtol=5, atol=0))
+
+  def testIsCloseMinIntNeighborDivergesFromNumPy(self):
+    # Documented divergence from NumPy: for values close to the most negative
+    # value but not identical, abs(b) overflow makes the wrapped rtol-scaled
+    # tolerance impossible to satisfy in integer arithmetic, so this reports
+    # not close where NumPy, computing in floating point, reports close.
+    # Enabling type promotion with float tolerances gives the NumPy result.
+    a = np.array([-127], np.int8)
+    b = np.array([-128], np.int8)
+    self.assertTrue(np.isclose(a, b, rtol=5, atol=0)[0])
+    self.assertAllEqual([False], np_math_ops.isclose(a, b, rtol=5, atol=0))
+
   def testIsCloseUnsignedNoWraparound(self):
     # The difference must be computed as max - min: 1 - 2 wraps around to 255
     # in uint8 arithmetic and would defeat the tolerance comparison.


### PR DESCRIPTION
## Summary

Fixes #108657.

`tf.experimental.numpy.isclose` compared integer inputs with pure equality, ignoring `rtol` and `atol` entirely. The issue's repro (int32 inputs, `rtol=9`) returned all `False` where NumPy returns all `True`. `allclose` was affected through the same path.

## Approach

This implements the approach maintainers agreed on in #108702 (comment by @ratgr following internal discussion): apply the tolerance formula to integer inputs using the operands' own arithmetic, with no unconditional cast to floating point. Integer tolerances stay in integer arithmetic; floating-point tolerances (including the defaults) require type promotion, which keeps the cost of promotion opt-in. Both prior PRs for this issue (#108702, #109328) were closed by the stale bot, not rejected.

Two details surfaced during verification:

- The difference is computed as `max(a, b) - min(a, b)` rather than `abs(a - b)`, because unsigned subtraction wraps around (`uint8` `1 - 2` is `255`) and `tf.abs` does not support unsigned dtypes at all.
- When promotion turns the tolerance side into floating point, the integer difference is cast to match it, because comparison ops like `LessEqual` do not promote mixed operands. This cast is only reachable on the promotion-enabled float-tolerance path.

## Verification

Verified locally against NumPy (not just by CI): int32/int64 broadcast cases including the issue's repro, uint8 wraparound cases, float-path and `equal_nan` regression cases, and integer-input/float-tolerance cases in three promotion configurations (disabled: raises as intended; legacy mode and `all` mode: matches NumPy). The full `np_math_ops_test.py` suite passes (48 tests).

Release notes updated as requested by maintainers in the prior PR discussion.

Credit to @Thrsu for the report, and to @gamila-wisam and @ayushozha for the earlier attempts.