### PR TITLE
Fix inaccurate cost estimation on ARM64 architecture

### DIFF
--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/memory/memory.h"
+#include "absl/strings/ascii.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/numbers.h"
 #include "absl/time/time.h"
@@ -107,7 +108,9 @@ inline uint64_t GetAarch64CycleScaleFixed() {
       return 1 << 16;
     }
     int64_t cpu_freq_khz;
-    if (!absl::SimpleAtoi(freq_str, &cpu_freq_khz) || cpu_freq_khz <= 0) {
+    if (!absl::SimpleAtoi(absl::StripTrailingAsciiWhitespace(freq_str),
+                          &cpu_freq_khz) ||
+        cpu_freq_khz <= 0) {
       return 1 << 16;
     }
     uint64_t sf =

--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -23,6 +23,7 @@ limitations under the License.
 
 #include "absl/memory/memory.h"
 #include "absl/strings/str_join.h"
+#include "absl/strings/numbers.h"
 #include "absl/time/time.h"
 #include "absl/types/optional.h"
 #include "tensorflow/core/activity_watcher/activity.h"
@@ -86,6 +87,36 @@ limitations under the License.
 namespace tensorflow {
 
 namespace {
+
+#if defined(__aarch64__) && defined(__linux__)
+// Returns a fixed-point scale factor to convert CNTVCT_EL0 virtual timer
+// cycles to x86-TSC-equivalent cycles.  The factor has 16 fractional bits,
+// so the hot-path update uses (elapsed * factor) >> 16.
+// Computed once per process and cached in a static local.
+inline uint64_t GetAarch64CycleScaleFixed() {
+  static const uint64_t scale_fixed = []() -> uint64_t {
+    uint64_t cntfrq;
+    asm volatile("mrs %0, cntfrq_el0" : "=r"(cntfrq));
+    if (cntfrq == 0) return 1 << 16;
+    std::string freq_str;
+    if (!tensorflow::ReadFileToString(
+            Env::Default(),
+            "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq",
+            &freq_str)
+             .ok()) {
+      return 1 << 16;
+    }
+    int64_t cpu_freq_khz;
+    if (!absl::SimpleAtoi(freq_str, &cpu_freq_khz) || cpu_freq_khz <= 0) {
+      return 1 << 16;
+    }
+    uint64_t sf =
+        (static_cast<uint64_t>(cpu_freq_khz) * 1000 << 16) / cntfrq;
+    return sf > 0 ? sf : (1 << 16);
+  }();
+  return scale_fixed;
+}
+#endif  // defined(__aarch64__) && defined(__linux__)
 
 // 1-D, 0 element tensor.
 static const Tensor* const kEmptyTensor = new Tensor;
@@ -168,32 +199,6 @@ class ExecutorImpl : public Executor {
 
     void Initialize(const GraphView& gview) {
       is_expensive_.resize(gview.num_nodes());
-#if defined(__aarch64__) && defined(__linux__)
-      // Auto-detect cycle scale factor.
-      // On ARM Linux, GetCurrentClockCycle() reads CNTVCT_EL0 (virtual timer
-      // counter), which runs at a fixed frequency independent of the CPU core.
-      // The scale factor converts timer cycles to x86-TSC-equivalent cycles.
-      {
-        uint64_t cntfrq;
-        asm volatile("mrs %0, cntfrq_el0" : "=r"(cntfrq));
-        if (cntfrq > 0) {
-          std::string freq_str;
-          if (tensorflow::ReadFileToString(
-              Env::Default(),
-              "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq",
-              &freq_str)
-              .ok()) {
-            int64_t cpu_freq_khz;
-            if (absl::SimpleAtoi(freq_str, &cpu_freq_khz) && cpu_freq_khz > 0) {
-              uint64_t scale = (static_cast<uint64_t>(cpu_freq_khz) * 1000) / cntfrq;
-              if (scale > 0) {
-                aarch64_cycle_scale_ = scale;
-              }
-            }
-          }
-        }
-      }
-#endif
       cost_estimates_ =
           std::make_unique<std::atomic_uint_fast64_t[]>(gview.num_nodes());
       for (int32_t i = 0; i < gview.num_nodes(); ++i) {
@@ -231,7 +236,9 @@ class ExecutorImpl : public Executor {
       auto prev_estimate = cost_estimate.load(std::memory_order_relaxed);
 #if defined(__aarch64__) && defined(__linux__)
       uint64_t new_estimate =
-          ((kCostDecay - 1) * prev_estimate + elapsed_cycles * aarch64_cycle_scale_) / kCostDecay;
+          ((kCostDecay - 1) * prev_estimate +
+           ((elapsed_cycles * GetAarch64CycleScaleFixed()) >> 16)) /
+          kCostDecay;
 #else
       uint64_t new_estimate =
           ((kCostDecay - 1) * prev_estimate + elapsed_cycles) / kCostDecay;
@@ -247,9 +254,6 @@ class ExecutorImpl : public Executor {
     static constexpr uint64_t kInitialCostEstimateCycles = 100 * 1000 * 1000;
     static constexpr uint64_t kOpIsExpensiveThresholdCycles = 8000;
     static constexpr uint64_t kCostDecay = 10;
-#if defined(__aarch64__) && defined(__linux__)
-    uint64_t aarch64_cycle_scale_ = 1;
-#endif
     std::vector<bool> is_expensive_;
     // std::unique_ptr<std::atomic<bool>[]> is_expensive_;
     std::unique_ptr<std::atomic_uint_fast64_t[]> cost_estimates_;

--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -168,6 +168,32 @@ class ExecutorImpl : public Executor {
 
     void Initialize(const GraphView& gview) {
       is_expensive_.resize(gview.num_nodes());
+#if defined(__aarch64__) && defined(__linux__)
+      // Auto-detect cycle scale factor.
+      // On ARM Linux, GetCurrentClockCycle() reads CNTVCT_EL0 (virtual timer
+      // counter), which runs at a fixed frequency independent of the CPU core.
+      // The scale factor converts timer cycles to x86-TSC-equivalent cycles.
+      {
+        uint64_t cntfrq;
+        asm volatile("mrs %0, cntfrq_el0" : "=r"(cntfrq));
+        if (cntfrq > 0) {
+          std::string freq_str;
+          if (tensorflow::ReadFileToString(
+              Env::Default(),
+              "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq",
+              &freq_str)
+              .ok()) {
+            int64_t cpu_freq_khz;
+            if (absl::SimpleAtoi(freq_str, &cpu_freq_khz) && cpu_freq_khz > 0) {
+              uint64_t scale = (static_cast<uint64_t>(cpu_freq_khz) * 1000) / cntfrq;
+              if (scale > 0) {
+                aarch64_cycle_scale_ = scale;
+              }
+            }
+          }
+        }
+      }
+#endif
       cost_estimates_ =
           std::make_unique<std::atomic_uint_fast64_t[]>(gview.num_nodes());
       for (int32_t i = 0; i < gview.num_nodes(); ++i) {
@@ -203,9 +229,13 @@ class ExecutorImpl : public Executor {
       // affect correctness but may slow down the update frequency.
       std::atomic_uint_fast64_t& cost_estimate = cost_estimates_[node.node_id];
       auto prev_estimate = cost_estimate.load(std::memory_order_relaxed);
-
+#if defined(__aarch64__) && defined(__linux__)
+      uint64_t new_estimate =
+          ((kCostDecay - 1) * prev_estimate + elapsed_cycles * aarch64_cycle_scale_) / kCostDecay;
+#else
       uint64_t new_estimate =
           ((kCostDecay - 1) * prev_estimate + elapsed_cycles) / kCostDecay;
+#endif
 
       cost_estimate.store(new_estimate, std::memory_order_relaxed);
     }
@@ -217,7 +247,9 @@ class ExecutorImpl : public Executor {
     static constexpr uint64_t kInitialCostEstimateCycles = 100 * 1000 * 1000;
     static constexpr uint64_t kOpIsExpensiveThresholdCycles = 8000;
     static constexpr uint64_t kCostDecay = 10;
-
+#if defined(__aarch64__) && defined(__linux__)
+    uint64_t aarch64_cycle_scale_ = 1;
+#endif
     std::vector<bool> is_expensive_;
     // std::unique_ptr<std::atomic<bool>[]> is_expensive_;
     std::unique_ptr<std::atomic_uint_fast64_t[]> cost_estimates_;


### PR DESCRIPTION
## Summary
Fix inaccurate cost estimation in the executor on ARM64 architecture.

## Problem

On ARM64, `GetCurrentClockCycle()` reads `CNTVCT_EL0` (the virtual timer counter), which runs at a fixed frequency (typically 100 MHz) independent of the CPU core frequency. On x86, it reads the TSC (Time Stamp Counter), which runs at the CPU frequency (e.g., 2.3 GHz).

TensorFlow's executor uses cycle counts to dynamically estimate op costs and decide whether to schedule them in a thread pool or inline. The key threshold `kOpIsExpensiveThresholdCycles = 8000` was calibrated for x86 TSC.

On ARM64, because the CNTVCT frequency is much lower than the CPU frequency, the same op produces roughly 1/23 fewer cycles (for 100 MHz vs 2.3 GHz). This causes:

- Ops that should be classified as "expensive" are incorrectly marked as "cheap"
- These ops are inlined instead of being dispatched to the thread pool
- Overall inference performance degrades

## Solution

On ARM64 Linux, automatically detect the ratio between CPU frequency and CNTVCT frequency as a scale factor, and apply it when updating cost estimates:

1. Read CNTVCT frequency via `mrs cntfrq_el0` assembly instruction (architecturally guaranteed to be user-accessible)
2. Read CPU max frequency from `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`
3. Compute `scale = cpu_freq / cntfrq`
4. Multiply `elapsed_cycles` by `scale` in `UpdateCostEstimate()`

If the sysfs file is unavailable (e.g., in some container environments), the default value `scale = 1` is used — no crash or incorrect behavior.

## Impact

- Only affects ARM64 Linux (guarded by `#if defined(__aarch64__) && defined(__linux__)`)
- x86, macOS ARM (Apple Silicon), Android, and other platforms are completely unaffected
- Improves cost estimation accuracy, leading to better scheduling decisions

## 摘要
修复 ARM64 架构下 executor 代价估计不准确的问题。

## 问题描述

在 ARM64 架构上，`GetCurrentClockCycle()` 读取的是 `CNTVCT_EL0`（虚拟定时器计数器），其频率是固定的（通常为 100 MHz），与 CPU 核心主频无关。而 x86 架构上读取的是 TSC（时间戳计数器），频率等于 CPU 主频（如 2.3 GHz）。

TensorFlow 的 executor 使用周期计数来动态估计 op 的代价，并据此决定是在线程池中调度还是内联执行。关键阈值 `kOpIsExpensiveThresholdCycles = 8000` 是基于 x86 TSC 校准的。

在 ARM64 上，由于 CNTVCT 频率远低于 CPU 主频，同样的 op 产生的周期数约为 x86 的 1/23（以 100 MHz vs 2.3 GHz 计算）。这导致：

- 本应被标记为"昂贵"的 op 被错误地判定为"廉价"
- 这些 op 被内联执行，无法利用线程池并行
- 整体推理性能下降

## 解决方案

在 ARM64 Linux 平台上，自动检测 CNTVCT 频率和 CPU 主频的比值作为缩放因子，在更新代价估计时应用该因子：

1. 通过 `mrs cntfrq_el0` 汇编指令读取 CNTVCT 频率（ARM 架构保证用户态可访问）
2. 从 `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq` 读取 CPU 最大频率
3. 计算 `scale = cpu_freq / cntfrq`
4. 在 `UpdateCostEstimate()` 中将 `elapsed_cycles` 乘以 `scale`

如果 sysfs 文件不可读（如某些容器环境），则保持默认值 `scale = 1`，不会崩溃或产生错误行为。

## 影响范围

- 仅影响 ARM64 Linux 平台（通过 `#if defined(__aarch64__) && defined(__linux__)` 保护）
- x86、macOS ARM（Apple Silicon）、Android 等其他平台完全不受影响
- 代价估计的准确性提升，使调度决策更合理