### PR TITLE
Create empty GFiles when closed without writes

### DIFF
--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -255,6 +255,8 @@ class FileIO(object):
     loss as last write might not have been replicated.
     """
     self._read_buf = None
+    if not self._closed and ("w" in self.__mode or "a" in self.__mode):
+      self._prewrite_check()
     if self._writable_file:
       self._writable_file.close()
       self._writable_file = None

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -128,6 +128,52 @@ class FileIoTest(test.TestCase, parameterized.TestCase):
     with file_io.FileIO(file_path, mode="r") as f:
       self.assertEqual("testing", f.read())
 
+  @parameterized.parameters("w", "wb", "w+", "w+b", "a", "ab", "a+", "a+b")
+  def testCloseCreatesEmptyFileInWriteMode(self, mode):
+    file_path = file_io.join(self._base_dir, "empty_file")
+    with file_io.FileIO(file_path, mode=mode):
+      pass
+    self.assertTrue(file_io.file_exists(file_path))
+    self.assertEqual(
+        b"", file_io.read_file_to_string(file_path, binary_mode=True))
+
+  @parameterized.parameters("w", "wb", "w+", "w+b")
+  def testCloseTruncatesFileInWriteMode(self, mode):
+    file_path = file_io.join(self._base_dir, "existing_file")
+    file_io.write_string_to_file(file_path, "contents")
+    with file_io.FileIO(file_path, mode=mode):
+      pass
+    self.assertEqual(
+        b"", file_io.read_file_to_string(file_path, binary_mode=True))
+
+  @parameterized.parameters("a", "ab", "a+", "a+b")
+  def testCloseDoesNotTruncateFileInAppendMode(self, mode):
+    file_path = file_io.join(self._base_dir, "existing_file")
+    file_io.write_string_to_file(file_path, "contents")
+    with file_io.FileIO(file_path, mode=mode):
+      pass
+    self.assertEqual(
+        b"contents", file_io.read_file_to_string(file_path, binary_mode=True))
+
+  @parameterized.parameters("w", "wb", "w+", "w+b", "a", "ab", "a+", "a+b")
+  def testCloseIsIdempotent(self, mode):
+    file_path = file_io.join(self._base_dir, "double_close_file")
+    f = file_io.FileIO(file_path, mode=mode)
+    f.close()
+    file_io.delete_file(file_path)
+    f.close()
+    self.assertFalse(file_io.file_exists(file_path))
+
+  @parameterized.parameters("w", "wb", "w+", "w+b")
+  def testDoubleCloseDoesNotTruncateReplacementFile(self, mode):
+    file_path = file_io.join(self._base_dir, "replacement_file")
+    f = file_io.FileIO(file_path, mode=mode)
+    f.close()
+    file_io.write_string_to_file(file_path, "contents")
+    f.close()
+    self.assertEqual(
+        b"contents", file_io.read_file_to_string(file_path, binary_mode=True))
+
   def testAppend(self):
     file_path = file_io.join(self._base_dir, "temp_file")
     with file_io.FileIO(file_path, mode="w") as f:


### PR DESCRIPTION
## Summary

- initialize the lazy writable handle when closing a GFile opened in write or append mode
- create empty files and apply write-mode truncation even when no write call occurs
- preserve existing contents for append modes
- keep repeated close calls idempotent without changing post-close reuse behavior
- cover text, binary, update, and double-close variants with regression tests

Fixes #45171

## Verification

- reproduced all 8 create-on-close failures with `tf-nightly 2.22.0.dev20260731` before the change
- ran the full `file_io_test.py` suite with the changed `FileIO.close` method over the nightly native file I/O bindings: 96 passed
- TensorFlow Pylint configuration: 10.00/10
- Python bytecode compilation and `git diff --check` passed

A full Bazel source build was not run on this macOS arm64 host.
