### PR TITLE
[TFLite] Clarify Interpreter input detail ordering

### DIFF
--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -821,6 +821,10 @@ class Interpreter:
   def get_output_details(self):
     """Gets model output tensor details.
 
+    The list order may differ from the return order of the original TensorFlow
+    function or the output order in a model signature. For models with
+    signatures, use `get_signature_runner()` to access outputs by name.
+
     Returns:
       A list in which each item is a dictionary with details about
       an output tensor. The dictionary contains the same fields as

--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -739,6 +739,10 @@ class Interpreter:
   def get_input_details(self):
     """Gets model input tensor details.
 
+    The list order may differ from the argument order of the original
+    TensorFlow function. For models with signatures, use
+    `get_signature_runner()` to provide inputs by name.
+
     Returns:
       A list in which each item is a dictionary with details about
       an input tensor. Each dictionary contains the following fields


### PR DESCRIPTION
## Summary
- document that `get_input_details()` order may differ from the original TensorFlow function argument order
- direct signature-bearing models to `get_signature_runner()` for name-based input binding

The reported TopK values are correct when `x1` and `x2` are bound by signature name. Positional zipping reverses the two inputs in this model because the interpreter input list is `x2`, then `x1`.

## Testing
- verified the issue reproducer with positional and signature-based input binding
- Python syntax check for `interpreter.py`

Closes #123996