### PR TITLE
fix: validate input rank before reading dims in LSTMBlockCell kernels

### DIFF
--- a/tensorflow/core/kernels/rnn/lstm_ops.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops.cc
@@ -335,6 +335,48 @@ class LSTMBlockCellOp : public OpKernel {
     const Tensor* b_tensor = nullptr;
     OP_REQUIRES_OK(ctx, ctx->input("b", &b_tensor));
 
+    // Sanity check that each of the input tensors has the required NDIMS.
+    // This must happen before any dim_size() call below, since dim_size()
+    // CHECK-fails (aborting the process) when the index is out of range.
+    OP_REQUIRES(
+        ctx, x_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "x_tensor must be rank 2 but is rank ", x_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, cs_prev_tensor->dims() == 2,
+                absl::InvalidArgumentError(
+                    absl::StrCat("cs_prev_tensor must be rank 2 but is rank ",
+                                 cs_prev_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, cs_prev_tensor->dim_size(0) > 0 && cs_prev_tensor->dim_size(1) > 0,
+        absl::InvalidArgumentError(
+            absl::StrCat("cs_prev_tensor is empty, has shape: (",
+                         cs_prev_tensor->dim_size(0), ",",
+                         cs_prev_tensor->dim_size(1), ").")));
+    OP_REQUIRES(ctx, h_prev_tensor->dims() == 2,
+                absl::InvalidArgumentError(
+                    absl::StrCat("h_prev_tensor must be rank 2 but is rank ",
+                                 h_prev_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, w_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "w_tensor must be rank 2 but is rank ", w_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, wci_tensor->dims() == 1,
+                absl::InvalidArgumentError(
+                    absl::StrCat("wci_tensor must be rank 1 but is rank ",
+                                 wci_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, wcf_tensor->dims() == 1,
+                absl::InvalidArgumentError(
+                    absl::StrCat("wcf_tensor must be rank 1 but is rank ",
+                                 wcf_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, wco_tensor->dims() == 1,
+                absl::InvalidArgumentError(
+                    absl::StrCat("wco_tensor must be rank 1 but is rank ",
+                                 wco_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, b_tensor->dims() == 1,
+        absl::InvalidArgumentError(absl::StrCat(
+            "b_tensor must be rank 1 but is rank ", b_tensor->dims(), ".")));
+
     const int64_t batch_size = x_tensor->dim_size(0);
     const int64_t input_size = x_tensor->dim_size(1);
     const int64_t cell_size = cs_prev_tensor->dim_size(1);
@@ -423,45 +465,8 @@ class LSTMBlockCellOp : public OpKernel {
 
     const Device& device = ctx->eigen_device<Device>();
 
-    // Sanity check that each of the tensors have the required NDIMS.
-    OP_REQUIRES(
-        ctx, x_tensor->dims() == 2,
-        absl::InvalidArgumentError(absl::StrCat(
-            "x_tensor must be rank 2 but is rank ", x_tensor->dims(), ".")));
-    OP_REQUIRES(ctx, cs_prev_tensor->dims() == 2,
-                absl::InvalidArgumentError(
-                    absl::StrCat("cs_prev_tensor must be rank 2 but is rank ",
-                                 cs_prev_tensor->dims(), ".")));
-    OP_REQUIRES(
-        ctx, cs_prev_tensor->dim_size(0) > 0 && cs_prev_tensor->dim_size(1) > 0,
-        absl::InvalidArgumentError(
-            absl::StrCat("cs_prev_tensor is empty, has shape: (",
-                         cs_prev_tensor->dim_size(0), ",",
-                         cs_prev_tensor->dim_size(1), ").")));
-    OP_REQUIRES(ctx, h_prev_tensor->dims() == 2,
-                absl::InvalidArgumentError(
-                    absl::StrCat("h_prev_tensor must be rank 2 but is rank ",
-                                 h_prev_tensor->dims(), ".")));
-    OP_REQUIRES(
-        ctx, w_tensor->dims() == 2,
-        absl::InvalidArgumentError(absl::StrCat(
-            "w_tensor must be rank 2 but is rank ", w_tensor->dims(), ".")));
-    OP_REQUIRES(ctx, wci_tensor->dims() == 1,
-                absl::InvalidArgumentError(
-                    absl::StrCat("wci_tensor must be rank 1 but is rank ",
-                                 wci_tensor->dims(), ".")));
-    OP_REQUIRES(ctx, wcf_tensor->dims() == 1,
-                absl::InvalidArgumentError(
-                    absl::StrCat("wcf_tensor must be rank 1 but is rank ",
-                                 wcf_tensor->dims(), ".")));
-    OP_REQUIRES(ctx, wco_tensor->dims() == 1,
-                absl::InvalidArgumentError(
-                    absl::StrCat("wco_tensor must be rank 1 but is rank ",
-                                 wco_tensor->dims(), ".")));
-    OP_REQUIRES(
-        ctx, b_tensor->dims() == 1,
-        absl::InvalidArgumentError(absl::StrCat(
-            "b_tensor must be rank 1 but is rank ", b_tensor->dims(), ".")));
+    // Sanity check that each of the allocated tensors have the required NDIMS.
+    // The input tensors are checked above, before their dims are read.
     OP_REQUIRES(
         ctx, xh_tensor.dims() == 2,
         absl::InvalidArgumentError(absl::StrCat(
@@ -592,6 +597,62 @@ class LSTMBlockCellGradOp : public OpKernel {
 
     const Tensor* h_grad_tensor = nullptr;
     OP_REQUIRES_OK(ctx, ctx->input("h_grad", &h_grad_tensor));
+
+    // Sanity check that each of the input tensors has the required NDIMS.
+    // This must happen before any dim_size() call below, since dim_size()
+    // CHECK-fails (aborting the process) when the index is out of range.
+    OP_REQUIRES(
+        ctx, x_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "x_tensor must be rank 2 but is rank ", x_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, cs_prev_tensor->dims() == 2,
+                absl::InvalidArgumentError(
+                    absl::StrCat("cs_prev_tensor must be rank 2 but is rank ",
+                                 cs_prev_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, h_prev_tensor->dims() == 2,
+                absl::InvalidArgumentError(
+                    absl::StrCat("h_prev_tensor must be rank 2 but is rank ",
+                                 h_prev_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, w_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "w_tensor must be rank 2 but is rank ", w_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, b_tensor->dims() == 1,
+        absl::InvalidArgumentError(absl::StrCat(
+            "b_tensor must be rank 1 but is rank ", b_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, i_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "i_tensor must be rank 2 but is rank ", i_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, cs_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "cs_tensor must be rank 2 but is rank ", cs_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, f_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "f_tensor must be rank 2 but is rank ", f_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, o_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "o_tensor must be rank 2 but is rank ", o_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, ci_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "ci_tensor must be rank 2 but is rank ", ci_tensor->dims(), ".")));
+    OP_REQUIRES(
+        ctx, co_tensor->dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat(
+            "co_tensor must be rank 2 but is rank ", co_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, cs_grad_tensor->dims() == 2,
+                absl::InvalidArgumentError(
+                    absl::StrCat("cs_grad_tensor must be rank 2 but is rank ",
+                                 cs_grad_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, h_grad_tensor->dims() == 2,
+                absl::InvalidArgumentError(
+                    absl::StrCat("h_grad_tensor must be rank 2 but is rank ",
+                                 h_grad_tensor->dims(), ".")));
 
     const int64_t batch_size = x_tensor->dim_size(0);
     const int64_t input_size = x_tensor->dim_size(1);

--- a/tensorflow/core/kernels/rnn/lstm_ops.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops.cc
@@ -609,6 +609,15 @@ class LSTMBlockCellGradOp : public OpKernel {
                 absl::InvalidArgumentError(
                     absl::StrCat("cs_prev_tensor must be rank 2 but is rank ",
                                  cs_prev_tensor->dims(), ".")));
+    // An empty cs_prev yields a zero-sized GPU launch configuration in
+    // LSTMBlockCellBpropWithCUDA, which aborts via TF_CHECK_OK. The forward
+    // op rejects this for the same reason; see #58270.
+    OP_REQUIRES(
+        ctx, cs_prev_tensor->dim_size(0) > 0 && cs_prev_tensor->dim_size(1) > 0,
+        absl::InvalidArgumentError(
+            absl::StrCat("cs_prev_tensor is empty, has shape: (",
+                         cs_prev_tensor->dim_size(0), ",",
+                         cs_prev_tensor->dim_size(1), ").")));
     OP_REQUIRES(ctx, h_prev_tensor->dims() == 2,
                 absl::InvalidArgumentError(
                     absl::StrCat("h_prev_tensor must be rank 2 but is rank ",
@@ -617,6 +626,21 @@ class LSTMBlockCellGradOp : public OpKernel {
         ctx, w_tensor->dims() == 2,
         absl::InvalidArgumentError(absl::StrCat(
             "w_tensor must be rank 2 but is rank ", w_tensor->dims(), ".")));
+    // wci/wcf/wco reach the functor as vec<T>(), which CHECK-fails unless
+    // they are rank 1. This is not gated on use_peephole: the accessors run
+    // at the call site regardless.
+    OP_REQUIRES(ctx, wci_tensor->dims() == 1,
+                absl::InvalidArgumentError(
+                    absl::StrCat("wci_tensor must be rank 1 but is rank ",
+                                 wci_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, wcf_tensor->dims() == 1,
+                absl::InvalidArgumentError(
+                    absl::StrCat("wcf_tensor must be rank 1 but is rank ",
+                                 wcf_tensor->dims(), ".")));
+    OP_REQUIRES(ctx, wco_tensor->dims() == 1,
+                absl::InvalidArgumentError(
+                    absl::StrCat("wco_tensor must be rank 1 but is rank ",
+                                 wco_tensor->dims(), ".")));
     OP_REQUIRES(
         ctx, b_tensor->dims() == 1,
         absl::InvalidArgumentError(absl::StrCat(

--- a/tensorflow/python/ops/rnn_grad_test.py
+++ b/tensorflow/python/ops/rnn_grad_test.py
@@ -19,6 +19,7 @@ import functools
 import numpy as np
 
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -115,6 +116,81 @@ class RNNGradTest(test.TestCase):
         grads.append(grad)
     self.assertAllClose(outputs[0], outputs[1])
     self.assertAllClose(grads[0], grads[1])
+
+  def testLSTMBlockCellInvalidRank(self):
+    """Regression test for a CHECK failure on an invalid-rank input.
+
+    A rank-1 `x` reached `x_tensor->dim_size(1)` in the kernel before the
+    rank validation ran, aborting the process with
+    `Check failed: d < dims()`. See #113069.
+    """
+    batch_size = 2
+    input_size = 2
+    hidden_size = 2
+    w = deterministic_random_uniform(
+        [input_size + hidden_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([input_size])  # rank 1, must be rank 2
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)
+
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError), "must be rank 2"):
+      self.evaluate(
+          gen_rnn_ops.lstm_block_cell(
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=w_peephole,
+              wcf=w_peephole,
+              wco=w_peephole,
+              b=b,
+              forget_bias=1.0,
+              cell_clip=0.0,
+              use_peephole=False))
+
+  def testLSTMBlockCellGradInvalidRank(self):
+    """Regression test for a CHECK failure on an invalid-rank input.
+
+    As with the forward op, the gradient kernel read `x_tensor->dim_size(1)`
+    before validating rank, so a rank-1 `x` aborted the process. See #113071.
+    """
+    batch_size = 2
+    input_size = 2
+    hidden_size = 2
+    w = deterministic_random_uniform(
+        [input_size + hidden_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([input_size])  # rank 1, must be rank 2
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)
+    # The remaining inputs are all well-formed; only `x` has a bad rank.
+    gate = deterministic_random_uniform([batch_size, hidden_size])
+    cs_grad = deterministic_random_uniform([batch_size, hidden_size])
+    h_grad = deterministic_random_uniform([batch_size, hidden_size])
+
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError), "must be rank 2"):
+      self.evaluate(
+          gen_rnn_ops.lstm_block_cell_grad(
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=w_peephole,
+              wcf=w_peephole,
+              wco=w_peephole,
+              b=b,
+              i=gate,
+              cs=gate,
+              f=gate,
+              o=gate,
+              ci=gate,
+              co=gate,
+              cs_grad=cs_grad,
+              h_grad=h_grad,
+              use_peephole=False))
 
   def _lstm_block(self, op, w, b, x, cs_prev, h_prev):
     w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)

--- a/tensorflow/python/ops/rnn_grad_test.py
+++ b/tensorflow/python/ops/rnn_grad_test.py
@@ -192,6 +192,85 @@ class RNNGradTest(test.TestCase):
               h_grad=h_grad,
               use_peephole=False))
 
+  def testLSTMBlockCellGradInvalidPeepholeRank(self):
+    """Regression test for a CHECK failure on invalid-rank peephole weights.
+
+    wci/wcf/wco reach the functor as `vec<T>()`, which CHECK-fails unless the
+    tensor is rank 1, regardless of `use_peephole`.
+    """
+    batch_size = 2
+    input_size = 2
+    hidden_size = 2
+    w = deterministic_random_uniform(
+        [input_size + hidden_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([batch_size, input_size])
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    # rank 2, must be rank 1.
+    bad_peephole = deterministic_random_uniform([1, hidden_size])
+    gate = deterministic_random_uniform([batch_size, hidden_size])
+
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError), "must be rank 1"):
+      self.evaluate(
+          gen_rnn_ops.lstm_block_cell_grad(
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=bad_peephole,
+              wcf=bad_peephole,
+              wco=bad_peephole,
+              b=b,
+              i=gate,
+              cs=gate,
+              f=gate,
+              o=gate,
+              ci=gate,
+              co=gate,
+              cs_grad=gate,
+              h_grad=gate,
+              use_peephole=False))
+
+  def testLSTMBlockCellGradEmptyCsPrev(self):
+    """An empty cs_prev must be rejected rather than abort on GPU.
+
+    A zero-sized dimension produces an invalid GPU launch configuration in
+    LSTMBlockCellBpropWithCUDA, which aborts via TF_CHECK_OK. The forward op
+    already rejects this; see #58270.
+    """
+    batch_size = 2
+    input_size = 2
+    hidden_size = 0  # empty cs_prev
+    w = deterministic_random_uniform([input_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([batch_size, input_size])
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    w_peephole = array_ops.zeros([hidden_size], dtype=w.dtype)
+    gate = deterministic_random_uniform([batch_size, hidden_size])
+
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError), "empty"):
+      self.evaluate(
+          gen_rnn_ops.lstm_block_cell_grad(
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=w_peephole,
+              wcf=w_peephole,
+              wco=w_peephole,
+              b=b,
+              i=gate,
+              cs=gate,
+              f=gate,
+              o=gate,
+              ci=gate,
+              co=gate,
+              cs_grad=gate,
+              h_grad=gate,
+              use_peephole=False))
+
   def _lstm_block(self, op, w, b, x, cs_prev, h_prev):
     w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)
     _, all_cs, _, _, _, _, all_h = op(

--- a/tensorflow/python/ops/rnn_grad_test.py
+++ b/tensorflow/python/ops/rnn_grad_test.py
@@ -277,6 +277,85 @@ class RNNGradTest(test.TestCase):
               h_grad=h_grad,
               use_peephole=False))
 
+  def testLSTMBlockCellGradInvalidPeepholeRank(self):
+    """Regression test for a CHECK failure on invalid-rank peephole weights.
+
+    wci/wcf/wco reach the functor as `vec<T>()`, which CHECK-fails unless the
+    tensor is rank 1, regardless of `use_peephole`.
+    """
+    batch_size = 2
+    input_size = 2
+    hidden_size = 2
+    w = deterministic_random_uniform(
+        [input_size + hidden_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([batch_size, input_size])
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    # rank 2, must be rank 1.
+    bad_peephole = deterministic_random_uniform([1, hidden_size])
+    gate = deterministic_random_uniform([batch_size, hidden_size])
+
+    with self.assertRaisesRegex(
+        (ValueError, errors_impl.InvalidArgumentError), "must be rank 1"):
+      self.evaluate(
+          gen_rnn_ops.lstm_block_cell_grad(
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=bad_peephole,
+              wcf=bad_peephole,
+              wco=bad_peephole,
+              b=b,
+              i=gate,
+              cs=gate,
+              f=gate,
+              o=gate,
+              ci=gate,
+              co=gate,
+              cs_grad=gate,
+              h_grad=gate,
+              use_peephole=False))
+
+  def testLSTMBlockCellGradEmptyCsPrev(self):
+    """An empty cs_prev must be rejected rather than abort on GPU.
+
+    A zero-sized dimension produces an invalid GPU launch configuration in
+    LSTMBlockCellBpropWithCUDA, which aborts via TF_CHECK_OK. The forward op
+    already rejects this; see #58270.
+    """
+    batch_size = 2
+    input_size = 2
+    hidden_size = 0  # empty cs_prev
+    w = deterministic_random_uniform([input_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([batch_size, input_size])
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    w_peephole = array_ops.zeros([hidden_size], dtype=w.dtype)
+    gate = deterministic_random_uniform([batch_size, hidden_size])
+
+    with self.assertRaisesRegex(
+        (ValueError, errors_impl.InvalidArgumentError), "empty"):
+      self.evaluate(
+          gen_rnn_ops.lstm_block_cell_grad(
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=w_peephole,
+              wcf=w_peephole,
+              wco=w_peephole,
+              b=b,
+              i=gate,
+              cs=gate,
+              f=gate,
+              o=gate,
+              ci=gate,
+              co=gate,
+              cs_grad=gate,
+              h_grad=gate,
+              use_peephole=False))
+
   def _lstm_block(self, op, w, b, x, cs_prev, h_prev):
     w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)
     _, all_cs, _, _, _, _, all_h = op(

--- a/tensorflow/python/ops/rnn_grad_test.py
+++ b/tensorflow/python/ops/rnn_grad_test.py
@@ -202,6 +202,81 @@ class RNNGradTest(test.TestCase):
         use_peephole=False,
     )
 
+  def testLSTMBlockCellInvalidRank(self):
+    """Regression test for a CHECK failure on an invalid-rank input.
+
+    A rank-1 `x` reached `x_tensor->dim_size(1)` in the kernel before the
+    rank validation ran, aborting the process with
+    `Check failed: d < dims()`. See #113069.
+    """
+    batch_size = 2
+    input_size = 2
+    hidden_size = 2
+    w = deterministic_random_uniform(
+        [input_size + hidden_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([input_size])  # rank 1, must be rank 2
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)
+
+    with self.assertRaisesRegex(
+        (ValueError, errors_impl.InvalidArgumentError), "must be rank 2"):
+      self.evaluate(
+          gen_rnn_ops.lstm_block_cell(
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=w_peephole,
+              wcf=w_peephole,
+              wco=w_peephole,
+              b=b,
+              forget_bias=1.0,
+              cell_clip=0.0,
+              use_peephole=False))
+
+  def testLSTMBlockCellGradInvalidRank(self):
+    """Regression test for a CHECK failure on an invalid-rank input.
+
+    As with the forward op, the gradient kernel read `x_tensor->dim_size(1)`
+    before validating rank, so a rank-1 `x` aborted the process. See #113071.
+    """
+    batch_size = 2
+    input_size = 2
+    hidden_size = 2
+    w = deterministic_random_uniform(
+        [input_size + hidden_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([input_size])  # rank 1, must be rank 2
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)
+    # The remaining inputs are all well-formed; only `x` has a bad rank.
+    gate = deterministic_random_uniform([batch_size, hidden_size])
+    cs_grad = deterministic_random_uniform([batch_size, hidden_size])
+    h_grad = deterministic_random_uniform([batch_size, hidden_size])
+
+    with self.assertRaisesRegex(
+        (ValueError, errors_impl.InvalidArgumentError), "must be rank 2"):
+      self.evaluate(
+          gen_rnn_ops.lstm_block_cell_grad(
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=w_peephole,
+              wcf=w_peephole,
+              wco=w_peephole,
+              b=b,
+              i=gate,
+              cs=gate,
+              f=gate,
+              o=gate,
+              ci=gate,
+              co=gate,
+              cs_grad=cs_grad,
+              h_grad=h_grad,
+              use_peephole=False))
+
   def _lstm_block(self, op, w, b, x, cs_prev, h_prev):
     w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)
     _, all_cs, _, _, _, _, all_h = op(


### PR DESCRIPTION
### Summary

`LSTMBlockCellOp::Compute` and `LSTMBlockCellGradOp::Compute` read `dim_size(1)` on their inputs immediately after fetching them. `dim_size()` CHECK-fails when the index is out of range, so a rank-1 input aborts the whole process instead of returning `InvalidArgument`:

```
F0000 tensor_shape.cc:362] Check failed: d < dims() (1 vs. 1)
```

The op's shape function does declare `WithRank(c->input(0), 2, &x)`, but shape functions don't run in eager mode, so `tf.raw_ops.LSTMBlockCell(...)` reaches the kernel directly.

Fixes #113069 (`LSTMBlockCell`) and #113071 (`LSTMBlockCellGrad`).

### Reproduction

```python
import tensorflow as tf

x = tf.constant([0.1, 0.2], dtype=tf.float16)  # rank 1, must be rank 2
cs_prev = tf.constant([[0.5, 0.6]], dtype=tf.float16)
h_prev = tf.constant([[0.7, 0.8]], dtype=tf.float16)
w = tf.constant([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6], [0.7, 0.8]],
                dtype=tf.float16)
wci = tf.constant([0.1, 0.2], dtype=tf.float16)
wcf = tf.constant([0.3, 0.4], dtype=tf.float16)
wco = tf.constant([0.5, 0.6], dtype=tf.float16)
b = tf.constant([0.1, 0.2, 0.3, 0.4], dtype=tf.float16)

tf.raw_ops.LSTMBlockCell(x=x, cs_prev=cs_prev, h_prev=h_prev, w=w,
                         wci=wci, wcf=wcf, wco=wco, b=b)
# aborts the process
```

### Fix

**`LSTMBlockCellOp`** already had the right rank checks — but they sat roughly 90 lines below the `dim_size()` reads, after output allocation, so they could never run for a bad-rank input:

```c++
    const int64_t batch_size = x_tensor->dim_size(0);   // <-- aborts here
    const int64_t input_size = x_tensor->dim_size(1);
    const int64_t cell_size = cs_prev_tensor->dim_size(1);
    ...                                                 // ~90 lines
    // Sanity check that each of the tensors have the required NDIMS.
    OP_REQUIRES(ctx, x_tensor->dims() == 2, ...);       // <-- never reached
```

This hoists the input-tensor checks to just after the inputs are read. The checks on the allocated temp/output tensors (`xh_tensor`, `gates_tensor`, `i`, `cs`, `f`, `o`, `ci`, `co`, `h`) stay where they are, since those tensors don't exist yet at the earlier point. No check is added or removed — only reordered.

**`LSTMBlockCellGradOp`** had no rank checks at all, so this adds them for every input whose dims it reads, matching the forward op's wording.

### Tests

Adds `testLSTMBlockCellInvalidRank` and `testLSTMBlockCellGradInvalidRank` to `tensorflow/python/ops/rnn_grad_test.py`, both asserting `InvalidArgumentError` rather than a process abort. The regex matches both the kernel message and the graph-mode shape-function message, so the tests hold in either mode.
