### PR TITLE
Improve tf.numpy.sign unsupported argument errors

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1627,12 +1627,14 @@ def broadcast_arrays(*args, **kwargs):  # pylint: disable=missing-docstring
 @tf_export.tf_export('experimental.numpy.sign', v1=[])
 @np_utils.np_doc_only('sign')
 def sign(x, out=None, where=None, **kwargs):  # pylint: disable=missing-docstring,redefined-outer-name
-  if out:
-    raise ValueError('tf.numpy doesnt support setting out.')
-  if where:
-    raise ValueError('tf.numpy doesnt support setting where.')
+  if out is not None:
+    raise ValueError("tf.numpy doesn't support setting out.")
+  if where is not None:
+    raise ValueError("tf.numpy doesn't support setting where.")
   if kwargs:
-    raise ValueError('tf.numpy doesnt support setting {}'.format(kwargs.keys()))
+    raise ValueError(
+        "tf.numpy doesn't support setting {}".format(kwargs.keys())
+    )
 
   x = asarray(x)
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -1330,6 +1330,11 @@ class ArrayMethodsTest(test.TestCase):
           arr = np.asarray(state.randn(*shape) * 100, dtype=dtype)
         self.match(np_array_ops.sign(arr), np.sign(arr))
 
+    with self.assertRaisesRegex(ValueError, "doesn't support setting out"):
+      np_array_ops.sign([1], out=[])
+    with self.assertRaisesRegex(ValueError, "doesn't support setting where"):
+      np_array_ops.sign([1], where=False)
+
 
 class ArrayManipulationTest(test.TestCase):
 


### PR DESCRIPTION
## What this PR changes

`tf.experimental.numpy.sign` documents `out` and `where` in its NumPy-compatible signature, but does not support setting either argument. The existing truthiness checks silently accepted falsey values such as `out=[]` and `where=False`; array-like values could also fail while being coerced to `bool` instead of producing the intended unsupported-argument error.

This change:

- checks `out` and `where` explicitly against `None`;
- improves the three user-facing error messages;
- adds regression coverage for falsey, non-`None` values.

## Compatibility

No public signature changes. Calls that explicitly pass unsupported falsey values now fail consistently with other non-`None` values.

## Tests

- `python -m py_compile tensorflow/python/ops/numpy_ops/np_array_ops.py tensorflow/python/ops/numpy_ops/np_array_ops_test.py`
- `git diff --check`

The targeted Bazel test was not run locally because Bazel is not installed in this environment; CI is expected to run the repository test target.

## AI assistance disclosure

Codex assisted with repository scanning and drafting the patch. The submitted diff was narrowed to the explicit unsupported-argument behavior and includes targeted regression assertions.