### PR TITLE
fix: accumulate float16 reductions in float32

### DIFF
--- a/tensorflow/core/kernels/reduction_ops.h
+++ b/tensorflow/core/kernels/reduction_ops.h
@@ -57,8 +57,11 @@ struct ReduceEigenImpl {
   }
 };
 
-// Specialization for BF16 Reducer to fix accuracy.
-// TODO: All BF16 reducers should have specializations to fix accuracy.
+// Specializations for reduced-precision reducers to fix accuracy: without
+// these, the sum is accumulated in the (narrow) input type and loses
+// precision well before the result type does.
+// TODO: All BF16 and FP16 reducers should have specializations to fix
+// accuracy.
 #define CASTING_SPECIALIZATION(Reducer, ScalarType, IntermediateType)        \
   template <typename Device, typename OUT_T, typename IN_T,                  \
             typename ReductionAxes>                                          \
@@ -78,6 +81,7 @@ struct ReduceEigenImpl {
   };
 
 CASTING_SPECIALIZATION(Eigen::internal::SumReducer, bfloat16, float);
+CASTING_SPECIALIZATION(Eigen::internal::SumReducer, Eigen::half, float);
 #undef CASTING_SPECIALIZATION
 
 template <typename Device, typename OUT_T, typename IN_T,
@@ -121,6 +125,7 @@ CASTING_SPECIALIZATION(int8_t, int64_t);
 CASTING_SPECIALIZATION(int16_t, int64_t);
 CASTING_SPECIALIZATION(int32_t, int64_t);
 CASTING_SPECIALIZATION(bfloat16, float);
+CASTING_SPECIALIZATION(Eigen::half, float);
 #undef CASTING_SPECIALIZATION
 
 // TODO(rmlarsen): Refactor this such that taking the sqrt can be optional

--- a/tensorflow/python/kernel_tests/math_ops/reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/reduction_ops_test.py
@@ -273,6 +273,15 @@ class SumReductionTest(BaseReductionTest):
       np_arr = self._makeIncremental((2,) * rank, dtypes.bfloat16)
       self._compareAllAxes(np_arr, rtol=1e-3, atol=5.)
 
+  def testFloat16LargeValues(self):
+    # Regression test for #123299: the sum was accumulated in float16 rather
+    # than float32, so large values lost precision well before the result
+    # type did. 60000 is exactly representable in float16.
+    np_arr = np.full((3, 2), 10000.0, dtype=np.float16)
+    with self.session():
+      tf_sum = self.evaluate(math_ops.reduce_sum(constant_op.constant(np_arr)))
+    self.assertAllClose(tf_sum, 60000.0)
+
   @test_util.run_deprecated_v1
   def testFloat32(self):
     for rank in range(1, _MAX_RANK + 1):
@@ -567,6 +576,16 @@ class MeanReductionTest(BaseReductionTest):
     for rank in range(1, _MAX_RANK + 1):
       np_arr = self._makeIncremental((2,) * rank, dtypes.bfloat16)
       self._compareAllAxes(np_arr)
+
+  def testFloat16ConstantInput(self):
+    # Regression test for #123299: accumulating in float16 made the mean of a
+    # constant tensor inexact (9992 rather than 10000), which in turn made
+    # reduce_std report a nonzero spread for identical elements.
+    np_arr = np.full((3, 2), 10000.0, dtype=np.float16)
+    with self.session():
+      x = constant_op.constant(np_arr)
+      self.assertAllClose(self.evaluate(math_ops.reduce_mean(x)), 10000.0)
+      self.assertAllClose(self.evaluate(math_ops.reduce_std(x)), 0.0)
 
   @test_util.run_deprecated_v1
   def testFloat64(self):


### PR DESCRIPTION
### Summary

`reduction_ops.h` gives `bfloat16` a `float` accumulator for both `SumReducer` and `MeanReducer`, under the comment *"Specialization for BF16 Reducer to fix accuracy"*. `Eigen::half` is simply missing from both lists, so `float16` reductions still accumulate in `float16` and lose precision long before the result type does.

Fixes #123299.

### Reproduction

Verified on `tf-nightly 2.22.0-dev20260726`:

```python
import numpy as np, tensorflow as tf
x = tf.constant(np.full((3, 2), 10000.0, dtype=np.float16))

tf.reduce_sum(x)       # 5.997e+04   -- expected 60000
tf.reduce_mean(x)      # 9.99e+03    -- expected 10000
tf.math.reduce_std(x)  # 8.0         -- expected 0.0, every element is identical
```

Both 60000.0 and 10000.0 are *exactly* representable in `float16` (max is 65504), so this is purely an accumulator-width problem, not an unavoidable rounding limit. The `float32` path returns `10000.0` and `0.0`, and NumPy also returns `1e+04` / `0.0` because it likewise accumulates `float16` in `float32`.

### Fix

Two lines, mirroring what `bfloat16` already does:

```c++
CASTING_SPECIALIZATION(Eigen::internal::SumReducer, Eigen::half, float);
...
CASTING_SPECIALIZATION(Eigen::half, float);   // MeanReducer
```

I also reworded the comment above the first macro, since it now covers more than BF16.

### Tests

* `SumReductionTest.testFloat16LargeValues` — the sum of six `10000.0` elements is exactly `60000`.
* `MeanReductionTest.testFloat16ConstantInput` — the mean of a constant tensor is exact and `reduce_std` is `0`.

Both are written against the existing `testBfloat16` / `testBFloat16` neighbours. A generic `_makeIncremental` sweep would not catch this, since the values there are small enough that `float16` accumulation is already exact.

### Two things worth a reviewer's judgement

1. **Performance.** This makes CPU `float16` reductions cast to `float`, exactly as `bfloat16` already does. I assume that trade was considered acceptable when the `bfloat16` specialization landed, but `float16` may have different callers.
2. **Verification.** I could not build TensorFlow on this machine, so the *bug* is verified against nightly but the *fix* is not runtime-verified, and I have not been able to run the wider reduction test suite. Results become strictly more accurate, so tolerance-based tests should be unaffected, but that is reasoning rather than a test run.
