### PR TITLE
Validate oneDNN quantized depthwise input ranges before scalar access

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -2111,6 +2111,20 @@ class MklQuantizedConvOp
   }
 
   void Compute(OpKernelContext* context) override {
+    // The oneDNN path reads the input range with Tensor::scalar(). Validate
+    // its shape before delegating to the base implementation, which may invoke
+    // ExtendConvFwdParams and read the range while constructing a primitive.
+    const Tensor& min_input = context->input(min_input_idx_);
+    const Tensor& max_input = context->input(max_input_idx_);
+    OP_REQUIRES(
+        context, TensorShapeUtils::IsScalar(min_input.shape()),
+        absl::InvalidArgumentError(absl::StrCat(
+            "`min_input` must be rank 0 but is rank ", min_input.dims())));
+    OP_REQUIRES(
+        context, TensorShapeUtils::IsScalar(max_input.shape()),
+        absl::InvalidArgumentError(absl::StrCat(
+            "`max_input` must be rank 0 but is rank ", max_input.dims())));
+
     // Compute int32 output tensor
     MklConvOp<Device, Tinput, /*Tfilter*/ qint8, Tbias, Toutput, Ttemp_output,
               /*Tpadding*/ int32, /*bias_enabled*/ false,

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -2114,16 +2114,18 @@ class MklQuantizedConvOp
     // The oneDNN path reads the input range with Tensor::scalar(). Validate
     // its shape before delegating to the base implementation, which may invoke
     // ExtendConvFwdParams and read the range while constructing a primitive.
-    const Tensor& min_input = context->input(min_input_idx_);
-    const Tensor& max_input = context->input(max_input_idx_);
+    const Tensor& min_input_tensor = context->input(min_input_idx_);
+    const Tensor& max_input_tensor = context->input(max_input_idx_);
     OP_REQUIRES(
-        context, TensorShapeUtils::IsScalar(min_input.shape()),
+        context, TensorShapeUtils::IsScalar(min_input_tensor.shape()),
         absl::InvalidArgumentError(absl::StrCat(
-            "`min_input` must be rank 0 but is rank ", min_input.dims())));
+            "`min_input` must be rank 0 but is rank ",
+            min_input_tensor.dims())));
     OP_REQUIRES(
-        context, TensorShapeUtils::IsScalar(max_input.shape()),
+        context, TensorShapeUtils::IsScalar(max_input_tensor.shape()),
         absl::InvalidArgumentError(absl::StrCat(
-            "`max_input` must be rank 0 but is rank ", max_input.dims())));
+            "`max_input` must be rank 0 but is rank ",
+            max_input_tensor.dims())));
 
     // Compute int32 output tensor
     MklConvOp<Device, Tinput, /*Tfilter*/ qint8, Tbias, Toutput, Ttemp_output,

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
@@ -656,6 +656,39 @@ TEST_F(QuantizedConv2DTest, DepthwiseConv2DWithBiasNewAPI) {
   TestDepthwiseConv2DWithBias(false);
 }
 
+TEST_F(QuantizedConv2DTest,
+       DepthwiseConv2DWithBiasRejectsNonScalarInputRanges) {
+  TF_ASSERT_OK(NodeDefBuilder("quantized_depthwise_conv_op",
+                              "_MklQuantizedDepthwiseConv2DWithBias")
+                   .Input(FakeInput(DT_QUINT8))
+                   .Input(FakeInput(DT_QINT8))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("Tinput", DataTypeToEnum<quint8>::v())
+                   .Attr("Tfilter", DataTypeToEnum<qint8>::v())
+                   .Attr("out_type", DataTypeToEnum<qint32>::v())
+                   .Attr("strides", {1, 1, 1, 1})
+                   .Attr("padding", "SAME")
+                   .Attr("_kernel", "QuantizedMklOp")
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  AddInputFromArray<quint8>(TensorShape({1, 2, 2, 1}), {1, 2, 3, 4});
+  AddInputFromArray<qint8>(TensorShape({2, 2, 1, 1}), {1, 2, 3, 4});
+  AddInputFromArray<float>(TensorShape({1}), {0.5f});
+  AddInputFromArray<float>(TensorShape({2}), {0.0f, 0.0f});
+  AddInputFromArray<float>(TensorShape({2}), {5.0f, 5.0f});
+  AddInputFromArray<float>(TensorShape({}), {-127.0f});
+  AddInputFromArray<float>(TensorShape({}), {127.0f});
+
+  const Status status = RunOpKernel();
+  EXPECT_EQ(status.code(), error::INVALID_ARGUMENT);
+  EXPECT_THAT(status.message(), HasSubstr("`min_input` must be rank 0"));
+}
+
 TEST_F(QuantizedConv2DTest, DepthwiseConv2DWithBiasAndReluOldAPI) {
   TestDepthwiseConv2DWithBiasAndRelu(true);
 }

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
@@ -686,7 +686,7 @@ TEST_F(QuantizedConv2DTest,
 
   const Status status = RunOpKernel();
   EXPECT_EQ(status.code(), error::INVALID_ARGUMENT);
-  EXPECT_THAT(status.message(), HasSubstr("`min_input` must be rank 0"));
+  EXPECT_THAT(status.message(), testing::HasSubstr("`min_input` must be rank 0"));
 }
 
 TEST_F(QuantizedConv2DTest, DepthwiseConv2DWithBiasAndReluOldAPI) {

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
@@ -657,7 +657,7 @@ TEST_F(QuantizedConv2DTest, DepthwiseConv2DWithBiasNewAPI) {
 }
 
 TEST_F(QuantizedConv2DTest,
-       DepthwiseConv2DWithBiasRejectsNonScalarInputRanges) {
+       DepthwiseConv2DWithBiasRejectsNonScalarMinInputRange) {
   TF_ASSERT_OK(NodeDefBuilder("quantized_depthwise_conv_op",
                               "_MklQuantizedDepthwiseConv2DWithBias")
                    .Input(FakeInput(DT_QUINT8))
@@ -680,14 +680,48 @@ TEST_F(QuantizedConv2DTest,
   AddInputFromArray<qint8>(TensorShape({2, 2, 1, 1}), {1, 2, 3, 4});
   AddInputFromArray<float>(TensorShape({1}), {0.5f});
   AddInputFromArray<float>(TensorShape({2}), {0.0f, 0.0f});
+  AddInputFromArray<float>(TensorShape({}), {5.0f});
+  AddInputFromArray<float>(TensorShape({}), {-127.0f});
+  AddInputFromArray<float>(TensorShape({}), {127.0f});
+
+  const absl::Status status = RunOpKernel();
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(status.message(),
+              ::testing::HasSubstr("`min_input` must be rank 0"));
+}
+
+TEST_F(QuantizedConv2DTest,
+       DepthwiseConv2DWithBiasRejectsNonScalarMaxInputRange) {
+  TF_ASSERT_OK(NodeDefBuilder("quantized_depthwise_conv_op",
+                              "_MklQuantizedDepthwiseConv2DWithBias")
+                   .Input(FakeInput(DT_QUINT8))
+                   .Input(FakeInput(DT_QINT8))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("Tinput", DataTypeToEnum<quint8>::v())
+                   .Attr("Tfilter", DataTypeToEnum<qint8>::v())
+                   .Attr("out_type", DataTypeToEnum<qint32>::v())
+                   .Attr("strides", {1, 1, 1, 1})
+                   .Attr("padding", "SAME")
+                   .Attr("_kernel", "QuantizedMklOp")
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  AddInputFromArray<quint8>(TensorShape({1, 2, 2, 1}), {1, 2, 3, 4});
+  AddInputFromArray<qint8>(TensorShape({2, 2, 1, 1}), {1, 2, 3, 4});
+  AddInputFromArray<float>(TensorShape({1}), {0.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
   AddInputFromArray<float>(TensorShape({2}), {5.0f, 5.0f});
   AddInputFromArray<float>(TensorShape({}), {-127.0f});
   AddInputFromArray<float>(TensorShape({}), {127.0f});
 
-  const Status status = RunOpKernel();
-  EXPECT_EQ(status.code(), error::INVALID_ARGUMENT);
+  const absl::Status status = RunOpKernel();
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_THAT(status.message(),
-              ::testing::HasSubstr("`min_input` must be rank 0"));
+              ::testing::HasSubstr("`max_input` must be rank 0"));
 }
 
 TEST_F(QuantizedConv2DTest, DepthwiseConv2DWithBiasAndReluOldAPI) {

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
@@ -686,7 +686,8 @@ TEST_F(QuantizedConv2DTest,
 
   const Status status = RunOpKernel();
   EXPECT_EQ(status.code(), error::INVALID_ARGUMENT);
-  EXPECT_THAT(status.message(), testing::HasSubstr("`min_input` must be rank 0"));
+  EXPECT_THAT(status.message(),
+              ::testing::HasSubstr("`min_input` must be rank 0"));
 }
 
 TEST_F(QuantizedConv2DTest, DepthwiseConv2DWithBiasAndReluOldAPI) {


### PR DESCRIPTION
Fixes #112525

Supersedes #123149.

The oneDNN quantized depthwise-convolution kernel reads `min_input` and `max_input` through `Tensor::scalar()` before validating their ranks. A non-scalar range could therefore reach unsafe scalar access.

Validate both input ranges as rank-0 tensors before delegating to the base oneDNN convolution implementation, and add a regression test for `QuantizedDepthwiseConv2DWithBias` that verifies non-scalar ranges fail with `INVALID_ARGUMENT`.

This revision also fixes the x86 CI compilation failures from #123149 by avoiding collisions with the existing scalar range variables and resolving the GoogleTest matcher from the global namespace.

## Testing
- `git diff --check`
- previous CI build-only validation passed on ARM64; refreshed x86 CI is pending on this PR