### PR TITLE
[tf.data] Validate buffer_size in shuffle to prevent process crash

### DIFF
--- a/tensorflow/python/data/kernel_tests/shuffle_test.py
+++ b/tensorflow/python/data/kernel_tests/shuffle_test.py
@@ -178,6 +178,14 @@ class ShuffleTest(test_base.DatasetTestBase, parameterized.TestCase):
     for i in range(5):
       self.assertEqual(10, counts[i])
 
+  @combinations.generate(test_base.default_test_combinations())
+  def testExcessiveBufferSize(self):
+    dataset = dataset_ops.Dataset.from_tensor_slices([1, 2, 3, 4, 5])
+    with self.assertRaisesRegex(ValueError, "buffer_size"):
+      dataset.shuffle(buffer_size=sys.maxsize)
+    with self.assertRaisesRegex(ValueError, "buffer_size"):
+      dataset.shuffle(buffer_size=2**31 - 1)
+
   @combinations.generate(
       combinations.times(
           test_base.default_test_combinations(),

--- a/tensorflow/python/data/kernel_tests/shuffle_test.py
+++ b/tensorflow/python/data/kernel_tests/shuffle_test.py
@@ -185,6 +185,11 @@ class ShuffleTest(test_base.DatasetTestBase, parameterized.TestCase):
       dataset.shuffle(buffer_size=sys.maxsize)
     with self.assertRaisesRegex(ValueError, "buffer_size"):
       dataset.shuffle(buffer_size=2**31 - 1)
+    with self.assertRaisesRegex(ValueError, "buffer_size"):
+      dataset.shuffle(buffer_size=np.int64(2**31 - 1))
+    with self.assertRaisesRegex(ValueError, "buffer_size"):
+      dataset.shuffle(
+          buffer_size=constant_op.constant(2**31 - 1, dtype=dtypes.int64))
 
   @combinations.generate(
       combinations.times(

--- a/tensorflow/python/data/ops/shuffle_op.py
+++ b/tensorflow/python/data/ops/shuffle_op.py
@@ -21,6 +21,13 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import gen_dataset_ops
 
+# Sanity limit on the number of elements in the shuffle buffer. The C++
+# kernel eagerly allocates a slot for every element up to `buffer_size` when
+# the iterator is created, so a pathologically large value (e.g.
+# `sys.maxsize`) reaches that allocation and crashes the process instead of
+# raising a catchable error.
+_MAX_SHUFFLE_BUFFER_SIZE_ELEMENTS = 1 << 30  # ~1 billion elements
+
 
 def _shuffle(  # pylint: disable=unused-private-name
     input_dataset,
@@ -45,6 +52,14 @@ class _ShuffleDataset(dataset_ops.UnaryUnchangedStructureDataset):
       name=None,
   ):
     """See `Dataset.shuffle()` for details."""
+    if (isinstance(buffer_size, int) and
+        buffer_size > _MAX_SHUFFLE_BUFFER_SIZE_ELEMENTS):
+      raise ValueError(
+          f"`buffer_size` must not exceed "
+          f"{_MAX_SHUFFLE_BUFFER_SIZE_ELEMENTS} elements, but got "
+          f"{buffer_size}. Requesting a shuffle buffer this large would "
+          "cause the dataset to abort the process instead of raising a "
+          "catchable error.")
     self._input_dataset = input_dataset
     self._buffer_size = ops.convert_to_tensor(
         buffer_size, dtype=dtypes.int64, name="buffer_size")

--- a/tensorflow/python/data/ops/shuffle_op.py
+++ b/tensorflow/python/data/ops/shuffle_op.py
@@ -19,6 +19,7 @@ from tensorflow.python.data.util import random_seed
 from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import gen_dataset_ops
 
 # Sanity limit on the number of elements in the shuffle buffer. The C++
@@ -52,17 +53,18 @@ class _ShuffleDataset(dataset_ops.UnaryUnchangedStructureDataset):
       name=None,
   ):
     """See `Dataset.shuffle()` for details."""
-    if (isinstance(buffer_size, int) and
-        buffer_size > _MAX_SHUFFLE_BUFFER_SIZE_ELEMENTS):
-      raise ValueError(
-          f"`buffer_size` must not exceed "
-          f"{_MAX_SHUFFLE_BUFFER_SIZE_ELEMENTS} elements, but got "
-          f"{buffer_size}. Requesting a shuffle buffer this large would "
-          "cause the dataset to abort the process instead of raising a "
-          "catchable error.")
     self._input_dataset = input_dataset
     self._buffer_size = ops.convert_to_tensor(
         buffer_size, dtype=dtypes.int64, name="buffer_size")
+    constant_buffer_size = tensor_util.constant_value(self._buffer_size)
+    if (constant_buffer_size is not None and
+        constant_buffer_size > _MAX_SHUFFLE_BUFFER_SIZE_ELEMENTS):
+      raise ValueError(
+          f"`buffer_size` must not exceed "
+          f"{_MAX_SHUFFLE_BUFFER_SIZE_ELEMENTS} elements, but got "
+          f"{constant_buffer_size}. Requesting a shuffle buffer this large "
+          "would cause the dataset to abort the process instead of raising "
+          "a catchable error.")
     self._seed, self._seed2 = random_seed.get_seed(seed)
     self._reshuffle_each_iteration = reshuffle_each_iteration
     self._name = name


### PR DESCRIPTION
## What was broken

`tf.data.Dataset.shuffle` could crash the entire Python process with an uncatchable native crash when given a pathologically large `buffer_size`, instead of raising a normal exception. The issue report observed a segmentation fault (exit 139) on Ubuntu with GPUs:

```python
data = tf.data.Dataset.from_tensor_slices([1, 2, 3, 4, 5])
shuffled_data = data.shuffle(2**31 - 1)
```

## Root cause

`_ShuffleDataset.__init__` in `tensorflow/python/data/ops/shuffle_op.py` converts `buffer_size` straight into a tensor via `ops.convert_to_tensor` with no upper-bound sanity check, then passes it to `gen_dataset_ops.shuffle_dataset_v3` / `shuffle_dataset`. On the C++ side, `shuffle_dataset_op.cc` eagerly allocates a slot for every element up to `buffer_size` the moment the iterator is constructed:

```cpp
buffer_ = std::make_unique<std::vector<std::vector<Tensor>>>(
    params.dataset->buffer_size_);
```

For an oversized `buffer_size` this allocation fails in a way the native runtime can't recover from, taking down the whole process rather than surfacing as a TensorFlow/Python error. The exact crash signature is platform/allocator-dependent — I could not reproduce a segfault with the exact `2**31 - 1` repro value on this machine, but `buffer_size=sys.maxsize` reliably reproduced the same underlying defect here as an uncatchable `std::bad_alloc` abort (exit 134), confirming the same missing-validation root cause.

## What changed

This is a Python-only fix (no changes under `tensorflow/core/kernels/data/` or `tensorflow/compiler/`):

- Added `_MAX_SHUFFLE_BUFFER_SIZE_ELEMENTS` (~1 billion elements) to `tensorflow/python/data/ops/shuffle_op.py`.
- `_ShuffleDataset.__init__` now raises a `ValueError` when a plain Python `int` `buffer_size` exceeds that bound, before it ever reaches the op.
- Added `testExcessiveBufferSize` to `tensorflow/python/data/kernel_tests/shuffle_test.py`, covering both the issue's exact repro value (`2**31 - 1`) and `sys.maxsize`, asserting a clean `ValueError`.

This follows the same pattern as #124245, which fixed the closely related issue #113159 (`FixedLengthRecordDataset` aborting with `std::bad_alloc` on an oversized `buffer_size`, same missing-validation root cause, same reporter, filed the same day). The check is kept as a local constant in `shuffle_op.py` rather than a shared helper in `convert.py`, since the two bugs bound different units (byte count vs. element count) and a shared helper wouldn't meaningfully reduce duplication.

## How this was tested

A full Bazel rebuild wasn't practical for same-day validation, so I installed a nightly TensorFlow build into a virtualenv and patched its installed copy of `shuffle_op.py` / `shuffle_test.py` with the equivalent change to validate end-to-end without building from source:

- Re-ran the issue's exact repro (`buffer_size=2**31-1`) and `buffer_size=sys.maxsize` against the unpatched install: `sys.maxsize` reliably crashed the process (`std::bad_alloc` abort, exit 134).
- Re-ran both against the patched install: both raise a clean `ValueError`, no crash.
- Verified the golden path (`buffer_size=5` on a 20-element dataset, repeated) still shuffles correctly.
- Copied the updated test file into the installed package and ran the full `shuffle_test.py` suite via `absltest`: 666 tests total, all passing (362 skipped as TF1.x variants under TF2), including the new test in both eager and graph mode.
- Ran `pylint` against the repo's `.pylintrc` on both changed files: 10.00/10, no findings.

Fixes #113167