### PR TITLE
Avoid eager shape ops in tf.boolean_mask with static shapes

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for array_ops."""
+import concurrent.futures
 import re
+import threading
 import time
 import unittest
+from unittest import mock
 
 from absl.testing import parameterized
 import numpy as np
@@ -208,6 +211,46 @@ class BooleanMaskTest(test_util.TensorFlowTestCase):
     for arr_shape in [(1, 1, 1), (1, 2, 2), (2, 2, 1)]:
       with self.subTest(arr_shape=arr_shape):
         self.CheckVersusNumpy(ndims_mask, arr_shape)
+
+  def testFullyDefinedShapeDoesNotReadShapeAtRuntime(self):
+    with context.eager_mode():
+      tensor_value = np.arange(24).reshape((2, 3, 4))
+      tensor = constant_op.constant(tensor_value)
+      mask = constant_op.constant(tensor_value % 2 == 0)
+      with mock.patch.object(
+          array_ops,
+          "shape",
+          side_effect=AssertionError("unexpected runtime Shape op"),
+      ):
+        result = array_ops.boolean_mask(tensor, mask)
+
+      self.assertAllEqual(tensor_value[tensor_value % 2 == 0], result)
+
+  @test_util.run_gpu_only
+  def testConcurrentEagerBooleanMaskOnGpu(self):
+    thread_count = 8
+    barrier = threading.Barrier(thread_count)
+    tensor_shape = (64, 64, 64, 4)
+    tensor_value = np.arange(
+        np.prod(tensor_shape), dtype=np.float32).reshape(tensor_shape)
+    expected = tensor_value[tensor_value >= tensor_value.size // 2]
+
+    def apply_mask(_):
+      with context.eager_mode(), test_util.force_gpu():
+        tensor = constant_op.constant(tensor_value)
+        barrier.wait(timeout=60)
+        for _ in range(5):
+          result = array_ops.boolean_mask(
+              tensor, tensor >= tensor_value.size // 2)
+        return result.numpy()
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=thread_count
+    ) as executor:
+      results = list(executor.map(apply_mask, range(thread_count)))
+
+    for result in results:
+      self.assertAllEqual(expected, result)
 
   def testEmptyInput2D(self):
     mask = np.array([True, False])

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -230,9 +230,9 @@ class BooleanMaskTest(test_util.TensorFlowTestCase):
   def testConcurrentEagerBooleanMaskOnGpu(self):
     thread_count = 8
     barrier = threading.Barrier(thread_count)
-    tensor_shape = (64, 64, 64, 4)
+    input_shape = (64, 64, 64, 4)
     tensor_value = np.arange(
-        np.prod(tensor_shape), dtype=np.float32).reshape(tensor_shape)
+        np.prod(input_shape), dtype=np.float32).reshape(input_shape)
     expected = tensor_value[tensor_value >= tensor_value.size // 2]
 
     def apply_mask(_):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1516,26 +1516,28 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
           " are None.  E.g. shape=[None] is ok, but shape=None is not.")
     axis = 0 if axis is None else axis
     axis_value = tensor_util.constant_value(axis)
+    flattened_shape = None
     if axis_value is not None:
       axis = axis_value
       shape_tensor[axis:axis + ndims_mask].assert_is_compatible_with(shape_mask)
-
-    leading_size = gen_math_ops.prod(shape(tensor)[axis:axis + ndims_mask], [0])
-    tensor = reshape(
-        tensor,
-        concat([
-            shape(tensor)[:axis], [leading_size],
-            shape(tensor)[axis + ndims_mask:]
-        ], 0))
-    # TODO(yongtang): tf.reshape in C++ kernel might have set the shape
-    # correctly, so the following may not be needed? It still might be possible
-    # that there are some edge case where tensor_util.constant_value resolves
-    # more cases than ShapeInference of tf.reshape in C++ kernel.
-    if axis_value is not None:
       first_dim = shape_tensor[axis:axis + ndims_mask].num_elements()
-      tensor.set_shape(
-          tensor_shape.as_shape(shape_tensor[:axis]).concatenate(
-              [first_dim]).concatenate(shape_tensor[axis + ndims_mask:]))
+      flattened_shape = shape_tensor[:axis].concatenate(
+          [first_dim]).concatenate(shape_tensor[axis + ndims_mask:])
+
+    if flattened_shape is not None and flattened_shape.is_fully_defined():
+      tensor = reshape(tensor, flattened_shape)
+    else:
+      leading_size = gen_math_ops.prod(
+          shape(tensor)[axis:axis + ndims_mask], [0]
+      )
+      tensor = reshape(
+          tensor,
+          concat([
+              shape(tensor)[:axis], [leading_size],
+              shape(tensor)[axis + ndims_mask:]
+          ], 0))
+    if flattened_shape is not None:
+      tensor.set_shape(flattened_shape)
 
     mask = reshape(mask, [-1])
     return _apply_mask_1d(tensor, mask, axis)


### PR DESCRIPTION
## Summary

- Build the `tf.boolean_mask` reshape target from its fully defined
  `TensorShape`.
- Preserve the existing runtime-shape path for partial shapes and dynamic axes.
- Add deterministic and concurrent GPU regression coverage.

This avoids eager `Shape`, `StridedSlice`, `Pack`, and `ConcatV2` helper ops
when the required shape is already known. Under concurrent GPU execution,
those helpers can receive corrupted shape inputs and fail nondeterministically.

Fixes #123980.

## Testing

- `BooleanMaskTest.testFullyDefinedShapeDoesNotReadShapeAtRuntime`
- `BooleanMaskTest.testConcurrentEagerBooleanMaskOnGpu` on a Tesla V100 16 GB
- Focused `BooleanMaskTest` coverage for dynamic axes, partial shapes, empty
  inputs, and empty outputs

The unmodified TensorFlow 2.20 wheel reproduced the reported `StridedSlice`
shape corruption on the first concurrent V100 run. The patched implementation
passed the exact GPU regression.
