### PR TITLE
Fix issue #17076: Add Python code examples for report_tensor_allocations_upon_oom and RunOptions

### DIFF
--- a/tensorflow/core/protobuf/config.proto
+++ b/tensorflow/core/protobuf/config.proto
@@ -837,7 +837,7 @@ message RunOptions {
   //
   // Example usage in Python:
   //   run_options = tf.compat.v1.RunOptions(timeout_in_ms=5000)
-  //   output = sess.run(fetches, options=run_options)
+  //   output = session.run(fetches, options=run_options)
   int64 timeout_in_ms = 2;
 
   // The thread pool to use, if session_inter_op_thread_pool is configured.
@@ -864,7 +864,7 @@ message RunOptions {
   // Example usage in Python:
   //   run_options = tf.compat.v1.RunOptions(
   //       report_tensor_allocations_upon_oom=True)
-  //   output = sess.run(fetches, options=run_options)
+  //   output = session.run(fetches, options=run_options)
   bool report_tensor_allocations_upon_oom = 7;
 
   // Everything inside Experimental is subject to change and is not subject

--- a/tensorflow/core/protobuf/config.proto
+++ b/tensorflow/core/protobuf/config.proto
@@ -834,6 +834,10 @@ message RunOptions {
   TraceLevel trace_level = 1;
 
   // Time to wait for operation to complete in milliseconds.
+  //
+  // Example usage in Python:
+  //   run_options = tf.compat.v1.RunOptions(timeout_in_ms=5000)
+  //   output = sess.run(fetches, options=run_options)
   int64 timeout_in_ms = 2;
 
   // The thread pool to use, if session_inter_op_thread_pool is configured.
@@ -856,6 +860,11 @@ message RunOptions {
   // out of memory (OOM).
   //
   // Enabling this option can slow down the Run() call.
+  //
+  // Example usage in Python:
+  //   run_options = tf.compat.v1.RunOptions(
+  //       report_tensor_allocations_upon_oom=True)
+  //   output = sess.run(fetches, options=run_options)
   bool report_tensor_allocations_upon_oom = 7;
 
   // Everything inside Experimental is subject to change and is not subject

--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -939,7 +939,32 @@ class BaseSession(SessionInterface):
 
     The optional `options` argument expects a [`RunOptions`] proto. The options
     allow controlling the behavior of this particular step (e.g. turning tracing
-    on).
+    on, setting step execution timeouts, or enabling detailed OOM allocation
+    reporting via `report_tensor_allocations_upon_oom`).
+
+    For example, to report detailed tensor allocation information if an out-of-memory
+    (OOM) error occurs during execution (note: this option is supported in
+    Graph mode / `tf.compat.v1.Session` and not in Eager mode):
+
+    ```python
+    run_options = tf.compat.v1.RunOptions(
+        report_tensor_allocations_upon_oom=True)
+    output = sess.run(fetches, feed_dict=feed_dict, options=run_options)
+    ```
+
+    To enable execution tracing and set a step execution timeout:
+
+    ```python
+    run_options = tf.compat.v1.RunOptions(
+        trace_level=tf.compat.v1.RunOptions.FULL_TRACE,
+        timeout_in_ms=5000)
+    run_metadata = tf.compat.v1.RunMetadata()
+    output = sess.run(
+        fetches,
+        feed_dict=feed_dict,
+        options=run_options,
+        run_metadata=run_metadata)
+    ```
 
     The optional `run_metadata` argument expects a [`RunMetadata`] proto. When
     appropriate, the non-Tensor output of this step will be collected there. For

--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -949,7 +949,7 @@ class BaseSession(SessionInterface):
     ```python
     run_options = tf.compat.v1.RunOptions(
         report_tensor_allocations_upon_oom=True)
-    output = sess.run(fetches, feed_dict=feed_dict, options=run_options)
+    output = session.run(fetches, feed_dict=feed_dict, options=run_options)
     ```
 
     To enable execution tracing and set a step execution timeout:
@@ -959,7 +959,7 @@ class BaseSession(SessionInterface):
         trace_level=tf.compat.v1.RunOptions.FULL_TRACE,
         timeout_in_ms=5000)
     run_metadata = tf.compat.v1.RunMetadata()
-    output = sess.run(
+    output = session.run(
         fetches,
         feed_dict=feed_dict,
         options=run_options,


### PR DESCRIPTION
Fixes #17076.

This PR addresses feature request #17076 by adding comprehensive Python code examples and documentation for `report_tensor_allocations_upon_oom` and other key fields of `RunOptions` (`trace_level`, `timeout_in_ms`). It also clarifies that `report_tensor_allocations_upon_oom` applies when executing in Graph mode (`tf.compat.v1.Session`).

### Changes Made
- **tensorflow/python/client/session.py**: Enhanced `Session.run` docstrings with code blocks demonstrating `report_tensor_allocations_upon_oom`, `trace_level`, and `timeout_in_ms`.
- **tensorflow/core/protobuf/config.proto**: Added Python code snippets under `RunOptions` proto fields.