### PR TITLE
Fix issue #65317: Add complex dtype check for tf.math.round

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -976,7 +976,7 @@ def round(x, name=None):  # pylint: disable=redefined-builtin
 
   ```python
   x = tf.constant([1.4+2.6j, 3.2+4.8j])
-  rounded = tf.complex(tf.round(tf.math.real(x)), tf.round(tf.math.imag(x)))
+  rounded = tf.complex(tf.math.round(tf.math.real(x)), tf.math.round(tf.math.imag(x)))
   ```
 
   Args:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -970,14 +970,32 @@ def round(x, name=None):  # pylint: disable=redefined-builtin
   tf.round(x)  # [ 1.0, 2.0, 2.0, 2.0, -4.0 ]
   ```
 
+  Note: This operation does not support complex dtypes. If you need to round
+  complex numbers, apply this operation separately to the real and imaginary
+  components:
+
+  ```python
+  x = tf.constant([1.4+2.6j, 3.2+4.8j])
+  rounded = tf.complex(tf.round(tf.math.real(x)), tf.round(tf.math.imag(x)))
+  ```
+
   Args:
-    x: A `Tensor` of type `float16`, `float32`, `float64`, `int32`, or `int64`.
+    x: A `Tensor` of type `bfloat16`, `float16`, `float32`, `float64`, `int32`,
+      or `int64`.
     name: A name for the operation (optional).
 
   Returns:
     A `Tensor` of same shape and type as `x`.
+
+  Raises:
+    TypeError: If `x` is a complex dtype (`complex64`, `complex128`).
   """
   x = ops.convert_to_tensor(x, name="x")
+  if x.dtype.is_complex:
+    raise TypeError(
+        f"tf.math.round does not support complex dtypes (received {x.dtype}). "
+        "To round complex numbers, apply tf.round separately to the real and "
+        "imaginary components using tf.math.real() and tf.math.imag().")
   if x.dtype.is_integer:
     return x
   else:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -993,8 +993,8 @@ def round(x, name=None):  # pylint: disable=redefined-builtin
   x = ops.convert_to_tensor(x, name="x")
   if x.dtype.is_complex:
     raise TypeError(
-        f"tf.math.round does not support complex dtypes (received {x.dtype}). "
-        "To round complex numbers, apply tf.round separately to the real and "
+        f"tf.math.round does not support complex dtypes (received {x.dtype.name}). "
+        "To round complex numbers, apply tf.math.round separately to the real and "
         "imaginary components using tf.math.real() and tf.math.imag().")
   if x.dtype.is_integer:
     return x

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -975,8 +975,9 @@ def round(x, name=None):  # pylint: disable=redefined-builtin
   components:
 
   ```python
-  x = tf.constant([1.4+2.6j, 3.2+4.8j])
-  rounded = tf.complex(tf.round(tf.math.real(x)), tf.round(tf.math.imag(x)))
+  x = tf.constant([1.4 + 2.6j, 3.2 + 4.8j])
+  rounded = tf.complex(
+      tf.math.round(tf.math.real(x)), tf.math.round(tf.math.imag(x)))
   ```
 
   Args:
@@ -993,9 +994,11 @@ def round(x, name=None):  # pylint: disable=redefined-builtin
   x = ops.convert_to_tensor(x, name="x")
   if x.dtype.is_complex:
     raise TypeError(
-        f"tf.math.round does not support complex dtypes (received {x.dtype.name}). "
-        "To round complex numbers, apply tf.math.round separately to the real and "
-        "imaginary components using tf.math.real() and tf.math.imag().")
+        f"tf.math.round does not support complex dtypes (received"
+        f" {x.dtype.name}). To round complex numbers, apply tf.math.round"
+        " separately to the real and imaginary components using tf.math.real()"
+        " and tf.math.imag()."
+    )
   if x.dtype.is_integer:
     return x
   else:

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -260,6 +260,31 @@ class RoundTest(test_util.TensorFlowTestCase):
         y_np = np.round(x_np)
         self.assertAllClose(y_tf_np, y_np, atol=1e-2)
 
+  def testComplexDtypeValidation(self):
+    """Test that complex dtypes raise TypeError with helpful message."""
+    # Test complex64
+    x_complex64 = constant_op.constant([1.4+2.6j, 3.2+4.8j], dtype=dtypes.complex64)
+    with self.assertRaisesRegex(
+        TypeError,
+        r"tf\.math\.round does not support complex dtypes.*complex64.*"
+        r"apply tf\.math\.round separately"):
+      math_ops.round(x_complex64)
+
+    # Test complex128
+    x_complex128 = constant_op.constant([1.4+2.6j, 3.2+4.8j], dtype=dtypes.complex128)
+    with self.assertRaisesRegex(
+        TypeError,
+        r"tf\.math\.round does not support complex dtypes.*complex128.*"
+        r"apply tf\.math\.round separately"):
+      math_ops.round(x_complex128)
+
+  def testBFloat16Support(self):
+    """Test that bfloat16 dtype works correctly with tf.math.round."""
+    x = constant_op.constant([0.9, 2.5, 2.3, 1.5, -4.5], dtype=dtypes.bfloat16)
+    result = math_ops.round(x)
+    expected = constant_op.constant([1.0, 2.0, 2.0, 2.0, -4.0], dtype=dtypes.bfloat16)
+    self.assertAllClose(self.evaluate(result), self.evaluate(expected))
+
 
 @test_util.with_eager_op_as_function
 @test_util.run_all_in_graph_and_eager_modes

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -260,6 +260,41 @@ class RoundTest(test_util.TensorFlowTestCase):
         y_np = np.round(x_np)
         self.assertAllClose(y_tf_np, y_np, atol=1e-2)
 
+  def testComplexDtypeValidation(self):
+    """Test that complex dtypes raise TypeError with helpful message."""
+    # Test complex64
+    x_complex64 = constant_op.constant(
+        [1.4 + 2.6j, 3.2 + 4.8j], dtype=dtypes.complex64
+    )
+    with self.assertRaisesRegex(
+        TypeError,
+        r"tf\.math\.round does not support complex dtypes.*complex64.*"
+        r"apply tf\.math\.round separately",
+    ):
+      math_ops.round(x_complex64)
+
+    # Test complex128
+    x_complex128 = constant_op.constant(
+        [1.4 + 2.6j, 3.2 + 4.8j], dtype=dtypes.complex128
+    )
+    with self.assertRaisesRegex(
+        TypeError,
+        r"tf\.math\.round does not support complex dtypes.*complex128.*"
+        r"apply tf\.math\.round separately",
+    ):
+      math_ops.round(x_complex128)
+
+  def testBFloat16Support(self):
+    """Test that bfloat16 dtype works correctly with tf.math.round."""
+    x = constant_op.constant(
+        [0.9, 2.5, 2.3, 1.5, -4.5], dtype=dtypes.bfloat16
+    )
+    result = math_ops.round(x)
+    expected = constant_op.constant(
+        [1.0, 2.0, 2.0, 2.0, -4.0], dtype=dtypes.bfloat16
+    )
+    self.assertAllClose(self.evaluate(result), self.evaluate(expected))
+
 
 @test_util.with_eager_op_as_function
 @test_util.run_all_in_graph_and_eager_modes


### PR DESCRIPTION
- Add explicit TypeError for complex dtypes (complex64, complex128)
- Update docstring to document bfloat16 support and complex limitation
- Provide helpful error message with workaround using tf.math.real/imag

Fixes #65317