### PR TITLE
Stabilize Euclidean norm gradients at magnitude extremes

### DIFF
--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -1905,6 +1905,7 @@ py_library(
         ":linalg_ops_impl",
         ":map_fn",
         ":math_ops",
+        ":norm_grad",
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/framework:tensor",
@@ -2040,6 +2041,7 @@ py_library(
         ":array_ops_gen",
         ":math_ops",
         ":math_ops_gen",
+        ":norm_grad",
         ":special_math_ops",
         "//tensorflow/python/compat",
         "//tensorflow/python/eager:context",
@@ -2049,6 +2051,19 @@ py_library(
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/framework:tensor",
         "//tensorflow/python/framework:tensor_util",
+        "//third_party/py/numpy",
+    ],
+)
+
+py_library(
+    name = "norm_grad",
+    srcs = ["norm_grad.py"],
+    strict_deps = True,
+    deps = [
+        ":array_ops",
+        ":cond",
+        ":math_ops",
+        "//tensorflow/python/framework:dtypes",
         "//third_party/py/numpy",
     ],
 )
@@ -3603,6 +3618,7 @@ cuda_py_strict_test(
         ":gradient_checker",
         ":gradient_checker_v2",
         ":gradients",
+        ":linalg_ops",
         ":math_grad",
         ":math_ops",
         "//tensorflow/python/eager:backprop",

--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -29,6 +29,7 @@ from tensorflow.python.ops import gen_linalg_ops
 from tensorflow.python.ops import linalg_ops_impl
 from tensorflow.python.ops import map_fn
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import norm_grad
 # pylint: disable=wildcard-import
 from tensorflow.python.ops.gen_linalg_ops import *
 # pylint: enable=wildcard-import
@@ -38,6 +39,16 @@ from tensorflow.python.util.tf_export import tf_export
 
 # Names below are lower_case.
 # pylint: disable=invalid-name
+
+
+def _euclidean_norm(tensor, axis):
+  """Computes a Euclidean norm with a numerically stable gradient."""
+  result = math_ops.sqrt(
+      math_ops.reduce_sum(
+          tensor * math_ops.conj(tensor), axis, keepdims=True
+      )
+  )
+  return norm_grad.safe_euclidean_norm(tensor, result, axis)
 
 
 def _RegularizedGramianCholesky(matrix, l2_regularizer, first_kind):
@@ -763,9 +774,7 @@ def norm(tensor,
         # NOTE: we unfortunately cannot use tf.math.reduce_euclidean_norm, since
         # this introduces a new op that is not supported in XLA, and breaks
         # many existing TPU workloads (e.g. ResNet).
-        result = math_ops.sqrt(
-            math_ops.reduce_sum(
-                tensor * math_ops.conj(tensor), axis, keepdims=True))
+        result = _euclidean_norm(tensor, axis)
     else:
       result = math_ops.abs(tensor)
       if ord == 1:

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -27,6 +27,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import gen_math_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import norm_grad
 from tensorflow.python.ops import special_math_ops
 
 
@@ -54,7 +55,10 @@ def _EuclideanNormGrad(op: ops.Operation, grad):
     output = array_ops.reshape(output, output_shape_kept_dims)
     grad = array_ops.reshape(grad, output_shape_kept_dims)
 
-  return math_ops.truediv(op.inputs[0], output / grad), None
+  direction = norm_grad.safe_euclidean_norm_grad(
+      op.inputs[0], output, op.inputs[1]
+  )
+  return math_ops.multiply_no_nan(direction, grad), None
 
 
 def SmartBroadcastGradientArgs(x, y, grad=None):

--- a/tensorflow/python/ops/math_grad_test.py
+++ b/tensorflow/python/ops/math_grad_test.py
@@ -28,6 +28,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import gradients
+from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import math_grad
 from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
@@ -280,9 +281,54 @@ class EuclideanNormGradientTest(test.TestCase):
         y = math_ops.reduce_euclidean_norm(x)
 
       dx = tape.gradient(y, x)
-      dx_answer = constant_op.constant(
-          [float("NaN"), float("NaN")], dtype=dtype)
+      dx_answer = constant_op.constant([0.0, 0.0], dtype=dtype)
       self.assertAllClose(dx, dx_answer)
+
+  def testExtremeMagnitudes(self):
+    for dtype in [dtypes.float32, dtypes.float64]:
+      np_dtype = dtype.as_numpy_dtype
+      values = [
+          np.finfo(np_dtype).tiny,
+          np.sqrt(np.finfo(np_dtype).max) * 2,
+      ]
+      for value in values:
+        x = constant_op.constant([value], dtype=dtype)
+
+        with backprop.GradientTape() as tape:
+          tape.watch(x)
+          y = math_ops.reduce_euclidean_norm(x)
+
+        self.assertAllClose(tape.gradient(y, x), [1.0])
+
+  def testBatchedExtremeMagnitudes(self):
+    tiny = np.finfo(np.float32).tiny
+    large = np.sqrt(np.finfo(np.float32).max) * 2
+    maximum = np.finfo(np.float32).max
+    x = constant_op.constant(
+        [
+            [0.0, 0.0],
+            [tiny, 0.0],
+            [large, 0.0],
+            [maximum, maximum],
+            [3.0, 4.0],
+        ],
+        dtype=dtypes.float32,
+    )
+
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = math_ops.reduce_euclidean_norm(x, axis=1, keepdims=True)
+
+    self.assertAllClose(
+        tape.gradient(y, x),
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [np.sqrt(0.5), np.sqrt(0.5)],
+            [0.6, 0.8],
+        ],
+    )
 
   def test2D_1(self):
     for dtype in [dtypes.float32, dtypes.float64]:
@@ -351,6 +397,118 @@ class EuclideanNormGradientTest(test.TestCase):
           lambda x: math_ops.reduce_euclidean_norm(x, 2), [x])
       err = gradient_checker_v2.max_error(*grads)
       self.assertLess(err, 2e-3)
+
+
+@test_util.run_all_in_graph_and_eager_modes
+class LinalgNormGradientTest(test.TestCase):
+
+  def testZeroAndExtremeMagnitudes(self):
+    for dtype in [dtypes.float32, dtypes.float64]:
+      np_dtype = dtype.as_numpy_dtype
+      values_and_expected = [
+          (0.0, 0.0),
+          (np.finfo(np_dtype).tiny, 1.0),
+          (np.sqrt(np.finfo(np_dtype).max) * 2, 1.0),
+      ]
+      for value, expected in values_and_expected:
+        x = constant_op.constant([value], dtype=dtype)
+
+        with backprop.GradientTape() as tape:
+          tape.watch(x)
+          y = linalg_ops.norm_v2(x)
+
+        self.assertAllClose(tape.gradient(y, x), [expected])
+
+  def testBatchedExtremeMagnitudes(self):
+    tiny = np.finfo(np.float32).tiny
+    large = np.sqrt(np.finfo(np.float32).max) * 2
+    maximum = np.finfo(np.float32).max
+    x = constant_op.constant(
+        [
+            [0.0, 0.0],
+            [tiny, 0.0],
+            [large, 0.0],
+            [maximum, maximum],
+            [3.0, 4.0],
+        ],
+        dtype=dtypes.float32,
+    )
+
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = linalg_ops.norm_v2(x, axis=1, keepdims=True)
+
+    self.assertAllClose(
+        tape.gradient(y, x),
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [np.sqrt(0.5), np.sqrt(0.5)],
+            [0.6, 0.8],
+        ],
+    )
+
+  def testComplex(self):
+    for dtype in [dtypes.complex64, dtypes.complex128]:
+      real_dtype = dtype.real_dtype.as_numpy_dtype
+      values_and_expected = [
+          (0.0j, 0.0j),
+          (np.finfo(real_dtype).tiny + 0.0j, 1.0 + 0.0j),
+          (3.0 + 4.0j, 0.6 + 0.8j),
+      ]
+      for value, expected in values_and_expected:
+        x = constant_op.constant([value], dtype=dtype)
+
+        with backprop.GradientTape() as tape:
+          tape.watch(x)
+          y = linalg_ops.norm_v2(x)
+
+        self.assertAllClose(tape.gradient(y, x), [expected])
+
+  def testMixedNonFiniteValuesPreserveForwardResult(self):
+    x = constant_op.constant(
+        [[0.0, 0.0], [np.inf, 0.0], [np.nan, 0.0]],
+        dtype=dtypes.float32,
+    )
+
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = linalg_ops.norm_v2(x, axis=1)
+
+    dx = tape.gradient(y, x)
+    y_value, dx_value = self.evaluate((y, dx))
+    self.assertEqual(y_value[0], 0.0)
+    self.assertTrue(np.isinf(y_value[1]))
+    self.assertTrue(np.isnan(y_value[2]))
+    self.assertAllEqual(dx_value[0], [0.0, 0.0])
+
+  def testFloat16LargeReduction(self):
+    x = array_ops.ones([65536], dtype=dtypes.float16)
+
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = linalg_ops.norm_v2(x)
+
+    dx = tape.gradient(y, x)
+    self.assertTrue(self.evaluate(math_ops.reduce_all(math_ops.is_finite(dx))))
+    self.assertAllClose(math_ops.reduce_min(dx), 1.0 / 256.0)
+    self.assertAllClose(math_ops.reduce_max(dx), 1.0 / 256.0)
+
+  def testSecondDerivative(self):
+    x = constant_op.constant([3.0, 4.0], dtype=dtypes.float64)
+
+    with backprop.GradientTape() as outer_tape:
+      outer_tape.watch(x)
+      with backprop.GradientTape() as inner_tape:
+        inner_tape.watch(x)
+        y = linalg_ops.norm_v2(x)
+      dx = inner_tape.gradient(y, x)
+
+    ddx = outer_tape.gradient(
+        dx, x, output_gradients=array_ops.ones_like(dx)
+    )
+    self.assertAllClose(ddx, [0.032, -0.024])
 
 
 class SegmentMinOrMaxGradientTest(test.TestCase):

--- a/tensorflow/python/ops/norm_grad.py
+++ b/tensorflow/python/ops/norm_grad.py
@@ -1,0 +1,180 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Numerically stable helpers for Euclidean norm gradients."""
+
+import numpy as np
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import cond
+from tensorflow.python.ops import math_ops
+
+
+def _norm_is_safe_per_output(norm, dtype):
+  """Checks which norms are outside underflow and overflow regions."""
+  real_dtype = dtype.real_dtype
+  finfo_dtype = (
+      np.float32 if real_dtype == dtypes.bfloat16 else
+      real_dtype.as_numpy_dtype
+  )
+  safe_norm_threshold = np.sqrt(np.finfo(finfo_dtype).tiny)
+  if dtype.is_complex:
+    real_norm = math_ops.real(norm)
+    norm_is_finite = math_ops.logical_and(
+        math_ops.is_finite(real_norm),
+        math_ops.is_finite(math_ops.imag(norm)),
+    )
+  else:
+    real_norm = norm
+    norm_is_finite = math_ops.is_finite(norm)
+  return math_ops.logical_and(
+      norm_is_finite,
+      math_ops.greater(math_ops.abs(real_norm), safe_norm_threshold),
+  )
+
+
+def _component_abs(tensor):
+  """Returns a scaling magnitude that cannot overflow for complex inputs."""
+  if tensor.dtype.is_complex:
+    return math_ops.maximum(
+        math_ops.abs(math_ops.real(tensor)),
+        math_ops.abs(math_ops.imag(tensor)),
+    )
+  return math_ops.abs(tensor)
+
+
+def _norm_is_safe(norm, dtype):
+  """Checks whether all norms avoid underflow and overflow regions."""
+  return math_ops.reduce_all(_norm_is_safe_per_output(norm, dtype))
+
+
+def _reduction_scale(tensor, axis):
+  """Returns a non-differentiable component scale for each reduction."""
+  return array_ops.stop_gradient(
+      math_ops.reduce_max(_component_abs(tensor), axis, keepdims=True)
+  )
+
+
+def _divide_by_real_denominator(tensor, denominator):
+  """Divides real or complex components without squaring the denominator."""
+  if tensor.dtype.is_complex:
+    return math_ops.complex(
+        math_ops.div_no_nan(math_ops.real(tensor), denominator),
+        math_ops.div_no_nan(math_ops.imag(tensor), denominator),
+    )
+  return math_ops.div_no_nan(tensor, denominator)
+
+
+def _scaled_euclidean_norm_direction(tensor, axis, scale):
+  """Computes a Euclidean norm direction after scaling input components."""
+  if tensor.dtype.real_dtype in (dtypes.float16, dtypes.bfloat16):
+    calculation_tensor = math_ops.cast(tensor, dtypes.float32)
+    calculation_scale = math_ops.cast(scale, dtypes.float32)
+  else:
+    calculation_tensor = tensor
+    calculation_scale = scale
+  scaled_tensor = _divide_by_real_denominator(
+      calculation_tensor, calculation_scale
+  )
+  if calculation_tensor.dtype.is_complex:
+    squared_components = (
+        math_ops.square(math_ops.real(scaled_tensor))
+        + math_ops.square(math_ops.imag(scaled_tensor))
+    )
+  else:
+    squared_components = math_ops.square(scaled_tensor)
+  scaled_norm = math_ops.sqrt(
+      math_ops.reduce_sum(
+          squared_components,
+          axis,
+          keepdims=True,
+      )
+  )
+  direction = _divide_by_real_denominator(scaled_tensor, scaled_norm)
+  return math_ops.cast(direction, tensor.dtype)
+
+
+def safe_euclidean_norm(tensor, norm, axis):
+  """Preserves `norm`'s value while substituting a stable risky-case gradient."""
+
+  def scaled_result():
+    scale = _reduction_scale(tensor, axis)
+    finite_scale = math_ops.is_finite(scale)
+    direction = _scaled_euclidean_norm_direction(tensor, axis, scale)
+    direction = array_ops.where_v2(
+        finite_scale, direction, array_ops.zeros_like(tensor)
+    )
+    finite_tensor = array_ops.where_v2(
+        finite_scale, tensor, array_ops.zeros_like(tensor)
+    )
+    zero_with_gradient = finite_tensor - array_ops.stop_gradient(finite_tensor)
+    gradient_surrogate = math_ops.reduce_sum(
+        zero_with_gradient * math_ops.conj(array_ops.stop_gradient(direction)),
+        axis,
+        keepdims=True,
+    )
+    use_scaled_gradient = math_ops.logical_and(
+        math_ops.logical_not(_norm_is_safe_per_output(norm, tensor.dtype)),
+        finite_scale,
+    )
+    stable_result = array_ops.stop_gradient(norm) + gradient_surrogate
+    return array_ops.where_v2(use_scaled_gradient, stable_result, norm)
+
+  return cond.cond(
+      _norm_is_safe(norm, tensor.dtype),
+      lambda: norm,
+      scaled_result,
+  )
+
+
+def safe_euclidean_norm_grad(tensor, norm, axis):
+  """Returns a stable Euclidean norm gradient direction.
+
+  For ordinary finite norms this computes `tensor / norm`. If the norm is
+  zero, close enough to zero that squaring may have underflowed, or non-finite
+  despite finite input components, the direction is recomputed after scaling
+  by the largest input component. Scaling keeps the squared reduction in a
+  representable range without changing the direction for any nonzero finite
+  input. Inputs containing non-finite components retain the direct behavior.
+
+  Args:
+    tensor: The input to the Euclidean norm.
+    norm: The norm result, with reduced dimensions retained.
+    axis: The dimensions reduced by the norm.
+
+  Returns:
+    A tensor with the same shape and dtype as `tensor` containing the gradient
+    direction. The minimum-norm subgradient zero is returned at the origin.
+  """
+  def direct_direction():
+    denominator = math_ops.real(norm) if tensor.dtype.is_complex else norm
+    return _divide_by_real_denominator(tensor, denominator)
+
+  def scaled_direction():
+    scale = _reduction_scale(tensor, axis)
+    direction = _scaled_euclidean_norm_direction(tensor, axis, scale)
+    direct = direct_direction()
+    fallback_direction = array_ops.where_v2(
+        math_ops.is_finite(scale), direction, direct
+    )
+    return array_ops.where_v2(
+        _norm_is_safe_per_output(norm, tensor.dtype),
+        direct,
+        fallback_direction,
+    )
+
+  return cond.cond(
+      _norm_is_safe(norm, tensor.dtype), direct_direction, scaled_direction
+  )

--- a/tensorflow/python/ops/norm_grad.py
+++ b/tensorflow/python/ops/norm_grad.py
@@ -159,8 +159,7 @@ def safe_euclidean_norm_grad(tensor, norm, axis):
     direction. The minimum-norm subgradient zero is returned at the origin.
   """
   def direct_direction():
-    denominator = math_ops.real(norm) if tensor.dtype.is_complex else norm
-    return _divide_by_real_denominator(tensor, denominator)
+    return math_ops.truediv(tensor, norm)
 
   def scaled_direction():
     scale = _reduction_scale(tensor, axis)


### PR DESCRIPTION
## Summary

- return the minimum-norm subgradient (zero) for Euclidean norms at the origin
- compute gradient directions from scale-normalized components when the original squared reduction underflows or overflows
- cover both `tf.linalg.norm` and `tf.math.reduce_euclidean_norm`, including batched, complex, and low-precision inputs

## Root cause

The current gradient ultimately evaluates `x / norm(x)`. At zero this is undefined, while very small inputs can make `x * conj(x)` underflow to zero and large inputs can make it overflow before the square root. Guarding only the zero denominator cannot recover the direction after either loss of range.

## Approach

The common finite path retains the direct, unscaled computation. For risky finite reductions, the largest component magnitude is treated as a fixed scale, components are normalized before squaring, and the resulting unit direction is supplied through a zero-valued gradient surrogate. This preserves the existing forward result exactly, including `Inf` and `NaN` behavior, while avoiding unstable squared magnitudes in the backward pass.

Complex inputs are scaled through their real and imaginary components so the scale itself is never squared. Float16 and bfloat16 normalized reductions accumulate in float32. Inputs containing non-finite components retain the existing direct behavior.

## Tests

- zero, tiny, and overflow-prone float32/float64 inputs
- batched mixtures of ordinary and extreme reductions
- finite inputs whose mathematical norm exceeds the dtype range
- complex64 and complex128 directions
- mixed zero, `Inf`, and `NaN` forward values
- large float16 reductions and an ordinary second derivative
- Python syntax, build formatting, lint, and whitespace checks
- focused eager and graph runtime validation against TensorFlow 2.20.0

Fixes #12071
