### PR TITLE
Add CUDA 13 / Blackwell (sm_100, sm_120) local build support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,15 +37,20 @@
 # Feature and Third party library support options:
 #     xla:          Build TF with XLA
 #     tpu:          Build TF with TPU support
-#     cuda:         Build with CUDA support.
-#     cuda_clang:   Build with CUDA Clang support (pre-Blackwell SMs).
-#     cuda_nvcc:    Build CUDA kernels with nvcc (needed for sm_100/sm_120).
-#     cuda12_version / cuda13_version: Hermetic CUDA toolkit pins.
-#     cuda13_nvcc:  CUDA 13 + nvcc (recommended for Blackwell / sm_100+).
+#     cuda:         Build with CUDA support (default hermetic CUDA 12).
+#     cuda_clang:   Build with CUDA Clang (SMs through compute_90 only).
+#     cuda_nvcc:    Build CUDA kernels with nvcc (required for sm_100/sm_120).
+#     cuda12_version / cuda13_version: Hermetic CUDA 12.x / 13.x toolkit pins.
 #     cuda_wheel:   Build pip wheels without embedding CUDA shared libs.
 #     rocm:         Build with AMD GPU support (rocm)
 #     nogcp:        Disable GCS support.
 #     nonccl:       Disable nccl support.
+#
+# Blackwell (sm_100 / sm_120) local builds: use existing configs, e.g.
+#   bazel build --config=cuda --config=cuda13_version --config=cuda_nvcc \
+#     --config=cuda_wheel //tensorflow/tools/pip_package:wheel
+# Do not add sm_100/sm_120 to cuda_clang; hermetic clang rejects those arches.
+# Default --config=cuda remains CUDA 12 (cuda_version -> cuda12_version).
 #
 #
 # Remote build execution options (only configured to work with TF team projects for now.)
@@ -297,8 +302,9 @@ common:cuda13_version --repo_env=HERMETIC_CUDNN_VERSION="9.12.0"
 common:cuda13_version --repo_env=HERMETIC_NVSHMEM_VERSION="3.3.20"
 common:cuda13_version --repo_env=HERMETIC_NCCL_VERSION="2.29.7"
 # Includes Blackwell: sm_100 (datacenter) and compute_120 (consumer, e.g. RTX 50).
-# Pair with --config=cuda_nvcc (or --config=cuda13_nvcc). Hermetic cuda_clang does
-# not currently support sm_100 / sm_120 ("unsupported CUDA gpu architecture").
+# Pair with --config=cuda_nvcc. Hermetic cuda_clang does not support sm_100/sm_120
+# ("unsupported CUDA gpu architecture"). Default --config=cuda stays on
+# cuda12_version; opt into CUDA 13 with --config=cuda13_version.
 common:cuda13_version --repo_env=HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_75,sm_80,sm_90,sm_100,compute_120"
 
 common:cuda_version --config=cuda12_version
@@ -330,8 +336,9 @@ common:cuda_clang --copt=-Qunused-arguments
 # release while SASS is only forward compatible inside the current
 # major release. Example: sm_80 kernels can run on sm_89 GPUs but
 # not on sm_90 GPUs. compute_80 kernels though can also run on sm_90 GPUs.
-# NOTE: Do not add sm_100 / sm_120 here until hermetic cuda_clang supports them.
-# For Blackwell builds use --config=cuda_nvcc or --config=cuda13_nvcc.
+# NOTE: Keep this list free of sm_100 / sm_120 until hermetic cuda_clang
+# supports them. For Blackwell use --config=cuda_nvcc and CUDA 13
+# (--config=cuda13_version or HERMETIC_CUDA_VERSION from ./configure).
 common:cuda_clang --repo_env=HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_60,sm_70,sm_80,sm_89,compute_90"
 # Permit newer CUDA versions than Clang is aware of
 common:cuda_clang --copt="-Wno-unknown-cuda-version"
@@ -351,14 +358,6 @@ common:cuda_nvcc --action_env=TF_NVCC_CLANG="1"
 common:cuda_nvcc --@local_config_cuda//:cuda_compiler=nvcc
 # Old config for backward compatibility
 common:nvcc_clang --config=cuda_nvcc
-
-# Convenience: CUDA 13 hermetic toolkit + nvcc device compiler.
-# Use this for local builds targeting Blackwell GPUs (sm_100 / sm_120), e.g.:
-#   bazel build --config=cuda13_nvcc --config=cuda_wheel \
-#     //tensorflow/tools/pip_package:wheel
-common:cuda13_nvcc --config=cuda
-common:cuda13_nvcc --config=cuda13_version
-common:cuda13_nvcc --config=cuda_nvcc
 
 # Debug config
 common:dbg -c dbg

--- a/.bazelrc
+++ b/.bazelrc
@@ -38,7 +38,11 @@
 #     xla:          Build TF with XLA
 #     tpu:          Build TF with TPU support
 #     cuda:         Build with CUDA support.
-#     cuda_clang    Build with CUDA Clang support.
+#     cuda_clang:   Build with CUDA Clang support (pre-Blackwell SMs).
+#     cuda_nvcc:    Build CUDA kernels with nvcc (needed for sm_100/sm_120).
+#     cuda12_version / cuda13_version: Hermetic CUDA toolkit pins.
+#     cuda13_nvcc:  CUDA 13 + nvcc (recommended for Blackwell / sm_100+).
+#     cuda_wheel:   Build pip wheels without embedding CUDA shared libs.
 #     rocm:         Build with AMD GPU support (rocm)
 #     nogcp:        Disable GCS support.
 #     nonccl:       Disable nccl support.
@@ -292,6 +296,9 @@ common:cuda13_version --repo_env=HERMETIC_CUDA_VERSION="13.0.0"
 common:cuda13_version --repo_env=HERMETIC_CUDNN_VERSION="9.12.0"
 common:cuda13_version --repo_env=HERMETIC_NVSHMEM_VERSION="3.3.20"
 common:cuda13_version --repo_env=HERMETIC_NCCL_VERSION="2.29.7"
+# Includes Blackwell: sm_100 (datacenter) and compute_120 (consumer, e.g. RTX 50).
+# Pair with --config=cuda_nvcc (or --config=cuda13_nvcc). Hermetic cuda_clang does
+# not currently support sm_100 / sm_120 ("unsupported CUDA gpu architecture").
 common:cuda13_version --repo_env=HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_75,sm_80,sm_90,sm_100,compute_120"
 
 common:cuda_version --config=cuda12_version
@@ -304,6 +311,9 @@ common:cuda --config=cuda_version
 common:cuda --@local_config_cuda//cuda:include_cuda_libs=true
 
 # This configuration is used for building the wheels.
+# Required for //tensorflow/tools/pip_package:wheel when CUDA is enabled so the
+# wheel does not embed CUDA shared libraries (install nvidia-* pip packages or
+# use a system CUDA/cuDNN runtime instead).
 common:cuda_wheel --@local_config_cuda//cuda:include_cuda_libs=false
 
 common:hermetic_cuda_umd --@cuda_driver//:include_cuda_umd_libs=true
@@ -320,6 +330,8 @@ common:cuda_clang --copt=-Qunused-arguments
 # release while SASS is only forward compatible inside the current
 # major release. Example: sm_80 kernels can run on sm_89 GPUs but
 # not on sm_90 GPUs. compute_80 kernels though can also run on sm_90 GPUs.
+# NOTE: Do not add sm_100 / sm_120 here until hermetic cuda_clang supports them.
+# For Blackwell builds use --config=cuda_nvcc or --config=cuda13_nvcc.
 common:cuda_clang --repo_env=HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_60,sm_70,sm_80,sm_89,compute_90"
 # Permit newer CUDA versions than Clang is aware of
 common:cuda_clang --copt="-Wno-unknown-cuda-version"
@@ -339,6 +351,14 @@ common:cuda_nvcc --action_env=TF_NVCC_CLANG="1"
 common:cuda_nvcc --@local_config_cuda//:cuda_compiler=nvcc
 # Old config for backward compatibility
 common:nvcc_clang --config=cuda_nvcc
+
+# Convenience: CUDA 13 hermetic toolkit + nvcc device compiler.
+# Use this for local builds targeting Blackwell GPUs (sm_100 / sm_120), e.g.:
+#   bazel build --config=cuda13_nvcc --config=cuda_wheel \
+#     //tensorflow/tools/pip_package:wheel
+common:cuda13_nvcc --config=cuda
+common:cuda13_nvcc --config=cuda13_version
+common:cuda13_nvcc --config=cuda_nvcc
 
 # Debug config
 common:dbg -c dbg

--- a/configure.py
+++ b/configure.py
@@ -500,13 +500,8 @@ def cuda_compute_capability_version(capability):
   sm_compute = re.match(r'^(?:sm|compute)_?([0-9]{2,})[a-zA-Z]?$', capability)
   if sm_compute:
     digits = sm_compute.group(1)
-    # sm_90 -> (9, 0), sm_100 -> (10, 0), sm_120 -> (12, 0)
-    if len(digits) == 2:
-      return int(digits[0]), int(digits[1])
-    if len(digits) == 3:
-      return int(digits[:2]), int(digits[2])
-    if len(digits) == 4:
-      return int(digits[:2]), int(digits[2:])
+    # Minor version is always the last digit: sm_90 -> (9, 0), sm_100 -> (10, 0).
+    return int(digits[:-1]), int(digits[-1])
   return None
 
 
@@ -542,29 +537,39 @@ def maybe_ensure_cuda13_for_blackwell(environ_cp):
   if not compute_capabilities_require_nvcc(caps):
     return False
 
-  pinned = False
+  pinned_cuda = False
+  pinned_cudnn = False
   if not environ_cp.get('HERMETIC_CUDA_VERSION'):
     environ_cp['HERMETIC_CUDA_VERSION'] = _BLACKWELL_HERMETIC_CUDA_VERSION
     write_repo_env_to_bazelrc(
         'cuda', 'HERMETIC_CUDA_VERSION', _BLACKWELL_HERMETIC_CUDA_VERSION
     )
-    pinned = True
+    pinned_cuda = True
   if not environ_cp.get('HERMETIC_CUDNN_VERSION'):
     environ_cp['HERMETIC_CUDNN_VERSION'] = _BLACKWELL_HERMETIC_CUDNN_VERSION
     write_repo_env_to_bazelrc(
         'cuda', 'HERMETIC_CUDNN_VERSION', _BLACKWELL_HERMETIC_CUDNN_VERSION
     )
-    pinned = True
+    pinned_cudnn = True
 
-  if pinned:
+  if pinned_cuda or pinned_cudnn:
+    pins = []
+    if pinned_cuda:
+      pins.append(
+          'HERMETIC_CUDA_VERSION=%s' % _BLACKWELL_HERMETIC_CUDA_VERSION
+      )
+    if pinned_cudnn:
+      pins.append(
+          'HERMETIC_CUDNN_VERSION=%s' % _BLACKWELL_HERMETIC_CUDNN_VERSION
+      )
     print(
         '\nNOTE: Blackwell compute capabilities (sm_100+) selected without an '
-        'explicit hermetic CUDA version. Pinning HERMETIC_CUDA_VERSION=%s and '
-        'HERMETIC_CUDNN_VERSION=%s (same as --config=cuda13_version). '
+        'explicit hermetic CUDA/cuDNN version. Pinning %s '
+        '(same as --config=cuda13_version). '
         'Default --config=cuda remains CUDA 12 for other builds.\n'
-        % (_BLACKWELL_HERMETIC_CUDA_VERSION, _BLACKWELL_HERMETIC_CUDNN_VERSION)
+        % ' and '.join(pins)
     )
-  return pinned
+  return pinned_cuda or pinned_cudnn
 
 
 def recommended_gpu_wheel_bazel_flags(environ_cp):

--- a/configure.py
+++ b/configure.py
@@ -475,12 +475,21 @@ def set_cc_opt_flags(environ_cp):
     write_to_bazelrc('build:opt --host_copt=%s' % opt)
 
 
+# Hermetic CUDA 13 pins used when configure selects Blackwell compute
+# capabilities and the user did not set HERMETIC_CUDA_VERSION explicitly.
+# Keep in sync with .bazelrc common:cuda13_version.
+_BLACKWELL_HERMETIC_CUDA_VERSION = '13.0.0'
+_BLACKWELL_HERMETIC_CUDNN_VERSION = '9.12.0'
+
+
 def cuda_compute_capability_version(capability):
   """Return (major, minor) for a CUDA compute capability string, or None.
 
   Accepts forms used by configure / Bazel hermetic CUDA, including:
   "7.5", "sm_80", "compute_90", "sm_120", "12.0".
   """
+  if capability is None:
+    return None
   capability = capability.strip()
   if not capability:
     return None
@@ -510,10 +519,67 @@ def compute_capabilities_require_nvcc(capabilities_csv):
   if not capabilities_csv:
     return False
   for part in capabilities_csv.replace(' ', '').split(','):
+    if not part:
+      continue
     version = cuda_compute_capability_version(part)
     if version is not None and version >= (10, 0):
       return True
   return False
+
+
+def clang_cuda_compiler_default(capabilities_csv):
+  """Whether TF_CUDA_CLANG should default to enabled for the given SMs."""
+  return not compute_capabilities_require_nvcc(capabilities_csv)
+
+
+def maybe_ensure_cuda13_for_blackwell(environ_cp):
+  """Pin hermetic CUDA 13 when Blackwell SMs are selected and version unset.
+
+  Does not override an explicit HERMETIC_CUDA_VERSION / HERMETIC_CUDNN_VERSION.
+  Leaves pre-Blackwell configures on the default CUDA 12 bazelrc pins.
+  """
+  caps = environ_cp.get('HERMETIC_CUDA_COMPUTE_CAPABILITIES', '')
+  if not compute_capabilities_require_nvcc(caps):
+    return False
+
+  pinned = False
+  if not environ_cp.get('HERMETIC_CUDA_VERSION'):
+    environ_cp['HERMETIC_CUDA_VERSION'] = _BLACKWELL_HERMETIC_CUDA_VERSION
+    write_repo_env_to_bazelrc(
+        'cuda', 'HERMETIC_CUDA_VERSION', _BLACKWELL_HERMETIC_CUDA_VERSION
+    )
+    pinned = True
+  if not environ_cp.get('HERMETIC_CUDNN_VERSION'):
+    environ_cp['HERMETIC_CUDNN_VERSION'] = _BLACKWELL_HERMETIC_CUDNN_VERSION
+    write_repo_env_to_bazelrc(
+        'cuda', 'HERMETIC_CUDNN_VERSION', _BLACKWELL_HERMETIC_CUDNN_VERSION
+    )
+    pinned = True
+
+  if pinned:
+    print(
+        '\nNOTE: Blackwell compute capabilities (sm_100+) selected without an '
+        'explicit hermetic CUDA version. Pinning HERMETIC_CUDA_VERSION=%s and '
+        'HERMETIC_CUDNN_VERSION=%s (same as --config=cuda13_version). '
+        'Default --config=cuda remains CUDA 12 for other builds.\n'
+        % (_BLACKWELL_HERMETIC_CUDA_VERSION, _BLACKWELL_HERMETIC_CUDNN_VERSION)
+    )
+  return pinned
+
+
+def recommended_gpu_wheel_bazel_flags(environ_cp):
+  """Return suggested bazel --config flags for a GPU pip wheel build."""
+  flags = ['--config=cuda', '--config=cuda_wheel']
+  caps = environ_cp.get('HERMETIC_CUDA_COMPUTE_CAPABILITIES', '')
+  if compute_capabilities_require_nvcc(caps):
+    # Explicit nvcc + CUDA 13 opt-in for Blackwell; safe even if configure
+    # already wrote HERMETIC_CUDA_VERSION into .tf_configure.bazelrc.
+    flags.extend(['--config=cuda13_version', '--config=cuda_nvcc'])
+  elif environ_cp.get('TF_CUDA_CLANG') == '1':
+    flags.append('--config=cuda_clang')
+  else:
+    flags.append('--config=cuda_nvcc')
+  return flags
 
 
 def set_tf_cuda_clang(environ_cp, enabled_by_default=True):
@@ -1109,6 +1175,12 @@ def set_other_cuda_vars(environ_cp):
   # If CUDA is enabled, always use GPU during build and test.
   if environ_cp.get('TF_CUDA_CLANG') == '1':
     write_to_bazelrc('build --config=cuda_clang')
+  elif compute_capabilities_require_nvcc(
+      environ_cp.get('HERMETIC_CUDA_COMPUTE_CAPABILITIES', '')
+  ):
+    # Explicit nvcc for Blackwell. Pre-Blackwell non-clang keeps --config=cuda
+    # only (cuda_compiler defaults to nvcc) to preserve existing behavior.
+    write_to_bazelrc('build --config=cuda_nvcc')
   else:
     write_to_bazelrc('build --config=cuda')
 
@@ -1336,16 +1408,17 @@ def main():
                                   environ_cp.get('LD_LIBRARY_PATH'))
 
     # Hermetic cuda_clang does not support Blackwell architectures
-    # (sm_100 / sm_120). Default to nvcc when those capabilities are selected.
+    # (sm_100 / sm_120). Default to nvcc and pin CUDA 13 when needed.
     caps = environ_cp.get('HERMETIC_CUDA_COMPUTE_CAPABILITIES', '')
-    clang_default = True
-    if compute_capabilities_require_nvcc(caps):
-      clang_default = False
+    maybe_ensure_cuda13_for_blackwell(environ_cp)
+    clang_default = clang_cuda_compiler_default(caps)
+    if not clang_default:
       print(
           '\nNOTE: Selected CUDA compute capabilities include sm_100+ '
           '(Blackwell). Hermetic clang does not support these architectures; '
-          'defaulting the CUDA compiler to nvcc. Use --config=cuda13_nvcc '
-          '(CUDA 13) or --config=cuda_nvcc when building.\n'
+          'defaulting the CUDA compiler to nvcc. Build with '
+          '--config=cuda13_version --config=cuda_nvcc (or rely on the '
+          'HERMETIC_CUDA_* pins written into .tf_configure.bazelrc).\n'
       )
     set_tf_cuda_clang(environ_cp, enabled_by_default=clang_default)
     if environ_cp.get('TF_CUDA_CLANG') == '1':
@@ -1415,8 +1488,11 @@ def main():
       '(Experimental) Build kernels into separate shared objects.')
   config_info_line('v1', 'Build with TensorFlow 1 API instead of TF 2 API.')
   config_info_line(
-      'cuda13_nvcc',
-      'CUDA 13 + nvcc (recommended for Blackwell sm_100 / sm_120).')
+      'cuda13_version',
+      'Hermetic CUDA 13.x (use with --config=cuda_nvcc for Blackwell).')
+  config_info_line(
+      'cuda_nvcc',
+      'Build CUDA kernels with nvcc (required for sm_100 / sm_120).')
   config_info_line(
       'cuda_wheel',
       'Build GPU pip wheels without embedding CUDA shared libraries.')
@@ -1426,12 +1502,14 @@ def main():
   config_info_line('nonccl', 'Disable NVIDIA NCCL support.')
 
   if environ_cp.get('TF_NEED_CUDA') == '1':
+    flag_str = ' '.join(recommended_gpu_wheel_bazel_flags(environ_cp))
     print(
         '\nGPU pip wheel tip: build with --config=cuda_wheel, for example:\n'
-        '  bazel build --config=cuda13_nvcc --config=cuda_wheel \\\n'
+        '  bazel build %s \\\n'
         '    //tensorflow/tools/pip_package:wheel\n'
         'At runtime install matching nvidia-* pip packages (or system '
         'CUDA/cuDNN) so libraries such as libcudnn.so.9 are findable.\n'
+        % flag_str
     )
 
 

--- a/configure.py
+++ b/configure.py
@@ -475,11 +475,53 @@ def set_cc_opt_flags(environ_cp):
     write_to_bazelrc('build:opt --host_copt=%s' % opt)
 
 
-def set_tf_cuda_clang(environ_cp):
+def cuda_compute_capability_version(capability):
+  """Return (major, minor) for a CUDA compute capability string, or None.
+
+  Accepts forms used by configure / Bazel hermetic CUDA, including:
+  "7.5", "sm_80", "compute_90", "sm_120", "12.0".
+  """
+  capability = capability.strip()
+  if not capability:
+    return None
+  decimal = re.match(r'^([0-9]+)\.([0-9]+)$', capability)
+  if decimal:
+    return int(decimal.group(1)), int(decimal.group(2))
+  # Optional trailing letter: sm_90a, sm_100f (architecture-accelerated / family).
+  sm_compute = re.match(r'^(?:sm|compute)_?([0-9]{2,})[a-zA-Z]?$', capability)
+  if sm_compute:
+    digits = sm_compute.group(1)
+    # sm_90 -> (9, 0), sm_100 -> (10, 0), sm_120 -> (12, 0)
+    if len(digits) == 2:
+      return int(digits[0]), int(digits[1])
+    if len(digits) == 3:
+      return int(digits[:2]), int(digits[2])
+    if len(digits) == 4:
+      return int(digits[:2]), int(digits[2:])
+  return None
+
+
+def compute_capabilities_require_nvcc(capabilities_csv):
+  """True if any capability needs nvcc (Blackwell sm_100 / sm_120 family).
+
+  The hermetic cuda_clang toolchain rejects sm_100 and sm_120 with
+  "unsupported CUDA gpu architecture". CUDA 13 + nvcc supports them.
+  """
+  if not capabilities_csv:
+    return False
+  for part in capabilities_csv.replace(' ', '').split(','):
+    version = cuda_compute_capability_version(part)
+    if version is not None and version >= (10, 0):
+      return True
+  return False
+
+
+def set_tf_cuda_clang(environ_cp, enabled_by_default=True):
   """set TF_CUDA_CLANG action_env.
 
   Args:
     environ_cp: copy of the os.environ.
+    enabled_by_default: whether clang is the default CUDA compiler choice.
   """
   question = 'Do you want to use clang as CUDA compiler?'
   yes_reply = 'Clang will be used as CUDA compiler.'
@@ -488,7 +530,7 @@ def set_tf_cuda_clang(environ_cp):
       environ_cp,
       'TF_CUDA_CLANG',
       None,
-      True,
+      enabled_by_default,
       question=question,
       yes_reply=yes_reply,
       no_reply=no_reply,
@@ -1293,7 +1335,19 @@ def main():
       write_action_env_to_bazelrc('LD_LIBRARY_PATH',
                                   environ_cp.get('LD_LIBRARY_PATH'))
 
-    set_tf_cuda_clang(environ_cp)
+    # Hermetic cuda_clang does not support Blackwell architectures
+    # (sm_100 / sm_120). Default to nvcc when those capabilities are selected.
+    caps = environ_cp.get('HERMETIC_CUDA_COMPUTE_CAPABILITIES', '')
+    clang_default = True
+    if compute_capabilities_require_nvcc(caps):
+      clang_default = False
+      print(
+          '\nNOTE: Selected CUDA compute capabilities include sm_100+ '
+          '(Blackwell). Hermetic clang does not support these architectures; '
+          'defaulting the CUDA compiler to nvcc. Use --config=cuda13_nvcc '
+          '(CUDA 13) or --config=cuda_nvcc when building.\n'
+      )
+    set_tf_cuda_clang(environ_cp, enabled_by_default=clang_default)
     if environ_cp.get('TF_CUDA_CLANG') == '1':
       # Set up which clang we should use as the cuda / host compiler.
       clang_cuda_compiler_path = set_clang_cuda_compiler_path(environ_cp)
@@ -1360,10 +1414,25 @@ def main():
       'dynamic_kernels',
       '(Experimental) Build kernels into separate shared objects.')
   config_info_line('v1', 'Build with TensorFlow 1 API instead of TF 2 API.')
+  config_info_line(
+      'cuda13_nvcc',
+      'CUDA 13 + nvcc (recommended for Blackwell sm_100 / sm_120).')
+  config_info_line(
+      'cuda_wheel',
+      'Build GPU pip wheels without embedding CUDA shared libraries.')
 
   print('Preconfigured Bazel build configs to DISABLE default on features:')
   config_info_line('nogcp', 'Disable GCP support.')
   config_info_line('nonccl', 'Disable NVIDIA NCCL support.')
+
+  if environ_cp.get('TF_NEED_CUDA') == '1':
+    print(
+        '\nGPU pip wheel tip: build with --config=cuda_wheel, for example:\n'
+        '  bazel build --config=cuda13_nvcc --config=cuda_wheel \\\n'
+        '    //tensorflow/tools/pip_package:wheel\n'
+        'At runtime install matching nvidia-* pip packages (or system '
+        'CUDA/cuDNN) so libraries such as libcudnn.so.9 are findable.\n'
+    )
 
 
 if __name__ == '__main__':

--- a/configure_test.py
+++ b/configure_test.py
@@ -1,0 +1,78 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for configure.py CUDA compute capability helpers."""
+
+import unittest
+
+import configure
+
+
+class CudaComputeCapabilityTest(unittest.TestCase):
+
+  def test_parse_decimal_form(self):
+    self.assertEqual(configure.cuda_compute_capability_version('7.5'), (7, 5))
+    self.assertEqual(configure.cuda_compute_capability_version('12.0'), (12, 0))
+
+  def test_parse_sm_and_compute_form(self):
+    self.assertEqual(configure.cuda_compute_capability_version('sm_80'), (8, 0))
+    self.assertEqual(
+        configure.cuda_compute_capability_version('compute_90'), (9, 0)
+    )
+    self.assertEqual(
+        configure.cuda_compute_capability_version('sm_100'), (10, 0)
+    )
+    self.assertEqual(
+        configure.cuda_compute_capability_version('sm_120'), (12, 0)
+    )
+    self.assertEqual(
+        configure.cuda_compute_capability_version('compute_120'), (12, 0)
+    )
+    self.assertEqual(
+        configure.cuda_compute_capability_version('sm_100a'), (10, 0)
+    )
+    self.assertEqual(
+        configure.cuda_compute_capability_version('sm_120a'), (12, 0)
+    )
+
+  def test_parse_invalid(self):
+    self.assertIsNone(configure.cuda_compute_capability_version(''))
+    self.assertIsNone(configure.cuda_compute_capability_version('gpu'))
+    self.assertIsNone(configure.cuda_compute_capability_version('sm_'))
+
+  def test_require_nvcc_for_blackwell(self):
+    self.assertTrue(
+        configure.compute_capabilities_require_nvcc('sm_120,compute_120')
+    )
+    self.assertTrue(configure.compute_capabilities_require_nvcc('sm_100'))
+    self.assertTrue(
+        configure.compute_capabilities_require_nvcc(
+            'sm_75,sm_80,sm_90,sm_100,compute_120'
+        )
+    )
+    self.assertTrue(configure.compute_capabilities_require_nvcc('12.0'))
+
+  def test_no_nvcc_required_for_pre_blackwell(self):
+    self.assertFalse(
+        configure.compute_capabilities_require_nvcc('sm_60,sm_70,sm_80,sm_89')
+    )
+    self.assertFalse(
+        configure.compute_capabilities_require_nvcc('7.5,8.0,9.0')
+    )
+    self.assertFalse(configure.compute_capabilities_require_nvcc(''))
+    self.assertFalse(configure.compute_capabilities_require_nvcc(None))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/configure_test.py
+++ b/configure_test.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for configure.py CUDA compute capability helpers."""
+"""Tests for configure.py CUDA / Blackwell helpers."""
 
 import unittest
+from unittest import mock
 
 import configure
 
@@ -23,10 +24,18 @@ class CudaComputeCapabilityTest(unittest.TestCase):
 
   def test_parse_decimal_form(self):
     self.assertEqual(configure.cuda_compute_capability_version('7.5'), (7, 5))
+    self.assertEqual(configure.cuda_compute_capability_version('9.0'), (9, 0))
+    self.assertEqual(configure.cuda_compute_capability_version('10.0'), (10, 0))
     self.assertEqual(configure.cuda_compute_capability_version('12.0'), (12, 0))
+
+  def test_parse_strips_whitespace(self):
+    self.assertEqual(
+        configure.cuda_compute_capability_version('  sm_80  '), (8, 0)
+    )
 
   def test_parse_sm_and_compute_form(self):
     self.assertEqual(configure.cuda_compute_capability_version('sm_80'), (8, 0))
+    self.assertEqual(configure.cuda_compute_capability_version('sm_89'), (8, 9))
     self.assertEqual(
         configure.cuda_compute_capability_version('compute_90'), (9, 0)
     )
@@ -45,11 +54,16 @@ class CudaComputeCapabilityTest(unittest.TestCase):
     self.assertEqual(
         configure.cuda_compute_capability_version('sm_120a'), (12, 0)
     )
+    self.assertEqual(
+        configure.cuda_compute_capability_version('sm_100f'), (10, 0)
+    )
 
   def test_parse_invalid(self):
     self.assertIsNone(configure.cuda_compute_capability_version(''))
+    self.assertIsNone(configure.cuda_compute_capability_version(None))
     self.assertIsNone(configure.cuda_compute_capability_version('gpu'))
     self.assertIsNone(configure.cuda_compute_capability_version('sm_'))
+    self.assertIsNone(configure.cuda_compute_capability_version('compute'))
 
   def test_require_nvcc_for_blackwell(self):
     self.assertTrue(
@@ -62,6 +76,12 @@ class CudaComputeCapabilityTest(unittest.TestCase):
         )
     )
     self.assertTrue(configure.compute_capabilities_require_nvcc('12.0'))
+    self.assertTrue(configure.compute_capabilities_require_nvcc('10.0'))
+    # Whitespace and empty tokens
+    self.assertTrue(
+        configure.compute_capabilities_require_nvcc(' sm_80 , sm_120 ')
+    )
+    self.assertTrue(configure.compute_capabilities_require_nvcc('sm_120,'))
 
   def test_no_nvcc_required_for_pre_blackwell(self):
     self.assertFalse(
@@ -70,8 +90,183 @@ class CudaComputeCapabilityTest(unittest.TestCase):
     self.assertFalse(
         configure.compute_capabilities_require_nvcc('7.5,8.0,9.0')
     )
+    self.assertFalse(configure.compute_capabilities_require_nvcc('sm_90'))
+    self.assertFalse(configure.compute_capabilities_require_nvcc('compute_90'))
     self.assertFalse(configure.compute_capabilities_require_nvcc(''))
     self.assertFalse(configure.compute_capabilities_require_nvcc(None))
+    # Invalid tokens alone do not force nvcc
+    self.assertFalse(configure.compute_capabilities_require_nvcc('gpu,sm_'))
+
+  def test_clang_cuda_compiler_default(self):
+    self.assertTrue(configure.clang_cuda_compiler_default('sm_80,sm_90'))
+    self.assertTrue(configure.clang_cuda_compiler_default(''))
+    self.assertFalse(configure.clang_cuda_compiler_default('sm_120'))
+    self.assertFalse(
+        configure.clang_cuda_compiler_default('sm_75,sm_100,compute_120')
+    )
+
+
+class MaybeEnsureCuda13ForBlackwellTest(unittest.TestCase):
+
+  def test_no_op_for_pre_blackwell(self):
+    environ = {
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_80,sm_90',
+    }
+    with mock.patch.object(configure, 'write_repo_env_to_bazelrc') as write_env:
+      pinned = configure.maybe_ensure_cuda13_for_blackwell(environ)
+    self.assertFalse(pinned)
+    self.assertNotIn('HERMETIC_CUDA_VERSION', environ)
+    write_env.assert_not_called()
+
+  def test_pins_cuda13_when_blackwell_and_version_unset(self):
+    environ = {
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_120,compute_120',
+    }
+    with mock.patch.object(configure, 'write_repo_env_to_bazelrc') as write_env:
+      pinned = configure.maybe_ensure_cuda13_for_blackwell(environ)
+    self.assertTrue(pinned)
+    self.assertEqual(
+        environ['HERMETIC_CUDA_VERSION'],
+        configure._BLACKWELL_HERMETIC_CUDA_VERSION,
+    )
+    self.assertEqual(
+        environ['HERMETIC_CUDNN_VERSION'],
+        configure._BLACKWELL_HERMETIC_CUDNN_VERSION,
+    )
+    write_env.assert_any_call(
+        'cuda',
+        'HERMETIC_CUDA_VERSION',
+        configure._BLACKWELL_HERMETIC_CUDA_VERSION,
+    )
+    write_env.assert_any_call(
+        'cuda',
+        'HERMETIC_CUDNN_VERSION',
+        configure._BLACKWELL_HERMETIC_CUDNN_VERSION,
+    )
+
+  def test_does_not_override_explicit_cuda_version(self):
+    environ = {
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_120',
+        'HERMETIC_CUDA_VERSION': '12.5.1',
+        'HERMETIC_CUDNN_VERSION': '9.3.0',
+    }
+    with mock.patch.object(configure, 'write_repo_env_to_bazelrc') as write_env:
+      pinned = configure.maybe_ensure_cuda13_for_blackwell(environ)
+    self.assertFalse(pinned)
+    self.assertEqual(environ['HERMETIC_CUDA_VERSION'], '12.5.1')
+    self.assertEqual(environ['HERMETIC_CUDNN_VERSION'], '9.3.0')
+    write_env.assert_not_called()
+
+  def test_pins_only_missing_cudnn_when_cuda_set(self):
+    environ = {
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_100',
+        'HERMETIC_CUDA_VERSION': '13.0.0',
+    }
+    with mock.patch.object(configure, 'write_repo_env_to_bazelrc') as write_env:
+      pinned = configure.maybe_ensure_cuda13_for_blackwell(environ)
+    self.assertTrue(pinned)
+    self.assertEqual(environ['HERMETIC_CUDA_VERSION'], '13.0.0')
+    self.assertEqual(
+        environ['HERMETIC_CUDNN_VERSION'],
+        configure._BLACKWELL_HERMETIC_CUDNN_VERSION,
+    )
+    write_env.assert_called_once_with(
+        'cuda',
+        'HERMETIC_CUDNN_VERSION',
+        configure._BLACKWELL_HERMETIC_CUDNN_VERSION,
+    )
+
+
+class SetOtherCudaVarsTest(unittest.TestCase):
+
+  def test_clang_writes_cuda_clang(self):
+    environ = {
+        'TF_CUDA_CLANG': '1',
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_80',
+    }
+    with mock.patch.object(configure, 'write_to_bazelrc') as write_rc:
+      configure.set_other_cuda_vars(environ)
+    write_rc.assert_called_once_with('build --config=cuda_clang')
+
+  def test_pre_blackwell_nvcc_path_preserves_config_cuda_only(self):
+    environ = {
+        'TF_CUDA_CLANG': '0',
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_80,sm_90',
+    }
+    with mock.patch.object(configure, 'write_to_bazelrc') as write_rc:
+      configure.set_other_cuda_vars(environ)
+    write_rc.assert_called_once_with('build --config=cuda')
+
+  def test_blackwell_writes_cuda_nvcc(self):
+    environ = {
+        'TF_CUDA_CLANG': '0',
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_120,compute_120',
+    }
+    with mock.patch.object(configure, 'write_to_bazelrc') as write_rc:
+      configure.set_other_cuda_vars(environ)
+    write_rc.assert_called_once_with('build --config=cuda_nvcc')
+
+
+class RecommendedGpuWheelFlagsTest(unittest.TestCase):
+
+  def test_blackwell_recommends_cuda13_and_nvcc(self):
+    environ = {
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_120',
+        'TF_CUDA_CLANG': '0',
+    }
+    flags = configure.recommended_gpu_wheel_bazel_flags(environ)
+    self.assertEqual(
+        flags,
+        [
+            '--config=cuda',
+            '--config=cuda_wheel',
+            '--config=cuda13_version',
+            '--config=cuda_nvcc',
+        ],
+    )
+    self.assertNotIn('--config=cuda13_nvcc', flags)
+
+  def test_pre_blackwell_clang(self):
+    environ = {
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_80',
+        'TF_CUDA_CLANG': '1',
+    }
+    flags = configure.recommended_gpu_wheel_bazel_flags(environ)
+    self.assertEqual(
+        flags,
+        ['--config=cuda', '--config=cuda_wheel', '--config=cuda_clang'],
+    )
+
+  def test_pre_blackwell_nvcc(self):
+    environ = {
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_80',
+        'TF_CUDA_CLANG': '0',
+    }
+    flags = configure.recommended_gpu_wheel_bazel_flags(environ)
+    self.assertEqual(
+        flags,
+        ['--config=cuda', '--config=cuda_wheel', '--config=cuda_nvcc'],
+    )
+
+
+class BlackwellDoesNotBreakCuda12DefaultsTest(unittest.TestCase):
+  """Guards that CUDA 12 defaults stay intact for non-Blackwell configures."""
+
+  def test_cuda12_capability_list_does_not_require_nvcc(self):
+    # Mirrors .bazelrc common:cuda12_version / common:cuda_clang SM lists.
+    cuda12_caps = 'sm_60,sm_70,sm_80,sm_89,compute_90'
+    self.assertFalse(configure.compute_capabilities_require_nvcc(cuda12_caps))
+    self.assertTrue(configure.clang_cuda_compiler_default(cuda12_caps))
+
+  def test_cuda13_default_list_requires_nvcc(self):
+    # Mirrors .bazelrc common:cuda13_version SM list (includes Blackwell).
+    cuda13_caps = 'sm_75,sm_80,sm_90,sm_100,compute_120'
+    self.assertTrue(configure.compute_capabilities_require_nvcc(cuda13_caps))
+    self.assertFalse(configure.clang_cuda_compiler_default(cuda13_caps))
+
+  def test_blackwell_pin_versions_match_cuda13_version_config(self):
+    self.assertEqual(configure._BLACKWELL_HERMETIC_CUDA_VERSION, '13.0.0')
+    self.assertEqual(configure._BLACKWELL_HERMETIC_CUDNN_VERSION, '9.12.0')
 
 
 if __name__ == '__main__':

--- a/configure_test.py
+++ b/configure_test.py
@@ -163,7 +163,8 @@ class MaybeEnsureCuda13ForBlackwellTest(unittest.TestCase):
         'HERMETIC_CUDA_VERSION': '13.0.0',
     }
     with mock.patch.object(configure, 'write_repo_env_to_bazelrc') as write_env:
-      pinned = configure.maybe_ensure_cuda13_for_blackwell(environ)
+      with mock.patch('builtins.print') as mock_print:
+        pinned = configure.maybe_ensure_cuda13_for_blackwell(environ)
     self.assertTrue(pinned)
     self.assertEqual(environ['HERMETIC_CUDA_VERSION'], '13.0.0')
     self.assertEqual(
@@ -175,6 +176,21 @@ class MaybeEnsureCuda13ForBlackwellTest(unittest.TestCase):
         'HERMETIC_CUDNN_VERSION',
         configure._BLACKWELL_HERMETIC_CUDNN_VERSION,
     )
+    # Message must mention only what was pinned (cuDNN), not CUDA.
+    printed = ' '.join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+    self.assertIn('HERMETIC_CUDNN_VERSION=', printed)
+    self.assertNotIn('HERMETIC_CUDA_VERSION=', printed)
+
+  def test_pin_message_lists_both_when_both_unset(self):
+    environ = {
+        'HERMETIC_CUDA_COMPUTE_CAPABILITIES': 'sm_120',
+    }
+    with mock.patch.object(configure, 'write_repo_env_to_bazelrc'):
+      with mock.patch('builtins.print') as mock_print:
+        configure.maybe_ensure_cuda13_for_blackwell(environ)
+    printed = ' '.join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+    self.assertIn('HERMETIC_CUDA_VERSION=', printed)
+    self.assertIn('HERMETIC_CUDNN_VERSION=', printed)
 
 
 class SetOtherCudaVarsTest(unittest.TestCase):

--- a/tensorflow/tools/pip_package/utils/tf_wheel.bzl
+++ b/tensorflow/tools/pip_package/utils/tf_wheel.bzl
@@ -86,10 +86,10 @@ def _tf_wheel_impl(ctx):
     override_include_cuda_libs = ctx.attr.override_include_cuda_libs[BuildSettingInfo].value
     if include_cuda_libs and not override_include_cuda_libs:
         fail("TF wheel shouldn't be built with CUDA dependencies." +
-             " Please provide `--config=cuda_wheel` for bazel build command" +
-             " (optionally with `--config=cuda13_nvcc` for CUDA 13 /" +
-             " Blackwell). If you absolutely need to add CUDA dependencies," +
-             " provide" +
+             " Please provide `--config=cuda_wheel` for bazel build command." +
+             " For CUDA 13 / Blackwell also pass `--config=cuda13_version`" +
+             " and `--config=cuda_nvcc`. If you absolutely need to add CUDA" +
+             " dependencies, provide" +
              " `--@local_config_cuda//cuda:override_include_cuda_libs=true`.")
     executable = ctx.executable.wheel_binary
 

--- a/tensorflow/tools/pip_package/utils/tf_wheel.bzl
+++ b/tensorflow/tools/pip_package/utils/tf_wheel.bzl
@@ -86,8 +86,10 @@ def _tf_wheel_impl(ctx):
     override_include_cuda_libs = ctx.attr.override_include_cuda_libs[BuildSettingInfo].value
     if include_cuda_libs and not override_include_cuda_libs:
         fail("TF wheel shouldn't be built with CUDA dependencies." +
-             " Please provide `--config=cuda_wheel` for bazel build command." +
-             " If you absolutely need to add CUDA dependencies, provide" +
+             " Please provide `--config=cuda_wheel` for bazel build command" +
+             " (optionally with `--config=cuda13_nvcc` for CUDA 13 /" +
+             " Blackwell). If you absolutely need to add CUDA dependencies," +
+             " provide" +
              " `--@local_config_cuda//cuda:override_include_cuda_libs=true`.")
     executable = ctx.executable.wheel_binary
 

--- a/third_party/xla/docs/build_from_source.md
+++ b/third_party/xla/docs/build_from_source.md
@@ -100,10 +100,10 @@ docker exec xla_gpu ./configure.py --backend=CUDA \
 
 **Blackwell (sm_100 / sm_120):** The hermetic CUDA-clang toolchain does not
 support these architectures yet (`unsupported CUDA gpu architecture`). Prefer
-**nvcc** as the device compiler (for example TensorFlow's
-`--config=cuda_nvcc` or `--config=cuda13_nvcc`) and CUDA 13 when building for
-Blackwell GPUs such as B100/B200 (`sm_100`) or GeForce RTX 50-series
-(`sm_120`).
+**nvcc** as the device compiler (TensorFlow: `--config=cuda_nvcc`) and CUDA 13
+(`--config=cuda13_version`, without changing the default CUDA 12
+`--config=cuda` pin) when building for Blackwell GPUs such as B100/B200
+(`sm_100`) or GeForce RTX 50-series (`sm_120`).
 
 For more details regarding
 [TensorFlow's GPU docker images you can check out this document.](https://www.tensorflow.org/install/source#gpu_support_2)

--- a/third_party/xla/docs/build_from_source.md
+++ b/third_party/xla/docs/build_from_source.md
@@ -98,6 +98,13 @@ docker exec xla_gpu ./configure.py --backend=CUDA \
   --cuda_compute_capabilities="9.0"
 ```
 
+**Blackwell (sm_100 / sm_120):** The hermetic CUDA-clang toolchain does not
+support these architectures yet (`unsupported CUDA gpu architecture`). Prefer
+**nvcc** as the device compiler (for example TensorFlow's
+`--config=cuda_nvcc` or `--config=cuda13_nvcc`) and CUDA 13 when building for
+Blackwell GPUs such as B100/B200 (`sm_100`) or GeForce RTX 50-series
+(`sm_120`).
+
 For more details regarding
 [TensorFlow's GPU docker images you can check out this document.](https://www.tensorflow.org/install/source#gpu_support_2)
 

--- a/third_party/xla/tensorflow.bazelrc
+++ b/third_party/xla/tensorflow.bazelrc
@@ -212,6 +212,8 @@ common:cuda_clang --copt=-Qunused-arguments
 # release while SASS is only forward compatible inside the current
 # major release. Example: sm_80 kernels can run on sm_89 GPUs but
 # not on sm_90 GPUs. compute_80 kernels though can also run on sm_90 GPUs.
+# NOTE: Hermetic cuda_clang currently rejects sm_100 / sm_120. For Blackwell
+# targets use --config=cuda_nvcc (see pjrt_cuda13 which already does).
 common:cuda_clang --repo_env=HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_60,sm_70,sm_80,sm_89,compute_90"
 # Permit newer CUDA versions than Clang is aware of
 common:cuda_clang --copt="-Wno-unknown-cuda-version"


### PR DESCRIPTION
## Summary

Hermetic `cuda_clang` rejects Blackwell architectures (`sm_100` / `sm_120`) with `unsupported CUDA gpu architecture`, which breaks local CUDA 13 builds for GPUs such as GeForce RTX 50-series.

This change improves the **existing** config path (no new `cuda13_nvcc` alias):

- Document that Blackwell builds should use `--config=cuda13_version` + `--config=cuda_nvcc` (+ `--config=cuda_wheel` for pip packages).
- Keep default `--config=cuda` on **CUDA 12** (`cuda_version` → `cuda12_version`).
- Leave `cuda_clang` compute capabilities free of `sm_100` / `sm_120` so the clang path is unchanged.
- In `./configure`, when the user selects sm_100+ capabilities:
  - default the CUDA device compiler to **nvcc** (not clang);
  - if hermetic CUDA/cuDNN versions are unset, pin CUDA **13.0.0** / cuDNN **9.12.0** (same pins as `cuda13_version`);
  - write `--config=cuda_nvcc` for Blackwell; pre-Blackwell non-clang still writes only `--config=cuda`.
- Clarify the pip wheel analysis error for CUDA 13 / Blackwell.
- Add unit tests for capability parsing, CUDA 12 preservation, CUDA 13 pinning, and recommended wheel flags.

## Example build (Blackwell)

```bash
bazel build \
  --config=cuda \
  --config=cuda13_version \
  --config=cuda_nvcc \
  --config=cuda_wheel \
  //tensorflow/tools/pip_package:wheel
```

## Test plan

- [x] `python3 -m unittest configure_test.py -v` (20 tests)
- [ ] CI (Kokoro) on this PR
- [ ] Manual: `./configure` with `HERMETIC_CUDA_COMPUTE_CAPABILITIES=sm_80` still defaults toward non-Blackwell / CUDA 12 behavior
- [ ] Manual: `./configure` with `sm_120` defaults to nvcc and pins CUDA 13 when versions are left empty