### PR TITLE
Fix tf.norm XLA compilation failure for ord=2 multi-axis norms

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/BUILD
+++ b/tensorflow/python/kernel_tests/linalg/BUILD
@@ -786,6 +786,7 @@ cuda_py_strict_test(
     # TODO(b/208263392): Re-enable. tf.Squeeze op after tf.Where op doesn't reshape.
     xla_enable_strict_auto_jit = False,
     deps = [
+        "//tensorflow/python/eager:def_function",
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:array_ops",

--- a/tensorflow/python/kernel_tests/linalg/norm_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/norm_op_test.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -58,6 +59,64 @@ class NormOpTest(test_lib.TestCase):
                       "integers")
       with self.assertRaisesRegex(ValueError, error_prefix):
         linalg_ops.norm(matrix, axis=axis_)
+
+  @test_util.run_v2_only
+  def testMatrixNormOrd2MultiAxisXlaCompile(self):
+    """Regression test for GitHub issue #122865.
+
+    tf.norm with ord=2 over two axes previously lowered to a ListDiff op
+    whose output shape depends on a runtime value (array_ops.rank), which
+    XLA cannot compile even when the axes and tensor rank are statically
+    known. When the rank is static, the remaining axes should be computed
+    in pure Python so no dynamically-shaped op reaches XLA.
+    """
+    if not test_lib.is_built_with_xla():
+      self.skipTest("Test only applicable when running with XLA support")
+
+    rng = np.random.RandomState(0)
+    matrix = rng.randn(3, 16, 32, 24).astype(np.float32)
+    tensor = constant_op.constant(matrix)
+
+    def norm_fn(t):
+      return linalg_ops.norm(t, ord=2, axis=[1, 2], keepdims=True)
+
+    eager_result = norm_fn(tensor)
+    xla_result = def_function.function(norm_fn, jit_compile=True)(tensor)
+    self.assertAllClose(eager_result, xla_result, rtol=1e-5, atol=1e-5)
+
+  @test_util.run_v2_only
+  def testMatrixNormOrd2MultiAxisNegativeAxisXlaCompile(self):
+    """Regression test for GitHub issue #122865, negative axis variant."""
+    if not test_lib.is_built_with_xla():
+      self.skipTest("Test only applicable when running with XLA support")
+
+    rng = np.random.RandomState(1)
+    matrix = rng.randn(3, 16, 32, 24).astype(np.float32)
+    tensor = constant_op.constant(matrix)
+
+    def norm_fn(t):
+      return linalg_ops.norm(t, ord=2, axis=[-3, -2], keepdims=True)
+
+    eager_result = norm_fn(tensor)
+    xla_result = def_function.function(norm_fn, jit_compile=True)(tensor)
+    self.assertAllClose(eager_result, xla_result, rtol=1e-5, atol=1e-5)
+
+  @test_util.run_v2_only
+  def testMatrixNormOrd2MultiAxisXlaCompileNoKeepdims(self):
+    """Regression test for GitHub issue #122865, keepdims=False variant."""
+    if not test_lib.is_built_with_xla():
+      self.skipTest("Test only applicable when running with XLA support")
+
+    rng = np.random.RandomState(2)
+    matrix = rng.randn(3, 16, 32, 24).astype(np.float32)
+    tensor = constant_op.constant(matrix)
+
+    def norm_fn(t):
+      return linalg_ops.norm(t, ord=2, axis=[1, 2], keepdims=False)
+
+    eager_result = norm_fn(tensor)
+    xla_result = def_function.function(norm_fn, jit_compile=True)(tensor)
+    self.assertAllClose(eager_result, xla_result, rtol=1e-5, atol=1e-5)
 
 
 def _GetNormOpTest(dtype_, shape_, ord_, axis_, keep_dims_, use_static_shape_):

--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -733,23 +733,35 @@ def norm(tensor,
 
     if ord in ['fro', 'euclidean', 2, 2.0]:
       if is_matrix_norm and ord in [2, 2.0]:
-        rank = array_ops.rank(tensor)
-        positive_axis = map_fn.map_fn(
+        static_rank = tensor.shape.rank
+        if static_rank is not None:
+          # axis is already validated to be a 2-tuple of Python ints above, so
+          # once the rank is also statically known, perm_before/perm_after are
+          # fully determined at trace time. Compute them in pure Python instead
+          # of emitting list_diff/map_fn/cond ops, whose output shapes XLA
+          # can't prove constant even though the values fully are.
+          positive_axis = tuple(a + static_rank if a < 0 else a for a in axis)
+          axes = list(range(static_rank))
+          perm_before = [a for a in axes if a not in positive_axis] + list(positive_axis)
+          perm_after = [perm_before.index(a) for a in axes]
+        else:
+          rank = array_ops.rank(tensor)
+          positive_axis = map_fn.map_fn(
             lambda i: cond.cond(
-                i >= 0,
-                lambda: i,
-                lambda: i + rank),
+              i >= 0,
+              lambda: i,
+              lambda: i + rank),
             ops.convert_to_tensor(axis))
-        axes = math_ops.range(rank)
-        perm_before = array_ops.concat([
+          axes = math_ops.range(rank)
+          perm_before = array_ops.concat([
             gen_array_ops.list_diff(axes, positive_axis, dtypes.int32)[0],
             positive_axis
-        ],
-                                       axis=0)
-        perm_after = map_fn.map_fn(
+          ],
+                                    axis=0)
+          perm_after = map_fn.map_fn(
             lambda i: math_ops.cast(
-                array_ops.squeeze(
-                    array_ops.where_v2(math_ops.equal(perm_before, i))),
+              array_ops.squeeze(
+                array_ops.where_v2(math_ops.equal(perm_before, i))),
                 dtype=dtypes.int32), axes)
         permed = array_ops.transpose(tensor, perm=perm_before)
         matrix_2_norm = array_ops.expand_dims(


### PR DESCRIPTION
tf.norm(x, ord=2, axis=[a, b], keepdims=...) failed to compile under jit_compile=True with 'Input 1 to node norm/ListDiff ... must be a compile-time constant.' The matrix-2-norm path in linalg_ops.norm() computed the transpose permutation via array_ops.rank (a runtime op) feeding gen_array_ops.list_diff, even though axis is already a static 2-tuple of Python ints and the tensor rank is almost always statically known too.

This adds a static-rank fast path that computes the same permutation as a plain Python list when tensor.shape.rank is known, avoiding the list_diff/map_fn/cond ops entirely. Falls back to the existing dynamic-rank implementation otherwise.

Verified against the reproducer in the issue: eager, graph, and XLA results match in both shape and value. verified both shape and value equivalence against eager/graph, not just shape

Fixes #122865