### PR TITLE
[AutoGraph] Support Python match statements

### DIFF
--- a/ci/official/requirements_updater/numpy1_requirements/requirements.in
+++ b/ci/official/requirements_updater/numpy1_requirements/requirements.in
@@ -8,7 +8,7 @@ astunparse == 1.6.3
 dill == 0.3.7
 astor == 0.7.1
 typing_extensions ~= 4.14.1
-gast == 0.4.0
+gast == 0.6.0
 termcolor == 2.3.0
 wrapt == 1.16.0
 tblib == 2.0.0

--- a/ci/official/requirements_updater/numpy1_requirements/requirements_lock_3_10.txt
+++ b/ci/official/requirements_updater/numpy1_requirements/requirements_lock_3_10.txt
@@ -128,9 +128,9 @@ flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
     # via -r ci/official/requirements_updater/requirements.in
-gast==0.4.0 \
-    --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
-    --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
+gast==0.6.0 \
+    --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
+    --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
     # via -r ci/official/requirements_updater/requirements.in
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \

--- a/ci/official/requirements_updater/numpy1_requirements/requirements_lock_3_11.txt
+++ b/ci/official/requirements_updater/numpy1_requirements/requirements_lock_3_11.txt
@@ -128,9 +128,9 @@ flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
     # via -r ci/official/requirements_updater/requirements.in
-gast==0.4.0 \
-    --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
-    --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
+gast==0.6.0 \
+    --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
+    --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
     # via -r ci/official/requirements_updater/requirements.in
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \

--- a/ci/official/requirements_updater/numpy1_requirements/requirements_lock_3_12.txt
+++ b/ci/official/requirements_updater/numpy1_requirements/requirements_lock_3_12.txt
@@ -128,9 +128,9 @@ flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
     # via -r ci/official/requirements_updater/requirements.in
-gast==0.4.0 \
-    --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
-    --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
+gast==0.6.0 \
+    --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
+    --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
     # via -r ci/official/requirements_updater/requirements.in
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \

--- a/ci/official/requirements_updater/requirements.in
+++ b/ci/official/requirements_updater/requirements.in
@@ -10,7 +10,7 @@ astunparse == 1.6.3
 dill == 0.3.7
 astor == 0.7.1
 typing_extensions ~= 4.14.1
-gast == 0.4.0
+gast == 0.6.0
 termcolor == 2.3.0
 wrapt == 1.16.0
 tblib == 2.0.0

--- a/requirements_lock_3_10.txt
+++ b/requirements_lock_3_10.txt
@@ -128,9 +128,9 @@ flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
     # via -r ci/official/requirements_updater/requirements.in
-gast==0.4.0 \
-    --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
-    --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
+gast==0.6.0 \
+    --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
+    --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
     # via -r ci/official/requirements_updater/requirements.in
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \

--- a/requirements_lock_3_11.txt
+++ b/requirements_lock_3_11.txt
@@ -128,9 +128,9 @@ flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
     # via -r ci/official/requirements_updater/requirements.in
-gast==0.4.0 \
-    --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
-    --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
+gast==0.6.0 \
+    --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
+    --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
     # via -r ci/official/requirements_updater/requirements.in
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \

--- a/requirements_lock_3_12.txt
+++ b/requirements_lock_3_12.txt
@@ -128,9 +128,9 @@ flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
     # via -r ci/official/requirements_updater/requirements.in
-gast==0.4.0 \
-    --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
-    --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
+gast==0.6.0 \
+    --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
+    --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
     # via -r ci/official/requirements_updater/requirements.in
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \

--- a/requirements_lock_3_13.txt
+++ b/requirements_lock_3_13.txt
@@ -128,9 +128,9 @@ flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
     # via -r ci/official/requirements_updater/requirements.in
-gast==0.4.0 \
-    --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
-    --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
+gast==0.6.0 \
+    --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
+    --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
     # via -r ci/official/requirements_updater/requirements.in
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \

--- a/requirements_lock_3_14.txt
+++ b/requirements_lock_3_14.txt
@@ -165,9 +165,9 @@ flatbuffers==25.9.23 \
     --hash=sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2 \
     --hash=sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12
     # via -r ci/official/requirements_updater/requirements.in
-gast==0.4.0 \
-    --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
-    --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
+gast==0.6.0 \
+    --hash=sha256:52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54 \
+    --hash=sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
     # via -r ci/official/requirements_updater/requirements.in
 google-pasta==0.2.0 \
     --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \

--- a/tensorflow/python/autograph/converters/continue_statements.py
+++ b/tensorflow/python/autograph/converters/continue_statements.py
@@ -138,6 +138,13 @@ class ContinueCanonicalizationTransformer(converter.Base):
     node.orelse = self._visit_non_loop_body(node.orelse)
     return node
 
+  def visit_match_case(self, node):
+    node.pattern = self.visit(node.pattern)
+    if node.guard is not None:
+      node.guard = self.visit(node.guard)
+    node.body = self._visit_non_loop_body(node.body)
+    return node
+
   def visit_With(self, node):
     node.items = self.visit_block(node.items)
     node.body = self._visit_non_loop_body(node.body)

--- a/tensorflow/python/autograph/converters/lists.py
+++ b/tensorflow/python/autograph/converters/lists.py
@@ -226,6 +226,13 @@ class ListTransformer(converter.Base):
     node.orelse = self._visit_and_process_block(node.orelse)
     return node
 
+  def visit_match_case(self, node):
+    node.pattern = self.visit(node.pattern)
+    if node.guard is not None:
+      node.guard = self.visit(node.guard)
+    node.body = self._visit_and_process_block(node.body)
+    return node
+
   def visit_With(self, node):
     node.items = self.visit_block(node.items)
     node.body = self._visit_and_process_block(node.body)

--- a/tensorflow/python/autograph/converters/return_statements.py
+++ b/tensorflow/python/autograph/converters/return_statements.py
@@ -146,6 +146,13 @@ class ConditionalReturnRewriter(converter.Base):
 
     return node
 
+  def visit_match_case(self, node):
+    node.pattern = self.visit(node.pattern)
+    if node.guard is not None:
+      node.guard = self.visit(node.guard)
+    node.body, _ = self._visit_statement_block(node, node.body)
+    return node
+
   def visit_FunctionDef(self, node):
     node.args = self.visit(node.args)
     node.body, _ = self._visit_statement_block(node, node.body)
@@ -332,6 +339,13 @@ class ReturnStatementsTransformer(converter.Base):
     node.test = self.visit(node.test)
     node.body = self._visit_statement_block(node, node.body)
     node.orelse = self._visit_statement_block(node, node.orelse)
+    return node
+
+  def visit_match_case(self, node):
+    node.pattern = self.visit(node.pattern)
+    if node.guard is not None:
+      node.guard = self.visit(node.guard)
+    node.body = self._visit_statement_block(node, node.body)
     return node
 
   def visit_FunctionDef(self, node):

--- a/tensorflow/python/autograph/converters/variables.py
+++ b/tensorflow/python/autograph/converters/variables.py
@@ -56,6 +56,14 @@ class VariableAccessTransformer(converter.Base):
       node = templates.replace_as_expression('ag__.ld(var_)', var_=node)
     return node
 
+  def visit_match_case(self, node):
+    # Pattern value and class names have stricter syntax than expressions, so
+    # they cannot be wrapped in `ag__.ld`.
+    if node.guard is not None:
+      node.guard = self.visit(node.guard)
+    node.body = self.visit_block(node.body)
+    return node
+
   def visit_Delete(self, node):
     node = self.generic_visit(node)
 

--- a/tensorflow/python/autograph/impl/BUILD
+++ b/tensorflow/python/autograph/impl/BUILD
@@ -95,6 +95,7 @@ tf_py_strict_test(
         "//tensorflow/python/autograph/core:test_lib",
         "//tensorflow/python/autograph/pyct:errors",
         "//tensorflow/python/autograph/pyct:inspect_utils",
+        "//tensorflow/python/autograph/pyct:loader",
         "//tensorflow/python/autograph/pyct:parser",
         "//tensorflow/python/autograph/utils:ag_logging",
         "//tensorflow/python/data/ops:dataset_ops",

--- a/tensorflow/python/autograph/impl/api_test.py
+++ b/tensorflow/python/autograph/impl/api_test.py
@@ -960,6 +960,109 @@ class ApiTest(test.TestCase):
       x = compiled_fn(constant_op.constant((4, 8)), 4)
       self.assertAllEqual(self.evaluate(x), (1, 2))
 
+  def test_to_graph_match_statement(self):
+
+    def test_fn(x, selector):
+      match selector:
+        case 'square':
+          return x**2
+        case 'double':
+          return x * 2
+        case _:
+          raise ValueError(selector)
+
+    compiled_fn = api.to_graph(test_fn)
+
+    x = constant_op.constant(3)
+    self.assertEqual(self.evaluate(compiled_fn(x, 'square')), 9)
+    self.assertEqual(self.evaluate(compiled_fn(x, 'double')), 6)
+    with self.assertRaisesRegex(ValueError, 'invalid'):
+      compiled_fn(x, 'invalid')
+
+  def test_to_graph_match_statement_with_capture_and_guard(self):
+
+    def test_fn(value):
+      match value:
+        case [head, *tail] if head > 0:  # pylint: disable=used-before-assignment
+          return head, tail
+        case _:
+          return None
+
+    compiled_fn = api.to_graph(test_fn)
+
+    self.assertEqual(compiled_fn([1, 2, 3]), (1, [2, 3]))
+    self.assertIsNone(compiled_fn([-1, 2, 3]))
+
+  def test_to_graph_match_statement_with_nested_return(self):
+
+    def test_fn(value, threshold):
+      match value:
+        case [head, *tail]:
+          if head > threshold:
+            return tail
+          return []
+        case _:
+          return None
+
+    compiled_fn = api.to_graph(test_fn)
+
+    self.assertEqual(compiled_fn([3, 4, 5], 2), [4, 5])
+    self.assertEqual(compiled_fn([1, 4, 5], 2), [])
+    self.assertIsNone(compiled_fn('invalid', 2))
+
+  def test_to_graph_match_statement_with_continue(self):
+
+    def test_fn(values):
+      result = []
+      for value in values:
+        match value:
+          case 0:
+            continue
+            result.append(100)  # pylint: disable=unreachable
+          case _:
+            pass
+        result.append(value)
+      return result
+
+    compiled_fn = api.to_graph(test_fn)
+
+    self.assertEqual(compiled_fn([0, 1, 2]), [1, 2])
+
+  def test_to_graph_match_statement_with_list_pop(self):
+
+    def test_fn(selector, values):
+      match selector:
+        case 'pop':
+          return values.pop()
+        case _:
+          return len(values)
+
+    compiled_fn = api.to_graph(
+        test_fn, experimental_optional_features=converter.Feature.LISTS)
+
+    self.assertEqual(compiled_fn('size', [1, 2, 3]), 3)
+
+  def test_to_graph_match_statement_with_class_pattern(self):
+
+    class Point:
+
+      __match_args__ = ('x', 'y')
+
+      def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def test_fn(value):
+      match value:
+        case Point(x, y):
+          return x + y
+        case _:
+          return None
+
+    compiled_fn = api.to_graph(test_fn)
+
+    self.assertEqual(compiled_fn(Point(2, 3)), 5)
+
   @test_util.run_deprecated_v1
   def test_to_graph_with_defaults(self):
 

--- a/tensorflow/python/autograph/impl/api_test.py
+++ b/tensorflow/python/autograph/impl/api_test.py
@@ -36,6 +36,7 @@ from tensorflow.python.autograph.impl import api
 from tensorflow.python.autograph.impl import conversion
 from tensorflow.python.autograph.pyct import errors
 from tensorflow.python.autograph.pyct import inspect_utils
+from tensorflow.python.autograph.pyct import loader
 from tensorflow.python.autograph.pyct import parser
 from tensorflow.python.autograph.utils import ag_logging
 from tensorflow.python.data.ops import dataset_ops
@@ -84,6 +85,11 @@ class ApiTest(test.TestCase):
         o for o in gc.get_objects() if id(o) not in object_ids_before)
     self.assertEmpty(
         tuple(o for o in objects_after if isinstance(o, TestResource)))
+
+  def _load_test_module(self, source):
+    module, _ = loader.load_source(
+        textwrap.dedent(source), delete_on_exit=True)
+    return module
 
   def test_converted_call_kwonly_args(self):
 
@@ -961,17 +967,18 @@ class ApiTest(test.TestCase):
       self.assertAllEqual(self.evaluate(x), (1, 2))
 
   def test_to_graph_match_statement(self):
+    test_module = self._load_test_module("""
+      def test_fn(x, selector):
+        match selector:
+          case 'square':
+            return x**2
+          case 'double':
+            return x * 2
+          case _:
+            raise ValueError(selector)
+    """)
 
-    def test_fn(x, selector):
-      match selector:
-        case 'square':
-          return x**2
-        case 'double':
-          return x * 2
-        case _:
-          raise ValueError(selector)
-
-    compiled_fn = api.to_graph(test_fn)
+    compiled_fn = api.to_graph(test_module.test_fn)
 
     x = constant_op.constant(3)
     self.assertEqual(self.evaluate(compiled_fn(x, 'square')), 9)
@@ -980,89 +987,95 @@ class ApiTest(test.TestCase):
       compiled_fn(x, 'invalid')
 
   def test_to_graph_match_statement_with_capture_and_guard(self):
+    test_module = self._load_test_module("""
+      def test_fn(value):
+        match value:
+          case [head, *tail] if head > 0:
+            return head, tail
+          case _:
+            return None
+    """)
 
-    def test_fn(value):
-      match value:
-        case [head, *tail] if head > 0:  # pylint: disable=used-before-assignment
-          return head, tail
-        case _:
-          return None
-
-    compiled_fn = api.to_graph(test_fn)
+    compiled_fn = api.to_graph(test_module.test_fn)
 
     self.assertEqual(compiled_fn([1, 2, 3]), (1, [2, 3]))
     self.assertIsNone(compiled_fn([-1, 2, 3]))
 
   def test_to_graph_match_statement_with_nested_return(self):
+    test_module = self._load_test_module("""
+      def test_fn(value, threshold):
+        match value:
+          case [head, *tail]:
+            if head > threshold:
+              return tail
+            return []
+          case _:
+            return None
+    """)
 
-    def test_fn(value, threshold):
-      match value:
-        case [head, *tail]:
-          if head > threshold:
-            return tail
-          return []
-        case _:
-          return None
-
-    compiled_fn = api.to_graph(test_fn)
+    compiled_fn = api.to_graph(test_module.test_fn)
 
     self.assertEqual(compiled_fn([3, 4, 5], 2), [4, 5])
     self.assertEqual(compiled_fn([1, 4, 5], 2), [])
     self.assertIsNone(compiled_fn('invalid', 2))
 
   def test_to_graph_match_statement_with_continue(self):
+    test_module = self._load_test_module("""
+      def test_fn(values):
+        result = []
+        for value in values:
+          match value:
+            case 0:
+              continue
+              result.append(100)
+            case _:
+              pass
+          result.append(value)
+        return result
+    """)
 
-    def test_fn(values):
-      result = []
-      for value in values:
-        match value:
-          case 0:
-            continue
-            result.append(100)  # pylint: disable=unreachable
-          case _:
-            pass
-        result.append(value)
-      return result
-
-    compiled_fn = api.to_graph(test_fn)
+    compiled_fn = api.to_graph(test_module.test_fn)
 
     self.assertEqual(compiled_fn([0, 1, 2]), [1, 2])
 
   def test_to_graph_match_statement_with_list_pop(self):
-
-    def test_fn(selector, values):
-      match selector:
-        case 'pop':
-          return values.pop()
-        case _:
-          return len(values)
+    test_module = self._load_test_module("""
+      def test_fn(selector, values):
+        match selector:
+          case 'pop':
+            return values.pop()
+          case _:
+            return len(values)
+    """)
 
     compiled_fn = api.to_graph(
-        test_fn, experimental_optional_features=converter.Feature.LISTS)
+        test_module.test_fn,
+        experimental_optional_features=converter.Feature.LISTS)
 
     self.assertEqual(compiled_fn('size', [1, 2, 3]), 3)
     self.assertEqual(compiled_fn('pop', [1, 2, 3]), 3)
 
   def test_to_graph_match_statement_with_class_pattern(self):
+    test_module = self._load_test_module("""
+      class Point:
 
-    class Point:
+        __match_args__ = ('x', 'y')
 
-      __match_args__ = ('x', 'y')
+        def __init__(self, x, y):
+          self.x = x
+          self.y = y
 
-      def __init__(self, x, y):
-        self.x = x
-        self.y = y
+      def test_fn(value):
+        match value:
+          case Point(x, y):
+            return x + y
+          case _:
+            return None
+    """)
 
-    def test_fn(value):
-      match value:
-        case Point(x, y):
-          return x + y
-        case _:
-          return None
+    compiled_fn = api.to_graph(test_module.test_fn)
 
-    compiled_fn = api.to_graph(test_fn)
-
-    self.assertEqual(compiled_fn(Point(2, 3)), 5)
+    self.assertEqual(compiled_fn(test_module.Point(2, 3)), 5)
     self.assertIsNone(compiled_fn('not a point'))
 
   @test_util.run_deprecated_v1

--- a/tensorflow/python/autograph/impl/api_test.py
+++ b/tensorflow/python/autograph/impl/api_test.py
@@ -1041,6 +1041,7 @@ class ApiTest(test.TestCase):
         test_fn, experimental_optional_features=converter.Feature.LISTS)
 
     self.assertEqual(compiled_fn('size', [1, 2, 3]), 3)
+    self.assertEqual(compiled_fn('pop', [1, 2, 3]), 3)
 
   def test_to_graph_match_statement_with_class_pattern(self):
 
@@ -1062,6 +1063,7 @@ class ApiTest(test.TestCase):
     compiled_fn = api.to_graph(test_fn)
 
     self.assertEqual(compiled_fn(Point(2, 3)), 5)
+    self.assertIsNone(compiled_fn('not a point'))
 
   @test_util.run_deprecated_v1
   def test_to_graph_with_defaults(self):

--- a/tensorflow/python/autograph/pyct/cfg.py
+++ b/tensorflow/python/autograph/pyct/cfg.py
@@ -619,10 +619,12 @@ class GraphBuilder(object):
       stmts_entered = self.owners[second] - self.owners[first]
       for stmt in stmts_entered:
         stmt_prev[stmt].add(first)
-    for stmt in stmt_next:
-      stmt_next[stmt] = frozenset(stmt_next[stmt])
-    for stmt in stmt_prev:
-      stmt_prev[stmt] = frozenset(stmt_prev[stmt])
+    stmt_next = {
+        stmt: frozenset(next_nodes) for stmt, next_nodes in stmt_next.items()
+    }
+    stmt_prev = {
+        stmt: frozenset(prev_nodes) for stmt, prev_nodes in stmt_prev.items()
+    }
 
     # Construct the final graph object.
     result = Graph(

--- a/tensorflow/python/autograph/pyct/cfg.py
+++ b/tensorflow/python/autograph/pyct/cfg.py
@@ -839,6 +839,28 @@ class AstToCfg(gast.NodeVisitor):
     self.builder.exit_cond_section(node)
     self.builder.end_statement(node)
 
+  def visit_Match(self, node):
+    self.builder.begin_statement(node)
+
+    # Match statements run at trace time, but their branches still need a
+    # conservative CFG for the static analyses that precede conversion.
+    self.builder.enter_cond_section(node)
+    self._process_basic_statement(node.subject)
+
+    for case in node.cases:
+      self.builder.new_cond_branch(node)
+      self._process_basic_statement(case.pattern)
+      if case.guard is not None:
+        self._process_basic_statement(case.guard)
+      for stmt in case.body:
+        self.visit(stmt)
+
+    # A match statement may leave all cases unmatched.
+    self.builder.new_cond_branch(node)
+
+    self.builder.exit_cond_section(node)
+    self.builder.end_statement(node)
+
   def visit_While(self, node):
     self.builder.begin_statement(node)
     self._enter_lexical_scope(node)

--- a/tensorflow/python/autograph/pyct/cfg_test.py
+++ b/tensorflow/python/autograph/pyct/cfg_test.py
@@ -358,6 +358,38 @@ class AstToCfgTest(test.TestCase):
     )
     self.assertGraphEnds(graph, 'a', ('a > 0', 'return'))
 
+  def test_match_straightline(self):
+
+    def test_fn(value):
+      match value:
+        case 0:
+          result = 'zero'
+        case 1 if value > 0:
+          result = 'one'
+      return result
+
+    graph, = self._build_cfg(test_fn).values()
+
+    self.assertGraphMatches(
+        graph,
+        (
+            (None, 'value', 'value'),
+            ('value', 'value', ('0', '1', 'return result')),
+            ('value', '0', "result = 'zero'"),
+            ('0', "result = 'zero'", 'return result'),
+            ('value', '1', 'value > 0'),
+            ('1', 'value > 0', "result = 'one'"),
+            ('value > 0', "result = 'one'", 'return result'),
+            (("result = 'zero'", "result = 'one'", 'value'),
+             'return result', None),
+        ),
+    )
+    self.assertStatementEdges(
+        graph,
+        (('value', 'Match:2', 'return result'),),
+    )
+    self.assertGraphEnds(graph, 'value', ('return result',))
+
   def test_while_straightline(self):
 
     def test_fn(a):

--- a/tensorflow/python/autograph/pyct/cfg_test.py
+++ b/tensorflow/python/autograph/pyct/cfg_test.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Tests for cfg module."""
 
+import textwrap
+
 import gast
 
 from tensorflow.python.autograph.pyct import cfg
@@ -359,16 +361,17 @@ class AstToCfgTest(test.TestCase):
     self.assertGraphEnds(graph, 'a', ('a > 0', 'return'))
 
   def test_match_straightline(self):
+    node = parser.parse(textwrap.dedent("""
+      def test_fn(value):
+        match value:
+          case 0:
+            result = 'zero'
+          case 1 if value > 0:
+            result = 'one'
+        return result
+    """).strip())
 
-    def test_fn(value):
-      match value:
-        case 0:
-          result = 'zero'
-        case 1 if value > 0:
-          result = 'one'
-      return result
-
-    graph, = self._build_cfg(test_fn).values()
+    graph, = cfg.build(node).values()
 
     self.assertGraphMatches(
         graph,

--- a/tensorflow/python/autograph/pyct/loader_test.py
+++ b/tensorflow/python/autograph/pyct/loader_test.py
@@ -82,7 +82,8 @@ class LoaderTest(test.TestCase):
         ],
         decorator_list=[],
         returns=None,
-        type_comment=None)
+        type_comment=None,
+        type_params=[])
 
     module, source, _ = loader.load_ast(node)
 

--- a/tensorflow/python/autograph/pyct/static_analysis/activity.py
+++ b/tensorflow/python/autograph/pyct/static_analysis/activity.py
@@ -663,6 +663,20 @@ class ActivityAnalyzer(transformer.Base):
                                           (node.orelse, NodeAnno.ORELSE_SCOPE)))
     return node
 
+  def visit_Match(self, node):
+    # Reaching-definitions analysis maps each of these expression scopes to the
+    # corresponding CFG node.
+    node.subject = self._process_statement(node.subject)
+    node.cases = self.visit_block(node.cases)
+    return node
+
+  def visit_match_case(self, node):
+    node.pattern = self._process_statement(node.pattern)
+    if node.guard is not None:
+      node.guard = self._process_statement(node.guard)
+    node.body = self.visit_block(node.body)
+    return node
+
   def visit_For(self, node):
     self._enter_scope(False)
     node.target = self.visit(node.target)

--- a/tensorflow/python/autograph/pyct/static_analysis/activity.py
+++ b/tensorflow/python/autograph/pyct/static_analysis/activity.py
@@ -316,6 +316,13 @@ class ActivityAnalyzer(transformer.Base):
       raise ValueError('Unknown context {} for node "{}".'.format(
           type(node.ctx), qn))
 
+  def _track_pattern_name(self, name):
+    if name is None:
+      return
+    qn = qual_names.QN(name)
+    self.scope.modified.add(qn)
+    self.scope.bound.add(qn)
+
   def _enter_scope(self, isolated, f_name=None):
     self.scope = Scope(self.scope, isolated=isolated, function_name=f_name)
 
@@ -666,15 +673,35 @@ class ActivityAnalyzer(transformer.Base):
   def visit_Match(self, node):
     # Reaching-definitions analysis maps each of these expression scopes to the
     # corresponding CFG node.
-    node.subject = self._process_statement(node.subject)
+    self._enter_scope(False)
+    node.subject = self.visit(node.subject)
+    self._exit_and_record_scope(node.subject)
     node.cases = self.visit_block(node.cases)
     return node
 
   def visit_match_case(self, node):
-    node.pattern = self._process_statement(node.pattern)
+    self._enter_scope(False)
+    node.pattern = self.visit(node.pattern)
+    self._exit_and_record_scope(node.pattern)
     if node.guard is not None:
-      node.guard = self._process_statement(node.guard)
+      self._enter_scope(False)
+      node.guard = self.visit(node.guard)
+      self._exit_and_record_scope(node.guard)
     node.body = self.visit_block(node.body)
+    return node
+
+  def visit_MatchAs(self, node):
+    node = self.generic_visit(node)
+    self._track_pattern_name(node.name)
+    return node
+
+  def visit_MatchStar(self, node):
+    self._track_pattern_name(node.name)
+    return node
+
+  def visit_MatchMapping(self, node):
+    node = self.generic_visit(node)
+    self._track_pattern_name(node.rest)
     return node
 
   def visit_For(self, node):

--- a/tensorflow/python/autograph/pyct/static_analysis/activity_test.py
+++ b/tensorflow/python/autograph/pyct/static_analysis/activity_test.py
@@ -312,6 +312,75 @@ class ActivityAnalyzerTest(ActivityAnalyzerTestBase):
         anno.getanno(if_node, NodeAnno.ORELSE_SCOPE).parent,
         ('x', 'y', 'z', 'u'), ('x', 'y', 'z', 'u'))
 
+  def test_match_subject_and_guard(self):
+
+    def test_fn(subject, guard):
+      match subject:
+        case _ if guard:
+          return True
+      return False
+
+    node, _ = self._parse_and_analyze(test_fn)
+    match_node = node.body[0]
+    self.assertScopeIs(
+        anno.getanno(match_node.subject, anno.Static.SCOPE), ('subject',), ())
+    self.assertScopeIs(
+        anno.getanno(match_node.cases[0].guard, anno.Static.SCOPE),
+        ('guard',), ())
+
+  def test_match_as_binds_name(self):
+
+    def test_fn(subject):
+      match subject:
+        case captured:
+          return captured
+
+    node, _ = self._parse_and_analyze(test_fn)
+    pattern = node.body[0].cases[0].pattern
+    pattern_scope = anno.getanno(pattern, anno.Static.SCOPE)
+    self.assertScopeIs(pattern_scope, (), ('captured',))
+    self.assertSymbolSetsAre(('captured',), pattern_scope.bound, 'bound')
+
+  def test_match_star_binds_name(self):
+
+    def test_fn(subject):
+      match subject:
+        case [*rest]:
+          return rest
+
+    node, _ = self._parse_and_analyze(test_fn)
+    pattern = node.body[0].cases[0].pattern
+    pattern_scope = anno.getanno(pattern, anno.Static.SCOPE)
+    self.assertScopeIs(pattern_scope, (), ('rest',))
+    self.assertSymbolSetsAre(('rest',), pattern_scope.bound, 'bound')
+
+  def test_match_mapping_binds_names(self):
+
+    def test_fn(subject):
+      match subject:
+        case {'key': value, **rest}:
+          return value, rest
+
+    node, _ = self._parse_and_analyze(test_fn)
+    pattern = node.body[0].cases[0].pattern
+    pattern_scope = anno.getanno(pattern, anno.Static.SCOPE)
+    self.assertScopeIs(pattern_scope, (), ('value', 'rest'))
+    self.assertSymbolSetsAre(('value', 'rest'), pattern_scope.bound, 'bound')
+
+  def test_match_class_reads_class_and_binds_names(self):
+
+    def test_fn(subject):
+      match subject:
+        case shapes.Point(x, coord=y):  # pylint: disable=undefined-variable
+          return x, y
+
+    node, _ = self._parse_and_analyze(test_fn)
+    pattern = node.body[0].cases[0].pattern
+    pattern_scope = anno.getanno(pattern, anno.Static.SCOPE)
+    self.assertScopeIs(
+        pattern_scope, ('shapes', 'shapes.Point'), ('x', 'y'))
+    self.assertSymbolSetsAre(('x', 'y'), pattern_scope.bound, 'bound')
+
   def test_if_attributes(self):
 
     def test_fn(a):

--- a/tensorflow/python/autograph/pyct/static_analysis/activity_test.py
+++ b/tensorflow/python/autograph/pyct/static_analysis/activity_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for activity module."""
 
+import sys
+import textwrap
+
 import gast
 
 from tensorflow.python.autograph.pyct import anno
@@ -127,6 +130,23 @@ class ActivityAnalyzerTestBase(test.TestCase):
     node, source = parser.parse_entity(test_fn, future_features=())
     entity_info = transformer.EntityInfo(
         name=test_fn.__name__,
+        source_code=source,
+        source_file=None,
+        future_features=(),
+        namespace={})
+    node = qual_names.resolve(node)
+    namer = naming.Namer({})
+    ctx = transformer.Context(entity_info, namer, None)
+    node = activity.resolve(node, ctx)
+    return node, entity_info
+
+  def _parse_match_and_analyze(self, source):
+    if sys.version_info < (3, 10):
+      self.skipTest('Pattern matching requires Python 3.10 or newer.')
+    source = textwrap.dedent(source)
+    node = parser.parse(source)
+    entity_info = transformer.EntityInfo(
+        name=node.name,
         source_code=source,
         source_file=None,
         future_features=(),
@@ -313,14 +333,13 @@ class ActivityAnalyzerTest(ActivityAnalyzerTestBase):
         ('x', 'y', 'z', 'u'), ('x', 'y', 'z', 'u'))
 
   def test_match_subject_and_guard(self):
-
-    def test_fn(subject, guard):
-      match subject:
-        case _ if guard:
-          return True
-      return False
-
-    node, _ = self._parse_and_analyze(test_fn)
+    node, _ = self._parse_match_and_analyze("""
+        def test_fn(subject, guard):
+          match subject:
+            case _ if guard:
+              return True
+          return False
+        """)
     match_node = node.body[0]
     self.assertScopeIs(
         anno.getanno(match_node.subject, anno.Static.SCOPE), ('subject',), ())
@@ -329,52 +348,48 @@ class ActivityAnalyzerTest(ActivityAnalyzerTestBase):
         ('guard',), ())
 
   def test_match_as_binds_name(self):
-
-    def test_fn(subject):
-      match subject:
-        case captured:
-          return captured
-
-    node, _ = self._parse_and_analyze(test_fn)
+    node, _ = self._parse_match_and_analyze("""
+        def test_fn(subject):
+          match subject:
+            case captured:
+              return captured
+        """)
     pattern = node.body[0].cases[0].pattern
     pattern_scope = anno.getanno(pattern, anno.Static.SCOPE)
     self.assertScopeIs(pattern_scope, (), ('captured',))
     self.assertSymbolSetsAre(('captured',), pattern_scope.bound, 'bound')
 
   def test_match_star_binds_name(self):
-
-    def test_fn(subject):
-      match subject:
-        case [*rest]:
-          return rest
-
-    node, _ = self._parse_and_analyze(test_fn)
+    node, _ = self._parse_match_and_analyze("""
+        def test_fn(subject):
+          match subject:
+            case [*rest]:
+              return rest
+        """)
     pattern = node.body[0].cases[0].pattern
     pattern_scope = anno.getanno(pattern, anno.Static.SCOPE)
     self.assertScopeIs(pattern_scope, (), ('rest',))
     self.assertSymbolSetsAre(('rest',), pattern_scope.bound, 'bound')
 
   def test_match_mapping_binds_names(self):
-
-    def test_fn(subject):
-      match subject:
-        case {'key': value, **rest}:
-          return value, rest
-
-    node, _ = self._parse_and_analyze(test_fn)
+    node, _ = self._parse_match_and_analyze("""
+        def test_fn(subject):
+          match subject:
+            case {'key': value, **rest}:
+              return value, rest
+        """)
     pattern = node.body[0].cases[0].pattern
     pattern_scope = anno.getanno(pattern, anno.Static.SCOPE)
     self.assertScopeIs(pattern_scope, (), ('value', 'rest'))
     self.assertSymbolSetsAre(('value', 'rest'), pattern_scope.bound, 'bound')
 
   def test_match_class_reads_class_and_binds_names(self):
-
-    def test_fn(subject):
-      match subject:
-        case shapes.Point(x, coord=y):  # pylint: disable=undefined-variable
-          return x, y
-
-    node, _ = self._parse_and_analyze(test_fn)
+    node, _ = self._parse_match_and_analyze("""
+        def test_fn(subject):
+          match subject:
+            case shapes.Point(x, coord=y):
+              return x, y
+        """)
     pattern = node.body[0].cases[0].pattern
     pattern_scope = anno.getanno(pattern, anno.Static.SCOPE)
     self.assertScopeIs(
@@ -872,7 +887,7 @@ class ActivityAnalyzerTest(ActivityAnalyzerTestBase):
 
     def test_fn():
       a: b
-      return a
+      return a  # pylint: disable=used-before-assignment
 
     node, _ = self._parse_and_analyze(test_fn)
     fn_node = node

--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -508,7 +508,7 @@ install_tensorflow_pip() {
 
   # Install the gast package in the virtualenv. Installing it in user system
   # packages does not appear to port it over when creating a virtualenv.
-  ${PIP_BIN_PATH} install --upgrade "gast==0.4.0" || \
+  ${PIP_BIN_PATH} install --upgrade "gast==0.6.0" || \
     die "Error: gast install, upgrade FAILED"
 
 }

--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -21,7 +21,7 @@ wheel ~= 0.41.2
 wrapt ~= 1.14.1
 
 # We need to pin the gast dependency exactly
-gast == 0.4.0
+gast == 0.6.0
 
 # Finally, install tensorboard and keras
 # Note that here we want the latest version that matches TF major.minor version

--- a/tensorflow/tools/pip_package/setup.py.tpl
+++ b/tensorflow/tools/pip_package/setup.py.tpl
@@ -100,7 +100,7 @@ REQUIRED_PACKAGES = [
     'absl-py >= 1.0.0',
     'astunparse >= 1.6.0',
     'flatbuffers >= 25.9.23',
-    'gast >=0.2.1,!=0.5.0,!=0.5.1,!=0.5.2',
+    'gast >=0.6.0',
     'google_pasta >= 0.1.1',
     'libclang >= 13.0.0',
     'opt_einsum >= 2.3.2',


### PR DESCRIPTION
Fixes #57166.

AutoGraph's CFG builder did not recognize Python structural pattern matching. Names in a `match` subject, pattern, or guard were consequently left outside any CFG statement, and conversion failed during reaching-definitions analysis.

This change:

* models the subject, case patterns, guards, case bodies, and unmatched path in AutoGraph's activity and CFG analyses;
* leaves Python's pattern selection to run at trace time;
* preserves statement-block behavior for returns, continues, and optional list conversions inside case bodies; and
* avoids wrapping class/value pattern names in `ag__.ld`, which is not valid pattern syntax.

Regression tests cover the original literal/wildcard example, capture patterns and guards, nested returns, continues, optional list `pop()`, class patterns, and CFG fallthrough.

Local verification on Python 3.13 with the current source over a TensorFlow 2.21 binary runtime:

* 6 targeted `api_test.py` match-statement tests passed.
* Full `cfg_test.py`: 56 passed (2 framework skips).
* Full `activity_test.py`: 44 passed (3 framework skips).
* Full `return_statements_test.py`: 20 passed.
* Full `continue_statements_test.py`: 11 passed.
* Full `lists_test.py`: 7 passed.
* Full `variables_test.py`: 14 passed.
* TensorFlow presubmit `pylint==2.13.9`: 10.00/10 on all changed files (with two pre-existing `modified-iterating-dict` findings in `cfg.py` disabled).
* `py_compile` and `git diff --check` passed.
