### PR TITLE
[TFLite] Saturate constant StridedSlice indices when lowering to int32

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/legalize-tf.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/legalize-tf.mlir
@@ -1428,6 +1428,19 @@ func.func @strided_slice_with_i64_constant_attributes(%arg0: tensor<10x10x10xf32
   // CHECK-NEXT: "tfl.strided_slice"(%arg0, [[BEGIN]], [[END]], [[STRIDES]]) <{begin_mask = 0 : i32, ellipsis_mask = 0 : i32, end_mask = 0 : i32, new_axis_mask = 0 : i32, offset = false, shrink_axis_mask = 1 : i32}> : (tensor<10x10x10xf32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<10x10xf32>
 }
 
+func.func @strided_slice_with_i64_limits(%arg0: tensor<3xf32>) -> tensor<3xf32> {
+  %begin = arith.constant dense<-9223372036854775808> : tensor<1xi64>
+  %end = arith.constant dense<9223372036854775807> : tensor<1xi64>
+  %strides = arith.constant dense<1> : tensor<1xi64>
+  %0 = "tf.StridedSlice"(%arg0, %begin, %end, %strides) {begin_mask = 1 : i64, ellipsis_mask = 0 : i64, end_mask = 0 : i64, new_axis_mask = 0 : i64, shrink_axis_mask = 0 : i64, offset = false} : (tensor<3xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xf32>
+  func.return %0 : tensor<3xf32>
+  // CHECK-LABEL: strided_slice_with_i64_limits
+  // CHECK-DAG: [[BEGIN:%.*]] = arith.constant dense<-2147483648> : tensor<1xi32>
+  // CHECK-DAG: [[END:%.*]] = arith.constant dense<2147483647> : tensor<1xi32>
+  // CHECK-DAG: [[STRIDES:%.*]] = arith.constant dense<1> : tensor<1xi32>
+  // CHECK-NEXT: "tfl.strided_slice"(%arg0, [[BEGIN]], [[END]], [[STRIDES]]) <{begin_mask = 1 : i32, ellipsis_mask = 0 : i32, end_mask = 0 : i32, new_axis_mask = 0 : i32, offset = false, shrink_axis_mask = 0 : i32}> : (tensor<3xf32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<3xf32>
+}
+
 func.func @strided_slice_non_zero_ellipsis_mask(%arg0: tensor<12x2x2x5xf32>, %arg1: tensor<1xi32>, %arg2: tensor<1xi32>, %arg3: tensor<1xi32>) -> tensor<1x2x2x5xf32> {
   %0 = "tf.StridedSlice"(%arg0, %arg1, %arg2, %arg3) {begin_mask = 0 : i64, ellipsis_mask = 1 : i64, end_mask = 0 : i64, new_axis_mask = 0 : i64, shrink_axis_mask = 0 : i64, offset = false} : (tensor<12x2x2x5xf32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1x2x2x5xf32>
   func.return %0 : tensor<1x2x2x5xf32>

--- a/tensorflow/compiler/mlir/lite/transforms/legalize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/legalize_patterns.td
@@ -70,6 +70,9 @@ def ExtractSingleElementAsInt32 : NativeCodeCall<
 def CreateTFCastToInt32Op : NativeCodeCall<
   "CreateCastToInt32($0, $_loc, $_builder)">;
 
+def CreateStridedSliceIndexToInt32 : NativeCodeCall<
+  "CreateStridedSliceIndexToInt32($0, $_loc, $_builder)">;
+
 def CreateInt32ConstOrCast : NativeCodeCall<
   "CreateInt32ConstOrCast($0, $_loc, $_builder)">;
 
@@ -608,8 +611,10 @@ def LegalizeStridedSlice : Pat<
     $input, $begin, $end, $strides, $begin_mask, $end_mask,
     $ellipsis_mask, $new_axis_mask, $shrink_axis_mask),
   (TFL_StridedSliceOp $input,
-    (CreateTFCastToInt32Op $begin), (CreateTFCastToInt32Op $end),
-    (CreateTFCastToInt32Op $strides), (convertIntAttrTo32Bit $begin_mask),
+    (CreateStridedSliceIndexToInt32 $begin),
+    (CreateStridedSliceIndexToInt32 $end),
+    (CreateStridedSliceIndexToInt32 $strides),
+    (convertIntAttrTo32Bit $begin_mask),
     (convertIntAttrTo32Bit $end_mask), (convertIntAttrTo32Bit $ellipsis_mask),
     (convertIntAttrTo32Bit $new_axis_mask),
     (convertIntAttrTo32Bit $shrink_axis_mask),

--- a/tensorflow/compiler/mlir/lite/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/legalize_tf.cc
@@ -22,9 +22,9 @@ limitations under the License.
 // constant folding support for the TensorFlow ops.
 
 #include <algorithm>
-#include <climits>
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <utility>
 
@@ -110,6 +110,34 @@ Value CreateCastToInt32(Value val, Location loc, PatternRewriter& rewriter) {
   return rewriter.createOrFold<TF::CastOp>(
       loc, UnrankedTensorType::get(new_ele_type), val,
       rewriter.getBoolAttr(false));
+}
+
+Value CreateStridedSliceIndexToInt32(Value val, Location loc,
+                                     PatternRewriter& rewriter) {
+  DenseIntElementsAttr value_attr;
+  if (matchPattern(val, m_Constant(&value_attr))) {
+    auto new_type = mlir::cast<ShapedType>(value_attr.getType())
+                        .clone(rewriter.getIntegerType(32));
+    auto clamp_to_int32 = [](const APInt& value) {
+      return static_cast<int32_t>(std::clamp<int64_t>(
+          value.getSExtValue(), std::numeric_limits<int32_t>::min(),
+          std::numeric_limits<int32_t>::max()));
+    };
+    if (value_attr.isSplat()) {
+      return arith::ConstantOp::create(
+          rewriter, loc,
+          DenseIntElementsAttr::get(
+              new_type, {clamp_to_int32(value_attr.getSplatValue<APInt>())}));
+    }
+    SmallVector<int32_t, 4> values;
+    values.reserve(value_attr.getNumElements());
+    for (const APInt& value : value_attr.getValues<APInt>()) {
+      values.push_back(clamp_to_int32(value));
+    }
+    return arith::ConstantOp::create(
+        rewriter, loc, DenseIntElementsAttr::get(new_type, values));
+  }
+  return CreateCastToInt32(val, loc, rewriter);
 }
 
 // Utility function to-


### PR DESCRIPTION
## Summary
- saturate constant 64-bit StridedSlice begin, end, and stride values before lowering them to the 32-bit Lite representation
- keep dynamic operands on the existing cast path
- cover INT64_MIN and INT64_MAX in the legalization test

## Testing
- `bazel test //tensorflow/compiler/mlir/lite/tests:legalize-tf.mlir.test`

Fixes #123997