### PR TITLE
Fix TFLite FuseMulAndFullyConnected on shape-expanding Mul

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -610,6 +610,26 @@ func.func @fuseMulIntoFollowingFullyConnected(%arg0: tensor<4x2xf32>) -> tensor<
 // CHECK-NEXT: return %[[fc]] : tensor<4x2xf32>
 }
 
+// CHECK-LABEL: @DontFuseExpandingMulIntoFollowingFullyConnected
+// Regression test for https://github.com/tensorflow/tensorflow/issues/124103:
+// Mul that expands the feature dim (e.g. [...,1]*[K] -> [...,K]) must not be
+// folded into a following FullyConnected filter.
+func.func @DontFuseExpandingMulIntoFollowingFullyConnected(%arg0: tensor<4x4x1xf32>) -> tensor<4x4x4xf32> {
+  %scale = arith.constant dense<[3.0, 4.0]> : tensor<2xf32>
+  %0 = "tfl.mul"(%arg0, %scale) {fused_activation_function = "NONE"} : (tensor<4x4x1xf32>, tensor<2xf32>) -> tensor<4x4x2xf32>
+  %filter = arith.constant dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]> : tensor<4x2xf32>
+  %bias = "tfl.no_value"() {value} : () -> none
+  %1 = "tfl.fully_connected"(%0, %filter, %bias) {fused_activation_function = "NONE", keep_num_dims = true, weights_format = "DEFAULT"} : (tensor<4x4x2xf32>, tensor<4x2xf32>, none) -> tensor<4x4x4xf32>
+  func.return %1 : tensor<4x4x4xf32>
+
+// CHECK-DAG: %[[SCALE:.*]] = arith.constant dense<[3.000000e+00, 4.000000e+00]> : tensor<2xf32>
+// CHECK-DAG: %[[MUL:.*]] = "tfl.mul"(%arg0, %[[SCALE]])
+// CHECK-DAG: %[[FILTER:.*]] = arith.constant dense<{{\[}}[1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00]]> : tensor<4x2xf32>
+// CHECK-DAG: %[[BIAS:.*]] = "tfl.no_value"()
+// CHECK: %[[FC:.*]] = "tfl.fully_connected"(%[[MUL]], %[[FILTER]], %[[BIAS]])
+// CHECK: return %[[FC]]
+}
+
 // CHECK-LABEL: @DontFuseRhsNonConstMulIntoFollowingFullyConnected
 func.func @DontFuseRhsNonConstMulIntoFollowingFullyConnected(%arg0: tensor<4x2xf32>, %arg1: tensor<2xf32>) -> tensor<4x2xf32> {
   %mul = "tfl.mul"(%arg0, %arg1) <{fused_activation_function = "NONE"}> : (tensor<4x2xf32>, tensor<2xf32>) -> tensor<4x2xf32>

--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -623,7 +623,7 @@ func.func @DontFuseExpandingMulIntoFollowingFullyConnected(%arg0: tensor<4x4x1xf
   func.return %1 : tensor<4x4x4xf32>
 
 // CHECK-DAG: %[[SCALE:.*]] = arith.constant dense<[3.000000e+00, 4.000000e+00]> : tensor<2xf32>
-// CHECK-DAG: %[[MUL:.*]] = "tfl.mul"(%arg0, %[[SCALE]])
+// CHECK-DAG: %[[MUL:.*]] = tfl.mul(%arg0, %[[SCALE]])
 // CHECK-DAG: %[[FILTER:.*]] = arith.constant dense<{{\[}}[1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00]]> : tensor<4x2xf32>
 // CHECK-DAG: %[[BIAS:.*]] = "tfl.no_value"()
 // CHECK: %[[FC:.*]] = "tfl.fully_connected"(%[[MUL]], %[[FILTER]], %[[BIAS]])

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
@@ -1690,6 +1690,17 @@ struct FuseMulAndFullyConnected
       if (multiplier_shape.getShape().size() != 1) return failure();
     }
 
+    // FC(Mul(x, s), W) -> FC(x, Mul(W, s)) is only valid when Mul does not
+    // change the shape of x. Expanding broadcasts (e.g. [..., 1] * [K] ->
+    // [..., K]) change the FC input feature size; folding the scale into W
+    // while feeding the original x produces an invalid graph
+    // (tensorflow/tensorflow#124103).
+    if (mul_op.getLhs().getType() != mul_op.getType()) {
+      return rewriter.notifyMatchFailure(
+          fc_op,
+          "Mul changes LHS shape; cannot fold into FullyConnected filter");
+    }
+
     // We rely on constant folding, implemented only for F32. Check types.
     if (!IsF32Value(mul_op.getRhs()) || !IsF32Value(fc_op.getFilter())) {
       return failure();


### PR DESCRIPTION
Fixes #124103

### Description

Chained MatMuls can fail TFLite conversion with an invalid `tfl.mul` (`4x4x4` vs broadcast `4x4x8`). Eager is fine; `_experimental_disable_fuse_mul_and_fc=True` also converts, pointing at `FuseMulAndFullyConnected`.

That pattern rewrites `FC(Mul(x, s), W)` into `FC(x, Mul(W, s))`, which is invalid when Mul expands `x` (e.g. `[...,1]*[K] -> [...,K]`). The reverse fusion already rejected shape-changing Muls; this one did not.

### Solution

Skip `FuseMulAndFullyConnected` when Mul's result type differs from its LHS.

### Changes

- `optimize_pass.cc` — shape guard
- `optimize.mlir` — `@DontFuseExpandingMulIntoFollowingFullyConnected`

### Test plan

- [ ] New optimize.mlir regression test
- [ ] Existing same-shape fuse cases still apply
- [ ] Issue #124103 repro converts after the fix