### PR TITLE
Validate ParallelConcat shape attr before rewriting the graph

### DIFF
--- a/tensorflow/core/common_runtime/BUILD
+++ b/tensorflow/core/common_runtime/BUILD
@@ -1567,6 +1567,7 @@ cc_library(
     deps = [
         ":optimization_registry",
         "//tensorflow/core:graph",
+        "//tensorflow/core/framework:tensor_shape",
         "//tensorflow/core/framework:tensor_shape_proto_cc",
         "//tensorflow/core/framework:types_proto_cc",
         "@com_google_absl//absl/container:inlined_vector",

--- a/tensorflow/core/common_runtime/parallel_concat_optimizer.cc
+++ b/tensorflow/core/common_runtime/parallel_concat_optimizer.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "tensorflow/core/common_runtime/optimization_registry.h"
+#include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/tensor_shape.pb.h"
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/graph/algorithm.h"
@@ -73,6 +74,11 @@ class ParallelConcatRemovePass : public GraphOptimizationPass {
       TF_RETURN_IF_ERROR(GetNodeAttr(n_attrs, "T", &dtype));
       TensorShapeProto shape;
       TF_RETURN_IF_ERROR(GetNodeAttr(n_attrs, "shape", &shape));
+      // A shape whose element count overflows int64 must be rejected here:
+      // the rewrite would otherwise materialize a TensorShape from it
+      // through code paths that CHECK-fail on overflow and abort the
+      // process.
+      TF_RETURN_IF_ERROR(TensorShape::IsValidShape(shape));
 
       // Add the start node
       Node* start;

--- a/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
@@ -96,6 +96,21 @@ class StackOpTest(test.TestCase):
     ):
       f()
 
+  def testParallelConcatShapeOverflow(self):
+    # Regression test for GitHub issue 108663: a shape whose element count
+    # overflows int64 used to abort the process with a fatal CHECK failure
+    # in the ParallelConcat rewrite pass instead of raising a catchable
+    # error. Only the eager path reaches the rewrite pass with the invalid
+    # shape; graph construction already rejects it at op-creation time.
+    if not context.executing_eagerly():
+      self.skipTest("Exercises the eager function-optimization path.")
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError, r"too large \(more than 2\*\*63 - 1"
+    ):
+      gen_array_ops.parallel_concat(
+          values=[array_ops.zeros([17, 5, 14], dtype=dtypes.int64)],
+          shape=[3037000500, 3037000500])
+
   def testSimpleParallelGPU(self):
     # tf.parallel_stack is only supported in graph mode.
     with ops.Graph().as_default():


### PR DESCRIPTION
## Summary

Fixes #108663.

`tf.raw_ops.ParallelConcat` with a `shape` attr whose element count overflows int64 aborts the process (SIGABRT) instead of raising a catchable error.

## Before (TF 2.21.0, macOS arm64, symbolized)

```
F0000 tensor_shape.cc:424] Check failed: 0 <= new_num_elements (0 vs. -9223372036709301616)
*** Check failure stack trace: ***
    @  tensorflow::TensorShapeBase<>::AddDim()
    @  tensorflow::TensorShapeBase<>::TensorShapeBase()
    @  tensorflow::(anonymous namespace)::ParallelConcatRemovePass::Run()
    @  tensorflow::OptimizationPassRegistry::RunGrouping()
    @  tensorflow::OptimizeFunctionGraph()
    @  tensorflow::ProcessFunctionLibraryRuntime::InstantiateMultiDevice()
    @  tensorflow::KernelAndDeviceFunc::Init()
    @  tensorflow::(anonymous namespace)::EagerLocalExecute()
    ...
```

The symbolized stack localizes the abort in `ParallelConcatRemovePass::Run` during eager function optimization, which materializes a concrete `TensorShape` from the attr through the CHECK-ing constructor. This confirms and completes the triage by @Ashutosh0x in the issue (their Windows wheel had no symbols, so the pass could not be pinpointed; note the crash is in the rewrite pass itself, one of the candidates their analysis had ruled out).

Only the eager path is affected. Two neighboring paths already handle this shape cleanly, which shapes the fix:
- Graph construction (e.g. inside `tf.function`) rejects it at op-creation time: `ValueError: Shape [3037000500,3037000500] is too large (more than 2**63 - 1 entries) for '{{node ParallelConcat}}' ...`
- Past the rewrite, `_ParallelConcatStart` reads the attr via `GetNodeAttr(TensorShape*)`, which validates with `TensorShape::IsValidShape` before constructing.

## Fix

Validate the shape proto with `TensorShape::IsValidShape` in the rewrite pass immediately after reading the attr, before any node is built. The pass now returns the same clean error as the other paths.

## After

```
InvalidArgumentError: Shape [3037000500,3037000500] is too large (more than 2**63 - 1 entries)
```

(The exact message is `IsValidShape`'s output, shown above surfacing on the graph path; the new eager-path regression test in `stack_op_test.py` gates it in CI. The test uses the minimal two-dimension repro from the issue thread and is eager-only by design, since graph construction never reaches the pass with an invalid shape.)

Credit to @jiren-the-gray for the report, @dhantule for confirming, and @Ashutosh0x for the elimination analysis that this PR builds on.