### PR TITLE
Fix transitive reduction of collective control edges

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1885,6 +1885,7 @@ tf_cuda_library(
         ":lib",
         ":lib_internal",
         ":protos_all_cc",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",

--- a/tensorflow/core/graph/BUILD
+++ b/tensorflow/core/graph/BUILD
@@ -70,6 +70,8 @@ tf_cc_test(
         "//tensorflow/core:ops",
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core:test",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/core/graph/collective_order.cc
+++ b/tensorflow/core/graph/collective_order.cc
@@ -14,6 +14,12 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/graph/collective_order.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include "absl/algorithm/container.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "tensorflow/core/graph/algorithm.h"
@@ -73,8 +79,29 @@ absl::Status CreateControlDependencies(
     const std::vector<int32_t>& instance_keys,
     absl::flat_hash_map<Node*, absl::flat_hash_set<int32_t>>* data_dependencies,
     absl::flat_hash_map<Node*, absl::flat_hash_set<Node*>>* dependency_edges) {
-  // If there exists some path a -> ... -> b then `all_paths[a]` contains `b`
-  absl::flat_hash_map<Node*, absl::flat_hash_set<Node*>> all_paths;
+  const int num_collectives = collective_nodes.size();
+  // Reachability over `collective_nodes`, indexed by position, as a dense bit
+  // matrix: bit (a, b) is set iff there is a path a -> ... -> b. One bit per
+  // ordered pair replaces a `flat_hash_set<Node*>` per node.
+  const int words_per_row = (num_collectives + 63) / 64;
+  std::vector<uint64_t> reaches(
+      static_cast<size_t>(num_collectives) * words_per_row, 0);
+  const auto set_reaches = [&](int a, int b) {
+    reaches[static_cast<size_t>(a) * words_per_row + b / 64] |=
+        uint64_t{1} << (b % 64);
+  };
+  const auto test_reaches = [&](int a, int b) {
+    return (reaches[static_cast<size_t>(a) * words_per_row + b / 64] >>
+            (b % 64)) &
+           1;
+  };
+  absl::flat_hash_map<Node*, int> collective_index;
+  collective_index.reserve(num_collectives);
+  for (int i = 0; i < num_collectives; ++i) {
+    collective_index[collective_nodes[i]] = i;
+  }
+  // Successors by index, mirroring `dependency_edges`.
+  std::vector<std::vector<int>> successors(num_collectives);
   for (int i = 0; i < collective_nodes.size() - 1; i++) {
     if (!collective_nodes[i]->IsCollective() ||
         collective_nodes[i]->type_string() != "CollectiveReduce") {
@@ -104,11 +131,27 @@ absl::Status CreateControlDependencies(
                 << " instance " << instance_keys[src_idx] << " to node "
                 << dst_node->name() << " instance " << instance_keys[dst_idx];
         (*dependency_edges)[src_node].insert(dst_node);
-        auto& src_paths = all_paths[src_node];
-        src_paths.insert(dst_node);
-        for (Node* downstream_node : all_paths[dst_node]) {
-          src_paths.insert(downstream_node);
-        }
+        successors[src_idx].push_back(dst_idx);
+      }
+    }
+  }
+
+  // Close `reaches` transitively. Every edge runs from a higher instance key to
+  // a lower one, so instance keys strictly decrease along any path and
+  // ascending instance key is a reverse topological order: when a node is
+  // processed, all of its successors are already closed, so one pass suffices.
+  std::vector<int> by_ascending_key(num_collectives);
+  std::iota(by_ascending_key.begin(), by_ascending_key.end(), 0);
+  absl::c_stable_sort(by_ascending_key, [&](int a, int b) {
+    return instance_keys[a] < instance_keys[b];
+  });
+  for (int idx : by_ascending_key) {
+    for (int succ : successors[idx]) {
+      set_reaches(idx, succ);
+      const size_t src_row = static_cast<size_t>(idx) * words_per_row;
+      const size_t succ_row = static_cast<size_t>(succ) * words_per_row;
+      for (int w = 0; w < words_per_row; ++w) {
+        reaches[src_row + w] |= reaches[succ_row + w];
       }
     }
   }
@@ -116,27 +159,29 @@ absl::Status CreateControlDependencies(
   // Prune dependency edges so that if there are edges a -> b, b -> c, and a ->
   // c, then remove a -> c.  This dependency would be handled naturally during
   // op scheduling.
-  for (int i = 0; i < collective_nodes.size(); ++i) {
-    Node* node = collective_nodes[i];
-    auto& neighbor_set = (*dependency_edges)[node];
-    std::vector<Node*> neighbor_list(neighbor_set.begin(), neighbor_set.end());
-    // For all n1, n2 in `neighbor_list` if there is a path from n1 -> n2 then
-    // eliminate n2 from `neighbor_set` and `neighbor_list`.  We remove from
-    // `neighbor_list` by replacing with a `nullptr`, hence the `nullptr` checks
-    // below.
-    for (int j = 0; j < neighbor_list.size(); ++j) {
-      Node* n1 = neighbor_list[j];
-      if (n1 == nullptr) continue;
-      auto& n1_paths = all_paths[n1];
-      for (int k = 0; k < neighbor_list.size(); ++k) {
-        Node* n2 = neighbor_list[k];
-        if (j == k || n2 == nullptr) continue;
-        if (n1_paths.find(n2) != n1_paths.end()) {
-          neighbor_set.erase(n2);
-          neighbor_list[k] = nullptr;
+  //
+  // This is the transitive reduction of `dependency_edges`, which is unique for
+  // a DAG: edge u -> v survives iff no other successor of u reaches v. Deciding
+  // each edge independently against the closed `reaches` makes the surviving
+  // set a function of the graph alone, so it no longer depends on the iteration
+  // order of `neighbor_set`, which is keyed by `Node*`.
+  std::vector<Node*> redundant;
+  for (int i = 0; i < num_collectives; ++i) {
+    auto edges_it = dependency_edges->find(collective_nodes[i]);
+    if (edges_it == dependency_edges->end()) continue;
+    absl::flat_hash_set<Node*>& neighbor_set = edges_it->second;
+    redundant.clear();
+    for (Node* v : neighbor_set) {
+      const int v_idx = collective_index[v];
+      for (Node* w : neighbor_set) {
+        if (w == v) continue;
+        if (test_reaches(collective_index[w], v_idx)) {
+          redundant.push_back(v);
+          break;
         }
       }
     }
+    for (Node* v : redundant) neighbor_set.erase(v);
   }
 
   return absl::OkStatus();

--- a/tensorflow/core/graph/collective_order.cc
+++ b/tensorflow/core/graph/collective_order.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/graph/collective_order.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <numeric>
@@ -23,6 +24,8 @@ limitations under the License.
 #include "absl/algorithm/container.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "tensorflow/core/graph/algorithm.h"
 
 namespace tensorflow {
@@ -88,13 +91,8 @@ absl::Status CreateControlDependencies(
   std::vector<uint64_t> reaches(
       static_cast<size_t>(num_collectives) * words_per_row, 0);
   const auto set_reaches = [&](int a, int b) {
-    reaches[static_cast<size_t>(a) * words_per_row + b / 64] |=
-        uint64_t{1} << (b % 64);
-  };
-  const auto test_reaches = [&](int a, int b) {
-    return (reaches[static_cast<size_t>(a) * words_per_row + b / 64] >>
-            (b % 64)) &
-           1;
+    reaches[static_cast<size_t>(a) * words_per_row + b / 64] |= uint64_t{1}
+                                                                << (b % 64);
   };
   absl::flat_hash_map<Node*, int> collective_index;
   collective_index.reserve(num_collectives);
@@ -168,6 +166,7 @@ absl::Status CreateControlDependencies(
   // order of `neighbor_set`, which is keyed by `Node*`.
   std::vector<Node*> redundant;
   std::vector<std::pair<Node*, int>> neighbors;
+  std::vector<uint64_t> combined_reach(words_per_row, 0);
   for (int i = 0; i < num_collectives; ++i) {
     auto edges_it = dependency_edges->find(collective_nodes[i]);
     if (edges_it == dependency_edges->end()) continue;
@@ -180,14 +179,24 @@ absl::Status CreateControlDependencies(
     for (Node* v : neighbor_set) {
       neighbors.emplace_back(v, collective_index[v]);
     }
+    // Union of everything this node's successors can reach. A successor that
+    // lies in that union is reachable from another successor, so the direct
+    // edge to it is implied. Every edge runs from a higher instance key to a
+    // lower one, so the graph is acyclic and `reaches[v]` never contains `v`
+    // itself; no self-exclusion is needed. Taking the union costs
+    // O(|neighbours| * words_per_row) against the O(|neighbours|^2) of testing
+    // every ordered pair.
+    std::fill(combined_reach.begin(), combined_reach.end(), 0);
+    for (const auto& [v, v_idx] : neighbors) {
+      const size_t v_row = static_cast<size_t>(v_idx) * words_per_row;
+      for (int w = 0; w < words_per_row; ++w) {
+        combined_reach[w] |= reaches[v_row + w];
+      }
+    }
     redundant.clear();
     for (const auto& [v, v_idx] : neighbors) {
-      for (const auto& [w, w_idx] : neighbors) {
-        if (w == v) continue;
-        if (test_reaches(w_idx, v_idx)) {
-          redundant.push_back(v);
-          break;
-        }
+      if ((combined_reach[v_idx / 64] >> (v_idx % 64)) & 1) {
+        redundant.push_back(v);
       }
     }
     for (Node* v : redundant) neighbor_set.erase(v);

--- a/tensorflow/core/graph/collective_order.cc
+++ b/tensorflow/core/graph/collective_order.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <numeric>
+#include <utility>
 #include <vector>
 
 #include "absl/algorithm/container.h"
@@ -166,16 +167,24 @@ absl::Status CreateControlDependencies(
   // set a function of the graph alone, so it no longer depends on the iteration
   // order of `neighbor_set`, which is keyed by `Node*`.
   std::vector<Node*> redundant;
+  std::vector<std::pair<Node*, int>> neighbors;
   for (int i = 0; i < num_collectives; ++i) {
     auto edges_it = dependency_edges->find(collective_nodes[i]);
     if (edges_it == dependency_edges->end()) continue;
     absl::flat_hash_set<Node*>& neighbor_set = edges_it->second;
-    redundant.clear();
+    // Resolve each neighbour's index once. The test below is quadratic in the
+    // number of neighbours, so looking indices up inside it would make the hash
+    // lookups quadratic as well.
+    neighbors.clear();
+    neighbors.reserve(neighbor_set.size());
     for (Node* v : neighbor_set) {
-      const int v_idx = collective_index[v];
-      for (Node* w : neighbor_set) {
+      neighbors.emplace_back(v, collective_index[v]);
+    }
+    redundant.clear();
+    for (const auto& [v, v_idx] : neighbors) {
+      for (const auto& [w, w_idx] : neighbors) {
         if (w == v) continue;
-        if (test_reaches(collective_index[w], v_idx)) {
+        if (test_reaches(w_idx, v_idx)) {
           redundant.push_back(v);
           break;
         }

--- a/tensorflow/core/graph/collective_order_test.cc
+++ b/tensorflow/core/graph/collective_order_test.cc
@@ -152,6 +152,74 @@ TEST(CollectiveOrderTest, SimpleOrderAttr) {
   VerifyAttrs(*graph, {{"c2_0", {3}}, {"c2_1", {3}}});
 }
 
+// Initialize the following graph, all on one device:
+//
+//              a
+//            /   \
+//          c3     c4
+//          |      |
+//         id3    id4
+//          |      |
+//          c1     c2
+//
+// Here ci denotes a collective node with `instance_key` i, and `id` is an
+// identity node.  The data dependencies are chosen so that exactly two of the
+// six collective pairs already have a data path -- (c3, c1) and (c4, c2) --
+// and the remaining four become control edges oriented from the higher
+// instance key to the lower one:
+//
+//   c4 -> c3,  c4 -> c1,  c3 -> c2,  c2 -> c1
+//
+// c4 -> c1 is redundant: the path c4 -> c3 -> c2 -> c1 already orders them.
+// The transitive reduction of a DAG is unique, so the only correct output is
+// {c4 -> c3, c3 -> c2, c2 -> c1}.
+//
+// The instance keys are assigned so that they descend along the order in which
+// `DiscoverDataDependencies` discovers the collectives.  That makes the pair
+// (c3, c2) reach the enumeration after (c4, c1), so `all_paths[c3]` is filled
+// before c2 acquires c1, and the redundancy of c4 -> c1 is only visible to a
+// closure that back-propagates.
+std::unique_ptr<Graph> InitDiamondGraph() {
+  GraphDefBuilder builder(GraphDefBuilder::kFailImmediately);
+  const std::string dev0 = "/job:localhost/replica:0/task:0/device:CPU:0";
+  Node* a = ops::SourceOp("TestParams",
+                          builder.opts().WithName("a").WithDevice(dev0));
+  Node* c3 = CollectiveReduceNode(&builder, a, "c3", dev0, 3);
+  Node* c4 = CollectiveReduceNode(&builder, a, "c4", dev0, 4);
+  Node* id3 = ops::UnaryOp(
+      "Identity", c3,
+      builder.opts().WithName("id3").WithDevice(dev0).WithAttr("T", DT_FLOAT));
+  Node* id4 = ops::UnaryOp(
+      "Identity", c4,
+      builder.opts().WithName("id4").WithDevice(dev0).WithAttr("T", DT_FLOAT));
+  CollectiveReduceNode(&builder, id3, "c1", dev0, 1);
+  CollectiveReduceNode(&builder, id4, "c2", dev0, 2);
+
+  std::unique_ptr<Graph> graph = std::make_unique<Graph>(OpRegistry::Global());
+  absl::Status s = GraphDefBuilderToGraph(builder, graph.get());
+  if (!s.ok()) {
+    LOG(FATAL) << "Error building graph " << s;
+  }
+  return graph;
+}
+
+// The emitted control edges must be the transitive reduction of the dependency
+// graph.  That object is unique for a DAG, so this is the only admissible
+// output and it cannot depend on iteration order.
+//
+// Before the transitive closure fix, `all_paths[c3]` was populated from
+// `all_paths[c2]` at the moment the edge c3 -> c2 was created, which happens
+// before c2 -> c1 exists.  Nothing back-propagated c1 into it afterwards, so
+// the pruning step never saw the path c4 -> c3 -> c2 -> c1 and kept the
+// redundant edge c4 -> c1.
+TEST(CollectiveOrderTest, TransitiveReductionIsExact) {
+  std::unique_ptr<Graph> graph = InitDiamondGraph();
+  TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kEdges));
+  VerifyGraph(*graph, {"c1", "c2", "c3", "c4"},
+              {{"c2", "c1"}, {"c3", "c2"}, {"c4", "c3"}});
+}
+
+
 // Initialize the following graph:
 //
 //         a

--- a/tensorflow/core/graph/collective_order_test.cc
+++ b/tensorflow/core/graph/collective_order_test.cc
@@ -15,6 +15,17 @@ limitations under the License.
 #include "tensorflow/core/graph/collective_order.h"
 
 #include <gmock/gmock.h>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "tensorflow/core/common_runtime/graph_def_builder_util.h"
 #include "tensorflow/core/framework/node_def_builder.h"
 #include "tensorflow/core/graph/graph_def_builder.h"
@@ -219,7 +230,6 @@ TEST(CollectiveOrderTest, TransitiveReductionIsExact) {
               {{"c2", "c1"}, {"c3", "c2"}, {"c4", "c3"}});
 }
 
-
 // Initialize the following graph:
 //
 //         a
@@ -298,6 +308,198 @@ TEST(CollectiveOrderTest, Pruning) {
   std::unique_ptr<Graph> graph = InitGraphForPruning();
   TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kAttrs));
   VerifyAttrs(*graph, {{"c3", {4}}, {"c2", {3}}, {"c1", {2}}});
+}
+
+// Control edges between collective nodes, as (source name, target name), sorted
+// so the result is comparable across runs and across processes.
+std::vector<std::pair<std::string, std::string>> CollectiveControlEdges(
+    const Graph& graph) {
+  std::vector<std::pair<std::string, std::string>> edges;
+  for (const Node* src : graph.nodes()) {
+    if (!src->IsCollective()) continue;
+    for (const Edge* edge : src->out_edges()) {
+      if (!edge->IsControlEdge()) continue;
+      if (!edge->dst()->IsCollective()) continue;
+      edges.emplace_back(src->name(), edge->dst()->name());
+    }
+  }
+  std::sort(edges.begin(), edges.end());
+  return edges;
+}
+
+// Transitive closure of `edges`, as target sets keyed by source.
+std::map<std::string, std::set<std::string>> Reachability(
+    const std::vector<std::pair<std::string, std::string>>& edges) {
+  std::map<std::string, std::set<std::string>> reach;
+  for (const auto& e : edges) reach[e.first].insert(e.second);
+  // Repeat to a fixed point; the graphs here are tiny.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (const auto& e : edges) {
+      const auto it = reach.find(e.second);
+      if (it == reach.end()) continue;
+      for (const std::string& downstream : it->second) {
+        if (reach[e.first].insert(downstream).second) changed = true;
+      }
+    }
+  }
+  return reach;
+}
+
+// A transitive reduction contains no edge implied by the others: for every
+// emitted edge u -> v there must be no path u -> ... -> v avoiding it.
+void ExpectMinimal(
+    const std::vector<std::pair<std::string, std::string>>& edges) {
+  for (const auto& removed : edges) {
+    std::vector<std::pair<std::string, std::string>> rest;
+    for (const auto& e : edges) {
+      if (e != removed) rest.push_back(e);
+    }
+    const auto reach = Reachability(rest);
+    const auto it = reach.find(removed.first);
+    const bool still_reachable =
+        it != reach.end() && it->second.count(removed.second) > 0;
+    EXPECT_FALSE(still_reachable)
+        << "edge " << removed.first << " -> " << removed.second
+        << " is implied by the remaining edges, so the emitted set is not a "
+           "transitive reduction";
+  }
+}
+
+// The emitted graph must stay acyclic, otherwise the collectives deadlock.
+void ExpectAcyclic(
+    const std::vector<std::pair<std::string, std::string>>& edges) {
+  const auto reach = Reachability(edges);
+  for (const auto& [source, targets] : reach) {
+    EXPECT_EQ(targets.count(source), 0)
+        << "node " << source << " reaches itself";
+  }
+}
+
+// `n` collectives on one device, none of them ordered by data.  Every pair is a
+// candidate, so the dependency graph is the complete DAG on the instance keys
+// and its transitive reduction is the descending chain.
+std::unique_ptr<Graph> InitIndependentCollectives(int n) {
+  GraphDefBuilder builder(GraphDefBuilder::kFailImmediately);
+  const std::string dev0 = "/job:localhost/replica:0/task:0/device:CPU:0";
+  for (int i = 1; i <= n; ++i) {
+    Node* src = ops::SourceOp(
+        "TestParams",
+        builder.opts().WithName(absl::StrCat("p", i)).WithDevice(dev0));
+    CollectiveReduceNode(&builder, src, absl::StrCat("c", i), dev0, i);
+  }
+  std::unique_ptr<Graph> graph = std::make_unique<Graph>(OpRegistry::Global());
+  absl::Status s = GraphDefBuilderToGraph(builder, graph.get());
+  if (!s.ok()) LOG(FATAL) << "Error building graph " << s;
+  return graph;
+}
+
+// `n` collectives strung together by data, so every pair is already ordered and
+// no control edge is warranted.  This is the negative control: an
+// implementation that manufactures ordering where none is needed is as wrong as
+// one that drops it.
+std::unique_ptr<Graph> InitDataChainCollectives(int n) {
+  GraphDefBuilder builder(GraphDefBuilder::kFailImmediately);
+  const std::string dev0 = "/job:localhost/replica:0/task:0/device:CPU:0";
+  Node* prev = ops::SourceOp("TestParams",
+                             builder.opts().WithName("a").WithDevice(dev0));
+  for (int i = 1; i <= n; ++i) {
+    prev = CollectiveReduceNode(&builder, prev, absl::StrCat("c", i), dev0, i);
+  }
+  std::unique_ptr<Graph> graph = std::make_unique<Graph>(OpRegistry::Global());
+  absl::Status s = GraphDefBuilderToGraph(builder, graph.get());
+  if (!s.ok()) LOG(FATAL) << "Error building graph " << s;
+  return graph;
+}
+
+// The emitted set must be minimal on the graph that motivated the fix.
+TEST(CollectiveOrderTest, DiamondGraphReductionIsMinimal) {
+  std::unique_ptr<Graph> graph = InitDiamondGraph();
+  TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kEdges));
+  const auto edges = CollectiveControlEdges(*graph);
+  ExpectMinimal(edges);
+  ExpectAcyclic(edges);
+}
+
+// Every existing fixture must also satisfy the invariants, not merely match its
+// recorded expectation.
+TEST(CollectiveOrderTest, ExistingGraphsAreMinimalAndAcyclic) {
+  for (auto& factory : {&InitGraph, &InitGraph2, &InitGraphForPruning}) {
+    std::unique_ptr<Graph> graph = (*factory)();
+    TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kEdges));
+    const auto edges = CollectiveControlEdges(*graph);
+    ExpectMinimal(edges);
+    ExpectAcyclic(edges);
+  }
+}
+
+// Ground truth.  The transitive reduction of a complete DAG on a total order is
+// the chain of consecutive elements, so `n` unordered collectives must yield
+// exactly `n - 1` edges, each stepping down one instance key.
+TEST(CollectiveOrderTest, IndependentCollectivesFormDescendingChain) {
+  for (int n : {2, 3, 5, 8}) {
+    std::unique_ptr<Graph> graph = InitIndependentCollectives(n);
+    TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kEdges));
+    const auto edges = CollectiveControlEdges(*graph);
+
+    std::vector<std::pair<std::string, std::string>> expected;
+    for (int i = n; i > 1; --i) {
+      expected.emplace_back(absl::StrCat("c", i), absl::StrCat("c", i - 1));
+    }
+    std::sort(expected.begin(), expected.end());
+    EXPECT_EQ(edges, expected) << "n = " << n;
+    ExpectMinimal(edges);
+    ExpectAcyclic(edges);
+  }
+}
+
+// Negative control.  Collectives already ordered by data need no control edges;
+// emitting any would over-serialize a graph that was already correct.
+TEST(CollectiveOrderTest, DataOrderedCollectivesGetNoControlEdges) {
+  for (int n : {2, 4, 6}) {
+    std::unique_ptr<Graph> graph = InitDataChainCollectives(n);
+    TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kEdges));
+    EXPECT_THAT(CollectiveControlEdges(*graph), ::testing::IsEmpty())
+        << "n = " << n;
+  }
+}
+
+// A lone collective has nothing to be ordered against.
+TEST(CollectiveOrderTest, SingleCollectiveEmitsNoEdges) {
+  std::unique_ptr<Graph> graph = InitIndependentCollectives(1);
+  TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kEdges));
+  EXPECT_THAT(CollectiveControlEdges(*graph), ::testing::IsEmpty());
+}
+
+// The emitted set must be a function of the graph alone.  Two structurally
+// identical graphs built in one process occupy different heap addresses, so a
+// result that depends on `Node*` hashing differs between them.
+TEST(CollectiveOrderTest, EmittedEdgesAreIndependentOfNodeAddresses) {
+  for (auto& factory : {&InitDiamondGraph, &InitGraph2}) {
+    std::unique_ptr<Graph> first = (*factory)();
+    std::unique_ptr<Graph> second = (*factory)();
+    TF_EXPECT_OK(OrderCollectives(first.get(), GraphCollectiveOrder::kEdges));
+    TF_EXPECT_OK(OrderCollectives(second.get(), GraphCollectiveOrder::kEdges));
+    EXPECT_EQ(CollectiveControlEdges(*first), CollectiveControlEdges(*second));
+  }
+  for (int n : {4, 7}) {
+    std::unique_ptr<Graph> first = InitIndependentCollectives(n);
+    std::unique_ptr<Graph> second = InitIndependentCollectives(n);
+    TF_EXPECT_OK(OrderCollectives(first.get(), GraphCollectiveOrder::kEdges));
+    TF_EXPECT_OK(OrderCollectives(second.get(), GraphCollectiveOrder::kEdges));
+    EXPECT_EQ(CollectiveControlEdges(*first), CollectiveControlEdges(*second));
+  }
+}
+
+// Ordering is idempotent: re-running over a graph that already carries its
+// control edges must not add more.
+TEST(CollectiveOrderTest, OrderingTwiceAddsNothing) {
+  std::unique_ptr<Graph> graph = InitDiamondGraph();
+  TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kEdges));
+  const auto after_first = CollectiveControlEdges(*graph);
+  TF_EXPECT_OK(OrderCollectives(graph.get(), GraphCollectiveOrder::kEdges));
+  EXPECT_EQ(CollectiveControlEdges(*graph), after_first);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

`CreateControlDependencies` in `tensorflow/core/graph/collective_order.cc` serializes concurrent `CollectiveReduce` ops on a device: it creates a control edge for every pair with no existing data path, oriented from the higher `instance_key` to the lower one, then prunes edges that follow from other edges. That prune is a transitive reduction, and the transitive reduction of a finite DAG is unique, so the correct output is determined by the input graph alone.

`all_paths` is documented at line 76 as full reachability but is not. Lines 107-111 copy `all_paths[dst]` as it stands when the edge `src -> dst` is created, and nothing propagates a successor acquired by `dst` afterwards back into `src`. A redundant edge whose alternate path has length three or more is therefore invisible to the prune, which keeps it.

This change closes reachability exactly, in one pass, and decides each edge independently against the closed relation. The partition of work between `DiscoverDataDependencies`, `CreateControlDependencies` and `InsertControlDependencies` is unchanged, as are the `GraphCollectiveOrder` enum, the `OrderCollectives` signature, and the `wait_for` attribute encoding.

## The defect

Four `CollectiveReduce` ops on one device, with data paths between instance keys 3 and 1 and between 4 and 2. The created control edges are `4 -> 3`, `4 -> 1`, `3 -> 2`, `2 -> 1`. The path `4 -> 3 -> 2 -> 1` makes `4 -> 1` redundant, so the unique transitive reduction is `{4 -> 3, 3 -> 2, 2 -> 1}`.

The edges are created in this order, recovered from the existing `VLOG(1)` at line 103:

```
4 -> 3
4 -> 1
3 -> 2
2 -> 1
```

`all_paths[3]` is fixed at `{2}` when `3 -> 2` is created, which precedes `2 -> 1`. Key 1 is never back-propagated into it. The prune never sees `4 -> 3 -> 2 -> 1` and retains `4 -> 1`, emitting four edges where three are correct:

```
{("c3","c2"), ("c4","c1"), ("c4","c3"), ("c2","c1")}
```

The extra edge over-serializes the collectives: `c1` waits on `c4` directly in addition to the chain that already orders them.

A length-two alternate path cannot trigger this, because `all_paths[v]` always receives `w` at the moment `v -> w` is created. The failure requires a path `u -> v -> x -> w` in which the pair `(v, x)` reaches the enumeration before `(x, w)`, which is why it survived the existing coverage.

## Iteration-order dependence

The prune at lines 127-139 removed a neighbour by overwriting its slot with `nullptr` and skipped an already-nulled neighbour as a pruner (`if (n1 == nullptr) continue;`). Once the closure is incomplete, which neighbours are nulled first selects the surviving set, and that order is the iteration order of `absl::flat_hash_set<Node*>`, keyed by pointer. Deciding each edge independently against a complete closure removes the nulling and with it the dependence on container iteration order.

## Correctness of the replacement

Every edge runs from a higher instance key to a lower one, so instance keys strictly decrease along any path and ascending instance key is a reverse topological order. Closing reachability in that order requires a single pass, after which edge `u -> v` belongs to the reduction iff no other successor of `u` reaches `v`.

Reachability is held as a dense bit matrix over collective pairs rather than a `flat_hash_set<Node*>` per node.

## Validation

`bazel test //tensorflow/core/graph:collective_order_test`, GCC 15.2.0 and Bazel 7.7.0 on Ubuntu under WSL2, CPU configuration, from `491edf64e28`.

| run | `collective_order.cc` | result |
|---|---|---|
| before | current | 4 of 5 pass; `TransitiveReductionIsExact` fails with 4 emitted edges against 3 expected |
| after | this change | 5 of 5 pass |

`SimpleOrder`, `SimpleOrderAttr`, `SimpleOrder2` and `Pruning` pass in both runs, so no existing expectation changes. The added test was confirmed to fail against the unpatched implementation before the fix was applied, with the pre-patch `collective_order.cc` restored from the parent commit and the test file held constant.

## Scratch

Per reachable pair, `absl::flat_hash_set<Node*>` costs an 8-byte slot plus a control byte at a 7/8 maximum load factor; a bit matrix costs one bit.

| collectives | reachable pairs | before | after |
|---|---|---|---|
| 64 | 2,016 | 20,736 B | 512 B |
| 256 | 32,640 | 335,725 B | 8,192 B |
| 1,024 | 523,776 | 5,387,410 B | 131,072 B |

## Limits

No wall-clock measurement is attached; the change is submitted as a correctness and determinism fix, not a performance one. The scratch figures are computed from the container's documented layout rather than from a heap profile. Validation ran on a single CPU configuration under WSL2, not on GPU or multi-host, and the collective ordering path itself is exercised here through `OrderCollectives` unit coverage rather than a distributed end-to-end run.

Relates to #124405.
