### PR TITLE
Fix thread count validation to prevent segfault (issue #105297)

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -2230,11 +2230,11 @@ class Context:
       TypeError: If num_threads is not an integer (including booleans).
       ValueError: If num_threads is not in the range [0, 10000].
     """
-    if isinstance(num_threads, bool) or not isinstance(num_threads, compat.integral_types):
+    if isinstance(num_threads, bool) or not isinstance(
+        num_threads, compat.integral_types):
       raise TypeError(
           f"num_threads must be an integer, got {type(num_threads).__name__}."
       )
-    
     if not (0 <= num_threads <= 10000):
       raise ValueError(
           f"num_threads must be in the range [0, 10000], got {num_threads}. "

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -2228,19 +2228,16 @@ class Context:
 
     Raises:
       TypeError: If num_threads is not an integer (including booleans).
-      ValueError: If num_threads is negative or exceeds 10000.
+      ValueError: If num_threads is not in the range [0, 10000].
     """
-    if isinstance(num_threads, bool) or not isinstance(num_threads, int):
+    if isinstance(num_threads, bool) or not isinstance(num_threads, compat.integral_types):
       raise TypeError(
           f"num_threads must be an integer, got {type(num_threads).__name__}."
       )
-    if num_threads < 0:
+    
+    if not (0 <= num_threads <= 10000):
       raise ValueError(
-          f"num_threads must be non-negative, got {num_threads}."
-      )
-    if num_threads > 10000:
-      raise ValueError(
-          f"num_threads must be at most 10000, got {num_threads}. "
+          f"num_threads must be in the range [0, 10000], got {num_threads}. "
           "Setting an excessively large number of threads can cause system "
           "instability or crashes."
       )

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -2226,6 +2226,20 @@ class Context:
 
   @intra_op_parallelism_threads.setter
   def intra_op_parallelism_threads(self, num_threads):
+    if not isinstance(num_threads, int):
+      raise TypeError(
+          f"num_threads must be an integer, got {type(num_threads).__name__}."
+      )
+    if num_threads < 0:
+      raise ValueError(
+          f"num_threads must be non-negative, got {num_threads}."
+      )
+    if num_threads > 10000:
+      raise ValueError(
+          f"num_threads must be at most 10000, got {num_threads}. "
+          "Setting an excessively large number of threads can cause system "
+          "instability or crashes."
+      )
     if self._intra_op_parallelism_threads == num_threads:
       return
 
@@ -2242,6 +2256,20 @@ class Context:
 
   @inter_op_parallelism_threads.setter
   def inter_op_parallelism_threads(self, num_threads):
+    if not isinstance(num_threads, int):
+      raise TypeError(
+          f"num_threads must be an integer, got {type(num_threads).__name__}."
+      )
+    if num_threads < 0:
+      raise ValueError(
+          f"num_threads must be non-negative, got {num_threads}."
+      )
+    if num_threads > 10000:
+      raise ValueError(
+          f"num_threads must be at most 10000, got {num_threads}. "
+          "Setting an excessively large number of threads can cause system "
+          "instability or crashes."
+      )
     if self._inter_op_parallelism_threads == num_threads:
       return
 

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -2220,13 +2220,17 @@ class Context:
 
     self._thread_local_data.function_call_options = None
 
-  @property
-  def intra_op_parallelism_threads(self):
-    return self.config.intra_op_parallelism_threads
+  def _validate_thread_count(self, num_threads):
+    """Validate thread count parameter.
 
-  @intra_op_parallelism_threads.setter
-  def intra_op_parallelism_threads(self, num_threads):
-    if not isinstance(num_threads, int):
+    Args:
+      num_threads: The number of threads to validate.
+
+    Raises:
+      TypeError: If num_threads is not an integer (including booleans).
+      ValueError: If num_threads is negative or exceeds 10000.
+    """
+    if isinstance(num_threads, bool) or not isinstance(num_threads, int):
       raise TypeError(
           f"num_threads must be an integer, got {type(num_threads).__name__}."
       )
@@ -2240,6 +2244,14 @@ class Context:
           "Setting an excessively large number of threads can cause system "
           "instability or crashes."
       )
+
+  @property
+  def intra_op_parallelism_threads(self):
+    return self.config.intra_op_parallelism_threads
+
+  @intra_op_parallelism_threads.setter
+  def intra_op_parallelism_threads(self, num_threads):
+    self._validate_thread_count(num_threads)
     if self._intra_op_parallelism_threads == num_threads:
       return
 
@@ -2256,20 +2268,7 @@ class Context:
 
   @inter_op_parallelism_threads.setter
   def inter_op_parallelism_threads(self, num_threads):
-    if not isinstance(num_threads, int):
-      raise TypeError(
-          f"num_threads must be an integer, got {type(num_threads).__name__}."
-      )
-    if num_threads < 0:
-      raise ValueError(
-          f"num_threads must be non-negative, got {num_threads}."
-      )
-    if num_threads > 10000:
-      raise ValueError(
-          f"num_threads must be at most 10000, got {num_threads}. "
-          "Setting an excessively large number of threads can cause system "
-          "instability or crashes."
-      )
+    self._validate_thread_count(num_threads)
     if self._inter_op_parallelism_threads == num_threads:
       return
 

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -2220,19 +2220,37 @@ class Context:
 
     self._thread_local_data.function_call_options = None
 
+  def _validate_thread_count(self, num_threads):
+    """Validate thread count parameter.
+
+    Args:
+      num_threads: The number of threads to validate.
+
+    Raises:
+      TypeError: If num_threads is not an integer (including booleans).
+      ValueError: If num_threads is not in the range [0, 10000].
+    """
+    if isinstance(num_threads, bool) or not isinstance(
+        num_threads, compat.integral_types):
+      raise TypeError(
+          f"num_threads must be an integer, got {type(num_threads).__name__}."
+      )
+    if not (0 <= num_threads <= 10000):
+      raise ValueError(
+          f"num_threads must be in the range [0, 10000], got {num_threads}. "
+          "Setting an excessively large number of threads can cause system "
+          "instability or crashes."
+      )
+
   @property
   def intra_op_parallelism_threads(self):
     return self.config.intra_op_parallelism_threads
 
   @intra_op_parallelism_threads.setter
   def intra_op_parallelism_threads(self, num_threads):
+    self._validate_thread_count(num_threads)
     if self._intra_op_parallelism_threads == num_threads:
       return
-
-    if num_threads < 0:
-      raise ValueError(
-          "Intra op parallelism threads must be >= 0, but got %d" % num_threads
-      )
 
     if self._context_handle is not None:
       raise RuntimeError(
@@ -2247,13 +2265,11 @@ class Context:
 
   @inter_op_parallelism_threads.setter
   def inter_op_parallelism_threads(self, num_threads):
+    # None keeps the default behavior.
+    if num_threads is not None:
+      self._validate_thread_count(num_threads)
     if self._inter_op_parallelism_threads == num_threads:
       return
-
-    if num_threads is not None and num_threads < 0:
-      raise ValueError(
-          "Inter op parallelism threads must be >= 0, but got %d" % num_threads
-      )
 
     if self._context_handle is not None:
       raise RuntimeError(

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -128,7 +128,13 @@ def set_intra_op_parallelism_threads(num_threads):
   appropriate number.
 
   Args:
-    num_threads: Number of parallel threads
+    num_threads: Number of parallel threads. Must be a non-negative integer
+      not exceeding 10000.
+
+  Raises:
+    TypeError: If `num_threads` is not an integer.
+    ValueError: If `num_threads` is negative or exceeds 10000.
+    RuntimeError: If called after the context has been initialized.
   """
   context.context().intra_op_parallelism_threads = num_threads
 
@@ -154,7 +160,13 @@ def set_inter_op_parallelism_threads(num_threads):
   0 means the system picks an appropriate number.
 
   Args:
-    num_threads: Number of parallel threads
+    num_threads: Number of parallel threads. Must be a non-negative integer
+      not exceeding 10000.
+
+  Raises:
+    TypeError: If `num_threads` is not an integer.
+    ValueError: If `num_threads` is negative or exceeds 10000.
+    RuntimeError: If called after the context has been initialized.
   """
   context.context().inter_op_parallelism_threads = num_threads
 

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -128,7 +128,13 @@ def set_intra_op_parallelism_threads(num_threads):
   appropriate number.
 
   Args:
-    num_threads: Number of parallel threads
+    num_threads: Number of parallel threads. Must be a non-negative integer
+      not exceeding 10000.
+
+  Raises:
+    TypeError: If `num_threads` is not an integer.
+    ValueError: If `num_threads` is negative or exceeds 10000.
+    RuntimeError: If called after the context has been initialized.
   """
   context.context().intra_op_parallelism_threads = num_threads
 
@@ -154,7 +160,13 @@ def set_inter_op_parallelism_threads(num_threads):
   0 means the system picks an appropriate number.
 
   Args:
-    num_threads: Number of parallel threads
+    num_threads: Number of parallel threads. Must be a non-negative integer
+      not exceeding 10000. None is allowed to keep default behavior.
+
+  Raises:
+    TypeError: If `num_threads` is not an integer (None is allowed).
+    ValueError: If `num_threads` is negative or exceeds 10000.
+    RuntimeError: If called after the context has been initialized.
   """
   context.context().inter_op_parallelism_threads = num_threads
 

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -922,6 +922,10 @@ class TensorFloat32Test(test.TestCase):
       config.set_intra_op_parallelism_threads('4')
     with self.assertRaisesRegex(TypeError, 'must be an integer'):
       config.set_intra_op_parallelism_threads(None)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads(True)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads(False)
 
     # Test ValueError for negative
     with self.assertRaisesRegex(ValueError, 'must be non-negative'):
@@ -951,6 +955,10 @@ class TensorFloat32Test(test.TestCase):
       config.set_inter_op_parallelism_threads('4')
     with self.assertRaisesRegex(TypeError, 'must be an integer'):
       config.set_inter_op_parallelism_threads(None)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads(True)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads(False)
 
     # Test ValueError for negative
     with self.assertRaisesRegex(ValueError, 'must be non-negative'):

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -927,17 +927,29 @@ class TensorFloat32Test(test.TestCase):
     with self.assertRaisesRegex(TypeError, 'must be an integer'):
       config.set_intra_op_parallelism_threads(False)
 
-    # Test ValueError for negative
-    with self.assertRaisesRegex(ValueError, 'must be non-negative'):
+    # Test ValueError for out of range
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
       config.set_intra_op_parallelism_threads(-1)
-    with self.assertRaisesRegex(ValueError, 'must be non-negative'):
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
       config.set_intra_op_parallelism_threads(-100)
-
-    # Test ValueError for exceeding maximum
-    with self.assertRaisesRegex(ValueError, 'must be at most 10000'):
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
       config.set_intra_op_parallelism_threads(10001)
-    with self.assertRaisesRegex(ValueError, 'must be at most 10000'):
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
       config.set_intra_op_parallelism_threads(2147483647)  # INT_MAX
+
+  @reset_eager
+  def testIntraOpParallelismThreadsNumpyInteger(self):
+    """Test validation of intra_op_parallelism_threads with numpy integers."""
+    import numpy as np
+    # Test valid numpy integers
+    config.set_intra_op_parallelism_threads(np.int32(1))
+    config.set_intra_op_parallelism_threads(np.int64(100))
+    
+    # Test out of range numpy integers
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_intra_op_parallelism_threads(np.int32(10001))
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_intra_op_parallelism_threads(np.int64(-1))
 
   @reset_eager
   def testInterOpParallelismThreadsValidation(self):
@@ -960,17 +972,29 @@ class TensorFloat32Test(test.TestCase):
     with self.assertRaisesRegex(TypeError, 'must be an integer'):
       config.set_inter_op_parallelism_threads(False)
 
-    # Test ValueError for negative
-    with self.assertRaisesRegex(ValueError, 'must be non-negative'):
+    # Test ValueError for out of range
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
       config.set_inter_op_parallelism_threads(-1)
-    with self.assertRaisesRegex(ValueError, 'must be non-negative'):
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
       config.set_inter_op_parallelism_threads(-100)
-
-    # Test ValueError for exceeding maximum
-    with self.assertRaisesRegex(ValueError, 'must be at most 10000'):
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
       config.set_inter_op_parallelism_threads(10001)
-    with self.assertRaisesRegex(ValueError, 'must be at most 10000'):
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
       config.set_inter_op_parallelism_threads(2147483647)  # INT_MAX
+
+  @reset_eager
+  def testInterOpParallelismThreadsNumpyInteger(self):
+    """Test validation of inter_op_parallelism_threads with numpy integers."""
+    import numpy as np
+    # Test valid numpy integers
+    config.set_inter_op_parallelism_threads(np.int32(1))
+    config.set_inter_op_parallelism_threads(np.int64(100))
+    
+    # Test out of range numpy integers
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_inter_op_parallelism_threads(np.int32(10001))
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_inter_op_parallelism_threads(np.int64(-1))
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -906,6 +906,64 @@ class TensorFloat32Test(test.TestCase):
     expected = array_ops.fill((self.DIM, self.DIM), self.DIM * (1 + 2**-12))
     self.assertAllClose(out, expected, rtol=2**-13, atol=0)
 
+  @reset_eager
+  def testIntraOpParallelismThreadsValidation(self):
+    """Test validation of intra_op_parallelism_threads parameter."""
+    # Test valid values
+    config.set_intra_op_parallelism_threads(0)  # System picks
+    config.set_intra_op_parallelism_threads(1)
+    config.set_intra_op_parallelism_threads(100)
+    config.set_intra_op_parallelism_threads(10000)  # Max allowed
+
+    # Test TypeError for non-integer
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads(1.5)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads('4')
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads(None)
+
+    # Test ValueError for negative
+    with self.assertRaisesRegex(ValueError, 'must be non-negative'):
+      config.set_intra_op_parallelism_threads(-1)
+    with self.assertRaisesRegex(ValueError, 'must be non-negative'):
+      config.set_intra_op_parallelism_threads(-100)
+
+    # Test ValueError for exceeding maximum
+    with self.assertRaisesRegex(ValueError, 'must be at most 10000'):
+      config.set_intra_op_parallelism_threads(10001)
+    with self.assertRaisesRegex(ValueError, 'must be at most 10000'):
+      config.set_intra_op_parallelism_threads(2147483647)  # INT_MAX
+
+  @reset_eager
+  def testInterOpParallelismThreadsValidation(self):
+    """Test validation of inter_op_parallelism_threads parameter."""
+    # Test valid values
+    config.set_inter_op_parallelism_threads(0)  # System picks
+    config.set_inter_op_parallelism_threads(1)
+    config.set_inter_op_parallelism_threads(100)
+    config.set_inter_op_parallelism_threads(10000)  # Max allowed
+
+    # Test TypeError for non-integer
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads(1.5)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads('4')
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads(None)
+
+    # Test ValueError for negative
+    with self.assertRaisesRegex(ValueError, 'must be non-negative'):
+      config.set_inter_op_parallelism_threads(-1)
+    with self.assertRaisesRegex(ValueError, 'must be non-negative'):
+      config.set_inter_op_parallelism_threads(-100)
+
+    # Test ValueError for exceeding maximum
+    with self.assertRaisesRegex(ValueError, 'must be at most 10000'):
+      config.set_inter_op_parallelism_threads(10001)
+    with self.assertRaisesRegex(ValueError, 'must be at most 10000'):
+      config.set_inter_op_parallelism_threads(2147483647)  # INT_MAX
+
 
 if __name__ == '__main__':
   ops.enable_eager_execution()

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -136,13 +136,6 @@ class ConfigTest(test.TestCase, parameterized.TestCase):
       config.set_intra_op_parallelism_threads(1)
 
   @reset_eager
-  def testIntraOpParallelismThreadsNegative(self):
-    with self.assertRaisesRegex(ValueError, 'must be >= 0'):
-      config.set_intra_op_parallelism_threads(-1)
-
-    config.set_intra_op_parallelism_threads(10)
-
-  @reset_eager
   def testInterOpParallelismThreads(self):
     config.set_inter_op_parallelism_threads(10)
     self.assertEqual(config.get_inter_op_parallelism_threads(),
@@ -154,16 +147,6 @@ class ConfigTest(test.TestCase, parameterized.TestCase):
       config.set_inter_op_parallelism_threads(1)
 
     config.set_inter_op_parallelism_threads(10)
-
-  @reset_eager
-  def testInterOpParallelismThreadsNegative(self):
-    with self.assertRaisesRegex(ValueError, 'must be >= 0'):
-      config.set_inter_op_parallelism_threads(-1)
-
-    config.set_inter_op_parallelism_threads(10)
-
-    # None keeps the default behavior instead of failing the comparison.
-    config.set_inter_op_parallelism_threads(None)
 
   @test_util.run_gpu_only
   @reset_eager
@@ -920,6 +903,97 @@ class TensorFloat32Test(test.TestCase):
     out = math_ops.matmul(x, y)
     expected = array_ops.fill((self.DIM, self.DIM), self.DIM * (1 + 2**-12))
     self.assertAllClose(out, expected, rtol=2**-13, atol=0)
+
+  @reset_eager
+  def testIntraOpParallelismThreadsValidation(self):
+    """Test validation of intra_op_parallelism_threads parameter."""
+    # Test valid values
+    config.set_intra_op_parallelism_threads(0)  # System picks
+    config.set_intra_op_parallelism_threads(1)
+    config.set_intra_op_parallelism_threads(100)
+    config.set_intra_op_parallelism_threads(10000)  # Max allowed
+
+    # Test TypeError for non-integer
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads(1.5)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads('4')
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads(None)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads(True)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_intra_op_parallelism_threads(False)
+
+    # Test ValueError for out of range
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_intra_op_parallelism_threads(-1)
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_intra_op_parallelism_threads(-100)
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_intra_op_parallelism_threads(10001)
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_intra_op_parallelism_threads(2147483647)  # INT_MAX
+
+  @reset_eager
+  def testIntraOpParallelismThreadsNumpyInteger(self):
+    """Test validation of intra_op_parallelism_threads with numpy integers."""
+    import numpy as np
+    # Test valid numpy integers
+    config.set_intra_op_parallelism_threads(np.int32(1))
+    config.set_intra_op_parallelism_threads(np.int64(100))
+
+    # Test out of range numpy integers
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_intra_op_parallelism_threads(np.int32(10001))
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_intra_op_parallelism_threads(np.int64(-1))
+
+  @reset_eager
+  def testInterOpParallelismThreadsValidation(self):
+    """Test validation of inter_op_parallelism_threads parameter."""
+    # Test valid values
+    config.set_inter_op_parallelism_threads(0)  # System picks
+    config.set_inter_op_parallelism_threads(1)
+    config.set_inter_op_parallelism_threads(100)
+    config.set_inter_op_parallelism_threads(10000)  # Max allowed
+
+    # Test TypeError for non-integer (None is allowed, keeps default)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads(1.5)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads('4')
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads(True)
+    with self.assertRaisesRegex(TypeError, 'must be an integer'):
+      config.set_inter_op_parallelism_threads(False)
+
+    # Test ValueError for out of range
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_inter_op_parallelism_threads(-1)
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_inter_op_parallelism_threads(-100)
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_inter_op_parallelism_threads(10001)
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_inter_op_parallelism_threads(2147483647)  # INT_MAX
+
+    # None keeps the default behavior instead of failing.
+    config.set_inter_op_parallelism_threads(None)
+
+  @reset_eager
+  def testInterOpParallelismThreadsNumpyInteger(self):
+    """Test validation of inter_op_parallelism_threads with numpy integers."""
+    import numpy as np
+    # Test valid numpy integers
+    config.set_inter_op_parallelism_threads(np.int32(1))
+    config.set_inter_op_parallelism_threads(np.int64(100))
+
+    # Test out of range numpy integers
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_inter_op_parallelism_threads(np.int32(10001))
+    with self.assertRaisesRegex(ValueError, 'must be in the range'):
+      config.set_inter_op_parallelism_threads(np.int64(-1))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #105297

Added validation to prevent segmentation faults when setting thread counts to excessively large values (e.g., INT_MAX)

## Changes made

- Added upper bound validation (max 10,000 threads) in `context.py` property setters for `intra_op_parallelism_threads` and `inter_op_parallelism_threads`
- Updated docstrings in `config.py` to document the upper bound and exceptions
- Added comprehensive unit tests in `config_test.py` covering valid values, type errors, negative values, and exceeding max