### PR TITLE
Validate resource variable dtypes in training ops

### DIFF
--- a/tensorflow/core/kernels/training_op_helpers.h
+++ b/tensorflow/core/kernels/training_op_helpers.h
@@ -33,6 +33,7 @@ limitations under the License.
 #include "tensorflow/core/framework/variant_op_registry.h"
 #include "tensorflow/core/kernels/dense_update_functor.h"
 #include "tensorflow/core/kernels/variable_ops.h"
+#include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/refcount.h"
 #include "tsl/platform/mutex.h"
 
@@ -46,9 +47,10 @@ namespace tensorflow {
 // @param lock_held  Whether the variable mutex was already held or not
 // NOTE: This function uses variable's `copy_on_read_mode` flag to decide if
 // it should immediately return or continue to lock the variable mutex for more
-// processing, and always sets the `copy_on_read_mode` flag to true when this
-// function returns. However, there is no guarantee that another op won't set
-// the `copy_on_read_mode` flag back to false after this function.
+// processing. Except for invalid dtype combinations, it always sets the
+// `copy_on_read_mode` flag to true when this function returns. However, there
+// is no guarantee that another op won't set the `copy_on_read_mode` flag back
+// to false after this function.
 // Therefore, for the operation that requires `copy_on_read` to stay true during
 // its execution, the caller needs to lock the variable mutex outside and call
 // this function with `lock_held = true` to avoid double locking.
@@ -65,6 +67,14 @@ absl::Status EnsureSparseVariableAccess(OpKernelContext* ctx, Var* var) {
   // enters this critical section will set the `copy_on_read_mode` flag to true.
   // All other threads can then exit this critical section immediately.
   if (var->copy_on_read_mode.load()) {
+    return absl::OkStatus();
+  }
+
+  // A resource variable with a different dtype is rejected later by
+  // GetInputTensorFromVariable. Avoid typed access here so the mismatch can be
+  // reported as a recoverable error instead of triggering Tensor's CHECK.
+  if (var->tensor()->IsInitialized() &&
+      var->tensor()->dtype() != DataTypeToEnum<T>::v()) {
     return absl::OkStatus();
   }
 
@@ -287,10 +297,20 @@ absl::Status GetInputTensorFromVariable(OpKernelContext* ctx, int input,
     TF_RETURN_IF_ERROR(LookupResource(ctx, handle, &var));
     if (sparse) {
       var->mu()->assert_held_shared();
+    } else {
+      var->mu()->assert_held();
+    }
+    if (var->tensor()->IsInitialized() &&
+        var->tensor()->dtype() != DataTypeToEnum<T>::v()) {
+      return errors::InvalidArgument(
+          "Resource variable at input ", input, " has type ",
+          DataTypeString(var->tensor()->dtype()), " but expected type ",
+          DataTypeString(DataTypeToEnum<T>::v()));
+    }
+    if (sparse) {
       *out = *var->tensor();
       return absl::OkStatus();
     }
-    var->mu()->assert_held();
     TF_RETURN_IF_ERROR(PrepareToUpdateVariable<Device, T>(
         ctx, var->tensor(), var->copy_on_read_mode.load()));
     *out = *var->tensor();

--- a/tensorflow/python/training/training_ops_test.py
+++ b/tensorflow/python/training/training_ops_test.py
@@ -458,6 +458,21 @@ class TrainingOpsTest(TensorFlowTestCase):
     return param_t, m_t, v_t
 
   @test_util.run_v2_only
+  def testResourceSparseApplyAdagradRejectsVariableDtypeMismatch(self):
+    var = variables.Variable(np.zeros((3, 3), dtype=np.float64))
+    accum = variables.Variable(np.zeros((3, 3), dtype=np.float64))
+    self.evaluate(variables.global_variables_initializer())
+
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError, "has type double but expected type float"):
+      self.evaluate(gen_training_ops.resource_sparse_apply_adagrad(
+          var.handle,
+          accum.handle,
+          constant_op.constant(0.1, dtype=dtypes.float32),
+          constant_op.constant(np.ones((3, 3)), dtype=dtypes.float32),
+          constant_op.constant([0, 1, 2], dtype=dtypes.int32)))
+
+  @test_util.run_v2_only
   def testResourceSparseApplyAdagradV2AndDisableCopyOnReadRace(self):
     dtype = np.float32
     index_type = np.int32


### PR DESCRIPTION
## Summary

- validate initialized resource variable dtypes before typed training-op access
- return a recoverable `InvalidArgumentError` instead of triggering a fatal tensor dtype check
- add CPU regression coverage for `ResourceSparseApplyAdagrad`

Fixes #113145.

## Testing

- reproduced the pre-fix failure with TensorFlow 2.21.0 (`SIGABRT`, `float expected, got double`)
- Python syntax and test discovery check
- `git diff --check`
- independent source-path review

The filtered Bazel target was attempted locally, but the test did not execute because the available Apple Command Line Tools could not provide the `macosx10.11` SDK requested by the Bazel Apple toolchain. TensorFlow CI is expected to provide the full build validation.
