### PR TITLE
Omit RTLD_GLOBAL helper from shared TensorFlow wheels

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -664,11 +664,25 @@ py_library(
     name = "pywrap_tensorflow",
     srcs = [
         "pywrap_tensorflow.py",
-    ] + if_static(
-        ["pywrap_dlopen_global_flags.py"],
-        # Import will fail, indicating no global dlopen flags
-        otherwise = [],
-    ),  # b/153585257
+    ] + select({
+        # Shared-object builds (default pip wheels: framework_shared_object=true)
+        # must NOT ship pywrap_dlopen_global_flags.py. That module forces
+        # RTLD_GLOBAL when loading _pywrap_tensorflow_internal, which leaks
+        # TF's statically linked LLVM/MLIR into the process global symbol
+        # table and can SIGSEGV later imports that ship their own LLVM
+        # (notably triton>=3.7). See tensorflow/tensorflow#124205 and the
+        # historical modular-op design in 5c7f9e31.
+        #
+        # Do not use if_static() here: under USE_PYWRAP_RULES=True it always
+        # takes the static branch (b/356020232), which reintroduced this file
+        # into shared wheels starting in TF 2.20 despite
+        # framework_shared_object still being true.
+        #
+        # Monolithic builds (--config=monolithic, framework_shared_object
+        # unset/false) still need RTLD_GLOBAL for custom-op symbol lookup.
+        "//tensorflow:framework_shared_object": [],
+        "//conditions:default": ["pywrap_dlopen_global_flags.py"],
+    }),
     strict_deps = True,
     visibility = ["//visibility:public"],
     deps = [

--- a/tensorflow/python/pywrap_dlopen_global_flags.py
+++ b/tensorflow/python/pywrap_dlopen_global_flags.py
@@ -14,11 +14,16 @@
 # =============================================================================
 """If possible, exports all symbols with RTLD_GLOBAL.
 
-Note that this file is only imported by pywrap_tensorflow.py if this is a static
-build (meaning there is no explicit framework cc_binary shared object dependency
-of _pywrap_tensorflow_internal.so). For regular (non-static) builds, RTLD_GLOBAL
-is not necessary, since the dynamic dependencies of custom/contrib ops are
-explicit.
+This module is packaged only for monolithic builds (framework_shared_object
+unset/false, e.g. --config=monolithic). Shared-object builds (default pip
+wheels) omit it on purpose so pywrap_tensorflow.py hits ImportError and loads
+with RTLD_LOCAL instead.
+
+RTLD_GLOBAL is required for monolithic Python loads so custom op shared objects
+can resolve TF symbols from the global table. It must NOT be used for shared
+wheels: TF links LLVM/MLIR, and leaking those symbols globally causes ABI
+clashes (SIGSEGV) when a later import (e.g. triton) brings its own LLVM. See
+tensorflow/tensorflow#124205.
 """
 
 import ctypes

--- a/tensorflow/python/pywrap_tensorflow.py
+++ b/tensorflow/python/pywrap_tensorflow.py
@@ -40,10 +40,8 @@ self_check.preload_check()
 # pylint: disable=wildcard-import,g-import-not-at-top,unused-import,line-too-long
 
 try:
-  # Shared-object wheels omit this module (see :pywrap_tensorflow BUILD select
-  # on //tensorflow:framework_shared_object). ImportError => RTLD_LOCAL, which
-  # is required so TF does not leak LLVM into the process global symbol table.
-  # Monolithic builds ship the module and load with RTLD_GLOBAL for custom ops.
+  # This import is expected to fail if there is an explicit shared object
+  # dependency (with_framework_lib=true), since we do not need RTLD_GLOBAL.
   from tensorflow.python import pywrap_dlopen_global_flags
   _use_dlopen_global_flags = True
 except ImportError:

--- a/tensorflow/python/pywrap_tensorflow.py
+++ b/tensorflow/python/pywrap_tensorflow.py
@@ -40,8 +40,10 @@ self_check.preload_check()
 # pylint: disable=wildcard-import,g-import-not-at-top,unused-import,line-too-long
 
 try:
-  # This import is expected to fail if there is an explicit shared object
-  # dependency (with_framework_lib=true), since we do not need RTLD_GLOBAL.
+  # Shared-object wheels omit this module (see :pywrap_tensorflow BUILD select
+  # on //tensorflow:framework_shared_object). ImportError => RTLD_LOCAL, which
+  # is required so TF does not leak LLVM into the process global symbol table.
+  # Monolithic builds ship the module and load with RTLD_GLOBAL for custom ops.
   from tensorflow.python import pywrap_dlopen_global_flags
   _use_dlopen_global_flags = True
 except ImportError:


### PR DESCRIPTION
Fixes #124205

### Description

Since TF 2.20, shared pip wheels ship `pywrap_dlopen_global_flags.py`, so Python loads `_pywrap_tensorflow_internal` with `RTLD_GLOBAL`. That leaks TF's LLVM/MLIR into the process global symbol table and can SIGSEGV a later `import triton` (>=3.7) on Linux.
Root cause: `if_static()` always takes the static branch under `USE_PYWRAP_RULES=True`, so the helper was packaged even though wheels still use `framework_shared_object=true`.

### Solution

Gate packaging of `pywrap_dlopen_global_flags.py` on `//tensorflow:framework_shared_object` instead of `if_static()`:
- shared wheels (`framework_shared_object=true`): omit file -> RTLD_LOCAL
- monolithic (`--config=monolithic`): keep file -> RTLD_GLOBAL for custom ops

### Changes

- `tensorflow/python/BUILD` — select-based packaging
- `tensorflow/python/pywrap_dlopen_global_flags.py` — docstring
- `tensorflow/python/pywrap_tensorflow.py` — import comment

### Test plan

- [ ] Shared wheel does not contain `pywrap_dlopen_global_flags.py`
- [ ] `import tensorflow; import triton` succeeds on Linux (triton >= 3.7)
- [ ] Monolithic build still packages the helper for RTLD_GLOBAL