### PR TITLE
Fix OverridableFetchContent override example to use prefixed variable name

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake
+++ b/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake
@@ -220,8 +220,8 @@ endfunction()
 # OVERRIDABLE_FETCH_CONTENT_<contentName>_<variable> where <contentName> is the
 # CONTENT_NAME argument content provided to this method and <variable> is the
 # argument of this method to override. For example, given CONTENT_NAME = foo
-# the GIT_REPOSITORY can be overridden by setting foo_GIT_REPOSITORY to the
-# value to use instead.
+# the GIT_REPOSITORY can be overridden by setting
+# OVERRIDABLE_FETCH_CONTENT_foo_GIT_REPOSITORY to the value to use instead.
 #
 # To convert a GIT_REPOSITORY / GIT_TAG reference to a URL,
 # set OVERRIDABLE_FETCH_CONTENT_GIT_REPOSITORY_AND_TAG_TO_URL_<contentName>

--- a/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake
+++ b/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake
@@ -259,8 +259,8 @@ function(OverridableFetchContent_Declare CONTENT_NAME)
     ${ARGN}
   )
   # Optionally override parsed arguments with values from variables in the form
-  # ${CONTENT_NAME}_${OVERRIDABLE_ARG}.
-  foreach(OVERRIDABLE_ARG in ${OVERRIDABLE_ARGS})
+  # OVERRIDABLE_FETCH_CONTENT_${CONTENT_NAME}_${OVERRIDABLE_ARG}.
+  foreach(OVERRIDABLE_ARG ${OVERRIDABLE_ARGS})
     set(OVERRIDE_VALUE
       ${OVERRIDABLE_FETCH_CONTENT_${CONTENT_NAME}_${OVERRIDABLE_ARG}}
     )


### PR DESCRIPTION
The doc comment for `OverridableFetchContent_Declare()` states the override convention is `OVERRIDABLE_FETCH_CONTENT_<contentName>_<variable>`, but the accompanying example omits the prefix (`foo_GIT_REPOSITORY`). Following the example silently does nothing, because the implementation only reads the prefixed form (`OVERRIDABLE_FETCH_CONTENT_${CONTENT_NAME}_${OVERRIDABLE_ARG}`), and CMake simply warns that the variable was unused.

This corrects the example to use `OVERRIDABLE_FETCH_CONTENT_foo_GIT_REPOSITORY`, matching both the stated convention and the implementation.

Fixes #124399 (Part A).