### PR TITLE
bound string buffer byteswap by buffer_size in ByteSwapBuffer

### DIFF
--- a/tensorflow/compiler/mlir/lite/core/model_builder_base.h
+++ b/tensorflow/compiler/mlir/lite/core/model_builder_base.h
@@ -220,10 +220,20 @@ class FlatBufferModelBase {
                              uint8_t* buffer, bool from_big_endian) {
     switch (tensor_type) {
       case tflite::TensorType_STRING: {
+        // A string buffer starts with an int32 count followed by (count + 1)
+        // int32 offsets, all of which need swapping. The count is read from the
+        // untrusted buffer, so cap the number of int32 words to what the buffer
+        // actually holds to avoid reading or writing past its end.
+        const size_t max_words = buffer_size / sizeof(int32_t);
+        if (max_words == 0) break;
         auto bp = reinterpret_cast<int32_t*>(buffer);
         int num_of_strings =
             from_big_endian ? bp[0] : flatbuffers::EndianSwap(bp[0]);
-        for (int i = 0; i < num_of_strings + 2; i++)
+        size_t words =
+            num_of_strings < 0
+                ? max_words
+                : std::min(static_cast<size_t>(num_of_strings) + 2, max_words);
+        for (size_t i = 0; i < words; i++)
           bp[i] = flatbuffers::EndianSwap(bp[i]);
         break;
       }

--- a/tensorflow/compiler/mlir/lite/core/model_builder_base.h
+++ b/tensorflow/compiler/mlir/lite/core/model_builder_base.h
@@ -218,6 +218,7 @@ class FlatBufferModelBase {
 
   static void ByteSwapBuffer(int8_t tensor_type, size_t buffer_size,
                              uint8_t* buffer, bool from_big_endian) {
+    if (buffer == nullptr) return;
     switch (tensor_type) {
       case tflite::TensorType_STRING: {
         // A string buffer starts with an int32 count followed by (count + 1)

--- a/tensorflow/compiler/mlir/lite/core/model_builder_base.h
+++ b/tensorflow/compiler/mlir/lite/core/model_builder_base.h
@@ -229,9 +229,12 @@ class FlatBufferModelBase {
         auto bp = reinterpret_cast<int32_t*>(buffer);
         int num_of_strings =
             from_big_endian ? bp[0] : flatbuffers::EndianSwap(bp[0]);
+        // A negative count is invalid; swap only the count word itself rather
+        // than the whole buffer, which would waste work and corrupt the string
+        // character data that follows the offset table.
         size_t words =
             num_of_strings < 0
-                ? max_words
+                ? 1
                 : std::min(static_cast<size_t>(num_of_strings) + 2, max_words);
         for (size_t i = 0; i < words; i++)
           bp[i] = flatbuffers::EndianSwap(bp[i]);

--- a/tensorflow/lite/core/model_test.cc
+++ b/tensorflow/lite/core/model_test.cc
@@ -977,6 +977,23 @@ TEST(BasicFlatBufferModel, ByteSwapStringBufferRespectsBufferSize) {
   EXPECT_EQ(storage[2], 0x12345678);
   EXPECT_EQ(storage[3], 0x23456789);
 }
+
+// A negative leading count is invalid. ByteSwapBuffer must swap only the count
+// word rather than treating it as a large unsigned length and running over the
+// whole buffer, which would corrupt the string character data.
+TEST(BasicFlatBufferModel, ByteSwapStringBufferHandlesNegativeCount) {
+  // storage[0] is the count (-1); the remaining words stand in for offset and
+  // character data that must remain untouched.
+  std::vector<int32_t> storage = {-1, 0x12345678, 0x23456789, 0x3456789a};
+  const size_t buffer_size = storage.size() * sizeof(int32_t);
+  FlatBufferModel::ByteSwapBuffer(
+      static_cast<int8_t>(TensorType_STRING), buffer_size,
+      reinterpret_cast<uint8_t*>(storage.data()), /*from_big_endian=*/true);
+  EXPECT_EQ(storage[0], flatbuffers::EndianSwap<int32_t>(-1));
+  EXPECT_EQ(storage[1], 0x12345678);
+  EXPECT_EQ(storage[2], 0x23456789);
+  EXPECT_EQ(storage[3], 0x3456789a);
+}
 #endif
 
 }  // namespace tflite

--- a/tensorflow/lite/core/model_test.cc
+++ b/tensorflow/lite/core/model_test.cc
@@ -994,6 +994,18 @@ TEST(BasicFlatBufferModel, ByteSwapStringBufferHandlesNegativeCount) {
   EXPECT_EQ(storage[2], 0x23456789);
   EXPECT_EQ(storage[3], 0x3456789a);
 }
+
+// A buffer smaller than a single int32 word cannot even hold the string count.
+// ByteSwapBuffer must break out before dereferencing bp[0] and leave it as is.
+TEST(BasicFlatBufferModel, ByteSwapStringBufferTooSmall) {
+  std::vector<uint8_t> storage = {0x01, 0x02};
+  const size_t buffer_size = storage.size();
+  FlatBufferModel::ByteSwapBuffer(
+      static_cast<int8_t>(TensorType_STRING), buffer_size, storage.data(),
+      /*from_big_endian=*/true);
+  EXPECT_EQ(storage[0], 0x01);
+  EXPECT_EQ(storage[1], 0x02);
+}
 #endif
 
 }  // namespace tflite

--- a/tensorflow/lite/core/model_test.cc
+++ b/tensorflow/lite/core/model_test.cc
@@ -962,4 +962,21 @@ TEST(BasicFlatBufferModel, TestHandleZeroSizeConstant) {
 // These tests will occur with the evaluation tests of individual operators,
 // not here.
 
+#if FLATBUFFERS_LITTLEENDIAN == 0
+// A string tensor buffer records the string count in its leading int32 word.
+// When that (untrusted) count implies more offset words than the buffer holds,
+// ByteSwapBuffer must not swap past the end of the buffer.
+TEST(BasicFlatBufferModel, ByteSwapStringBufferRespectsBufferSize) {
+  // Only the first two words belong to the tensor buffer; the last two are
+  // guards that must remain untouched.
+  std::vector<int32_t> storage = {2, 0x11111111, 0x12345678, 0x23456789};
+  const size_t buffer_size = 2 * sizeof(int32_t);
+  FlatBufferModel::ByteSwapBuffer(
+      static_cast<int8_t>(TensorType_STRING), buffer_size,
+      reinterpret_cast<uint8_t*>(storage.data()), /*from_big_endian=*/true);
+  EXPECT_EQ(storage[2], 0x12345678);
+  EXPECT_EQ(storage[3], 0x23456789);
+}
+#endif
+
 }  // namespace tflite


### PR DESCRIPTION
The TensorType_STRING case in ByteSwapBuffer reads the string count from the first int32 of the buffer and swaps num_of_strings + 2 words, ignoring buffer_size, so a crafted TFLite model whose string tensor declares a count larger than its buffer overruns that buffer when loaded on a big-endian host. It is reachable from untrusted model data via the non-verifying BuildFromBuffer/BuildFromFile paths, which run ByteConvertModel without tflite::VerifyModelBuffer. Cap the number of int32 words to buffer_size / sizeof(int32_t), matching the other dtype cases, and skip buffers too small to hold the count.