### PR TITLE
Gate exp(LHS)*exp(RHS) => exp(LHS+RHS) rewrite behind fast-math

### DIFF
--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -5132,7 +5132,12 @@ absl::Status AlgebraicSimplifierVisitor::HandleMultiply(
 
   VLOG(10) << "trying to transform exp(LHS) * exp(RHS) => exp(LHS+RHS) "
            << multiply->ToString();
-  if (Match(multiply, m::Multiply(m::Exp(m::Op(&lhs)), m::Exp(m::Op(&rhs))))) {
+  // This transformation is not numerically equivalent at overflow/underflow
+  // boundaries: exp(LHS) * exp(RHS) can evaluate to NaN (e.g. Inf * 0) while
+  // exp(LHS + RHS) evaluates to a finite value (e.g. exp(0) = 1). Only apply
+  // it when the caller has opted into fast-math semantics.
+  if (options_.enable_fast_math() &&
+      Match(multiply, m::Multiply(m::Exp(m::Op(&lhs)), m::Exp(m::Op(&rhs))))) {
     auto add = multiply->AddInstruction(HloInstruction::CreateBinary(
         multiply->shape(), HloOpcode::kAdd, lhs, rhs));
     return ReplaceWithNewInstruction(

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -2806,7 +2806,10 @@ TEST_F(AlgebraicSimplifierTest, ExpDiv) {
       GmockMatch(m::Exp(m::Subtract(m::Parameter(0), m::Parameter(1)))));
 }
 
-// Test that exp(A)*exp(B) is simplified to exp(A+B)
+// Test that exp(A)*exp(B) is simplified to exp(A+B) when fast-math is
+// enabled. This rewrite is not numerically equivalent at overflow/underflow
+// boundaries (e.g. exp(100)*exp(-100) is NaN, but exp(100 + -100) is 1), so
+// it is gated behind enable_fast_math.
 TEST_F(AlgebraicSimplifierTest, ExpMul) {
   auto m = CreateNewVerifiedModule();
   Shape r0f32 = ShapeUtil::MakeShape(F32, {});
@@ -2828,11 +2831,59 @@ TEST_F(AlgebraicSimplifierTest, ExpMul) {
               GmockMatch(m::Multiply(m::Exp(m::Parameter(0)),
                                      m::Exp(m::Parameter(1)))));
 
-  AlgebraicSimplifier simplifier(default_options_);
-  ASSERT_TRUE(simplifier.Run(m.get()).value());
+  // By default (fast-math disabled), the rewrite must not fire, since it
+  // would change NaN results (from overflow*underflow) into finite ones.
+  AlgebraicSimplifier default_simplifier(default_options_);
+  ASSERT_FALSE(default_simplifier.Run(m.get()).value());
+  EXPECT_THAT(computation->root_instruction(),
+              GmockMatch(m::Multiply(m::Exp(m::Parameter(0)),
+                                     m::Exp(m::Parameter(1)))));
+
+  // With fast-math enabled, the rewrite is allowed to fire.
+  AlgebraicSimplifierOptions fast_math_options = default_options_;
+  fast_math_options.set_enable_fast_math(true);
+  AlgebraicSimplifier fast_math_simplifier(fast_math_options);
+  ASSERT_TRUE(fast_math_simplifier.Run(m.get()).value());
 
   EXPECT_THAT(computation->root_instruction(),
               GmockMatch(m::Exp(m::Add(m::Parameter(0), m::Parameter(1)))));
+}
+
+// Regression test for https://github.com/tensorflow/tensorflow/issues/123169
+// exp(100) * exp(-100) is NaN (Inf * 0), but the naive rewrite to
+// exp(100 + -100) = exp(0) = 1 silently changes this to a finite value.
+// Without fast-math, the multiply of two exponentials must be preserved so
+// that NaN semantics are not altered.
+TEST_F(AlgebraicSimplifierTest, ExpMulOverflowUnderflowPreservesNanByDefault) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      x = f32[] constant(100.0)
+      y = f32[] constant(-100.0)
+      exp0 = f32[] exponential(x)
+      exp1 = f32[] exponential(y)
+      ROOT mul = f32[] multiply(exp0, exp1)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+
+  // Default options (fast-math disabled): the exp(A)*exp(B) => exp(A+B)
+  // rewrite must not apply, preserving the original NaN-producing
+  // computation.
+  AlgebraicSimplifier default_simplifier(default_options_);
+  TF_ASSERT_OK(default_simplifier.Run(m.get()).status());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Multiply(m::Exp(m::Constant()),
+                                     m::Exp(m::Constant()))));
+
+  // With fast-math enabled, the rewrite is expected to apply (this is the
+  // documented, opt-in behavior).
+  AlgebraicSimplifierOptions fast_math_options = default_options_;
+  fast_math_options.set_enable_fast_math(true);
+  AlgebraicSimplifier fast_math_simplifier(fast_math_options);
+  ASSERT_TRUE(fast_math_simplifier.Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Exp(m::Add(m::Constant(), m::Constant()))));
 }
 
 // Test that pow(exp(A), B) is simplified to exp(A*B)

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -2834,7 +2834,9 @@ TEST_F(AlgebraicSimplifierTest, ExpMul) {
   // By default (fast-math disabled), the rewrite must not fire, since it
   // would change NaN results (from overflow*underflow) into finite ones.
   AlgebraicSimplifier default_simplifier(default_options_);
-  ASSERT_FALSE(default_simplifier.Run(m.get()).value());
+  TF_ASSERT_OK_AND_ASSIGN(bool changed_default,
+                           default_simplifier.Run(m.get()));
+  EXPECT_FALSE(changed_default);
   EXPECT_THAT(computation->root_instruction(),
               GmockMatch(m::Multiply(m::Exp(m::Parameter(0)),
                                      m::Exp(m::Parameter(1)))));
@@ -2843,7 +2845,9 @@ TEST_F(AlgebraicSimplifierTest, ExpMul) {
   AlgebraicSimplifierOptions fast_math_options = default_options_;
   fast_math_options.set_enable_fast_math(true);
   AlgebraicSimplifier fast_math_simplifier(fast_math_options);
-  ASSERT_TRUE(fast_math_simplifier.Run(m.get()).value());
+  TF_ASSERT_OK_AND_ASSIGN(bool changed_fast_math,
+                           fast_math_simplifier.Run(m.get()));
+  EXPECT_TRUE(changed_fast_math);
 
   EXPECT_THAT(computation->root_instruction(),
               GmockMatch(m::Exp(m::Add(m::Parameter(0), m::Parameter(1)))));
@@ -2871,7 +2875,9 @@ TEST_F(AlgebraicSimplifierTest, ExpMulOverflowUnderflowPreservesNanByDefault) {
   // rewrite must not apply, preserving the original NaN-producing
   // computation.
   AlgebraicSimplifier default_simplifier(default_options_);
-  TF_ASSERT_OK(default_simplifier.Run(m.get()).status());
+  TF_ASSERT_OK_AND_ASSIGN(bool changed_default,
+                           default_simplifier.Run(m.get()));
+  EXPECT_FALSE(changed_default);
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Multiply(m::Exp(m::Constant()),
                                      m::Exp(m::Constant()))));
@@ -2881,7 +2887,9 @@ TEST_F(AlgebraicSimplifierTest, ExpMulOverflowUnderflowPreservesNanByDefault) {
   AlgebraicSimplifierOptions fast_math_options = default_options_;
   fast_math_options.set_enable_fast_math(true);
   AlgebraicSimplifier fast_math_simplifier(fast_math_options);
-  ASSERT_TRUE(fast_math_simplifier.Run(m.get()).value());
+  TF_ASSERT_OK_AND_ASSIGN(bool changed_fast_math,
+                           fast_math_simplifier.Run(m.get()));
+  EXPECT_TRUE(changed_fast_math);
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Exp(m::Add(m::Constant(), m::Constant()))));
 }


### PR DESCRIPTION
Fixes #123169

The AlgebraicSimplifier rewrite `exp(LHS) * exp(RHS) => exp(LHS+RHS)` is not numerically equivalent at overflow/underflow boundaries. For example, `exp(100) * exp(-100)` evaluates to `Inf * 0 = NaN`, while the rewritten form `exp(100 + -100) = exp(0) = 1.0` silently turns that NaN into a finite value — causing XLA-compiled functions to diverge from eager/graph execution.

This PR gates the rewrite behind `options_.enable_fast_math()`, matching the existing convention in this file for other NaN-sensitive optimizations (e.g. `A - A => 0`, `0 * RHS => 0`).

**Testing**
- Updated `ExpMul` to verify the rewrite is skipped by default and only applies with fast-math enabled.
- Added `ExpMulOverflowUnderflowPreservesNanByDefault`, a regression test reproducing the exact `exp(100)*exp(-100)` case from the issue.
- `bazel test //xla/hlo/transforms/simplifiers:algebraic_simplifier_test --test_filter="*ExpMul*"` passes.