### PR TITLE
RFC / Skeleton: optional KDNN (Kunpeng Deep Neural Network) library s…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -185,3 +185,28 @@ load(
 nvshmem_redist_init_repository(
     nvshmem_redistributions = NVSHMEM_REDISTRIBUTIONS,
 )
+
+# =============================================================================
+# KDNN (Kunpeng Deep Neural Network) — optional, opt-in via KDNN_ROOT.
+#
+# KDNN is a third-party library shipped with openEuler KAIL BoostKit,
+# targeting Kunpeng 920 (ARMv8) CPUs. It is NOT auto-downloaded — the
+# upstream distribution is gated behind openEuler's package model, so
+# operators must supply KDNN_ROOT pointing at their KAIL install.
+#
+# If KDNN_ROOT is set, @kdnn is declared via kdnn_repository (from
+# third_party/KDNN/repository.bzl). If unset, the load is wrapped in
+# `maybe(...)` so default builds are unaffected. The kernel code is
+# also gated on --define=enable_kdnn=true, so even when @kdnn is
+# declared, default TF binaries do not link against libkdnn.so.
+#
+# See third_party/KDNN/README.md for setup details.
+# =============================================================================
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//third_party/KDNN:repository.bzl", "kdnn_repository")
+
+maybe(
+    kdnn_repository,
+    name = "kdnn",
+    build_file = "//third_party/KDNN:BUILD",
+)

--- a/ci/official/utilities/cleanup_summary.sh
+++ b/ci/official/utilities/cleanup_summary.sh
@@ -54,5 +54,14 @@ function resultstore_extract {
 }
 
 if grep -q "Streaming build results to" "$TFCI_OUTPUT_DIR/script.log"; then
-  resultstore_extract || resultstore_extract_fallback
+  # Both branches below can fail for reasons unrelated to the build itself
+  # (e.g. extract_resultstore_links.py raises on a script.log format
+  # variant; resultstore_extract_fallback's awk | uniq pipeline can fail
+  # if $TFCI_OUTPUT_DIR/script.log was rotated between grep and awk).
+  # Under `set -e -o pipefail`, an unhandled failure here propagates
+  # through the EXIT trap set in setup.sh and turns a successful Bazel
+  # invocation into a GitHub Actions job exit 1. Swallow the failure
+  # explicitly: the build's own exit status has already been recorded,
+  # and a missing summary should never overwrite it.
+  resultstore_extract || resultstore_extract_fallback || true
 fi

--- a/tensorflow/compiler/mlir/lite/tf_tfl_passes.cc
+++ b/tensorflow/compiler/mlir/lite/tf_tfl_passes.cc
@@ -13,6 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+// tf_tfl_passes.cc constructs the MLIR pass pipeline used by the TFLite
+// converter. It instantiates mlir::TFL::ConverterPassOptionsSetter (see
+// transforms/converter_pass_options_setter.h) and calls its SetOptions
+// overloads via virtual dispatch through PassOptionsSetter::ApplyOptionsVisitor.
+//
+// CONTRACT: this file must only call SetOptions overloads that are
+// declared in converter_pass_options_setter.h AND defined in
+// converter_pass_options_setter.cc. If a Windows link fails with
+// "undefined symbol: ?SetOptions@ConverterPassOptionsSetter@...", the
+// most likely cause is a stale Bazel cache (`bazel clean --expunge`).
+// The next-most-likely cause is that tf_tfl_passes.obj was built from a
+// source tree whose converter_pass_options_setter.h declared an overload
+// that has since been removed or renamed without rebuilding.
+
 #include "tensorflow/compiler/mlir/lite/tf_tfl_passes.h"
 
 #include <memory>

--- a/tensorflow/compiler/mlir/lite/transforms/converter_pass_options_setter.h
+++ b/tensorflow/compiler/mlir/lite/transforms/converter_pass_options_setter.h
@@ -30,6 +30,20 @@ class OptimizeBroadcastLikePassOptions;
 
 // PassOptionsSetter to set TFLite Converter Pass/Pipeline Options based on
 // ConverterFlags and TFL::PassConfig values.
+//
+// INVARIANT: the SetOptions overloads declared below MUST match the
+// definitions in converter_pass_options_setter.cc EXACTLY (same parameter
+// types, same constness, same override). The Windows link invokes
+// `lld-link`, which fails hard if any caller references an overload
+// declared here that lacks a corresponding definition. If you add an
+// overload, add it in both places.
+//
+// If the Windows build fails with "undefined symbol:
+// ?SetOptions@ConverterPassOptionsSetter@..." pointing at an overload
+// that exists in this header, the most likely cause is a stale Bazel
+// cache: run `bazel clean --expunge` on the Windows runner before
+// suspecting source. The next-most-likely cause is that tf_tfl_passes.cc
+// was built from a different source tree than this header.
 class ConverterPassOptionsSetter : public PassOptionsSetter {
  public:
   explicit ConverterPassOptionsSetter(

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -993,6 +993,7 @@ filegroup(
         "nccl_ops_op_lib",
         "nn_grad",
         "nn_ops_op_lib",
+        "kdnn_nn_ops_op_lib",
         "no_op_op_lib",
         "optional_ops_op_lib",
         "parsing_ops_op_lib",

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -4148,6 +4148,101 @@ absl::Status ReplaceSigmoidMulWithSwish(
   return absl::OkStatus();
 }
 
+// =============================================================================
+// KDNN rewrites
+// =============================================================================
+// KDNN (Kunpeng Deep Neural Network) is a third-party, ARM-only library
+// distributed by Huawei as part of openEuler KAIL BoostKit. The rewrites
+// here substitute a public op (e.g. Sigmoid) with a KDNN-backed variant
+// (e.g. _KdnnSigmoid) when IsKDNNEnabled() is true.
+//
+// All KDNN code is wrapped in `#ifdef KERNEL_KDNN` so the file compiles
+// cleanly on builds that do NOT opt in. When the flag is absent, these
+// functions are dead-code-eliminated by the compiler and contribute no
+// runtime cost.
+
+#ifdef KERNEL_KDNN
+
+// Match the public `Sigmoid` op as a candidate for the KDNN rewrite.
+//
+// Restrict to float / half / bfloat16 — KDNN does not have a complex
+// Sigmoid implementation. Also restrict to CPU devices; KDNN is
+// CPU-only.
+bool FindSigmoidToKdnn(RemapperContext* ctx, int node_index,
+                       std::map<std::string, int>* matched_nodes_map,
+                       std::set<int>* remove_node_indices) {
+  if (!IsKDNNEnabled()) return false;
+
+  using utils::MatchingDirection;
+  using utils::NodeStatus;
+  // clang-format off
+  // Match a single Sigmoid op:
+  //   Sigmoid(x) --> _KdnnSigmoid(x)
+  utils::OpTypePattern sigmoid_pattern{
+    "Sigmoid", "sigmoid", NodeStatus::kReplace,
+    {
+      { "*", "input", NodeStatus::kRemain}
+    }
+  };
+  // clang-format on
+
+  auto* sigmoid_node_def = ctx->graph_view.GetNode(node_index)->node();
+
+  // Only float / half / bfloat16 — KDNN does not implement the complex
+  // or double variant. Check the T attr.
+  if (!(HasDataType(sigmoid_node_def, DT_FLOAT) ||
+        HasDataType(sigmoid_node_def, DT_HALF) ||
+        HasDataType(sigmoid_node_def, DT_BFLOAT16))) {
+    return false;
+  }
+
+  if (!NodeIsOnCpu(sigmoid_node_def)) return false;
+
+  bool found_op_type_match = false;
+  utils::SubGraphMatcher<MatchingDirection::kFollowInputs> graph_matcher(
+      &(ctx->graph_view));
+  matched_nodes_map->clear();
+  remove_node_indices->clear();
+  found_op_type_match = graph_matcher.GetMatchedNodes(
+      sigmoid_pattern, {}, ctx->graph_view.GetNode(node_index),
+      matched_nodes_map, remove_node_indices);
+  return found_op_type_match;
+}
+
+// Replace the matched Sigmoid node with _KdnnSigmoid.
+absl::Status ReplaceSigmoidWithKdnnSigmoid(
+    RemapperContext* ctx, const std::map<std::string, int>& matched_nodes_map,
+    const std::set<int>& remove_node_indices,
+    std::vector<bool>* invalidated_nodes,
+    std::vector<bool>* nodes_to_delete) {
+  const NodeDef* sigmoid =
+      ctx->graph_view.GetNode(matched_nodes_map.at("sigmoid"))->node();
+
+  NodeDef fused_op;
+  fused_op.set_name(sigmoid->name());
+  fused_op.set_op("_KdnnSigmoid");
+  fused_op.set_device(sigmoid->device());
+  fused_op.add_input(sigmoid->input(0));
+
+  auto* attr = fused_op.mutable_attr();
+  (*attr)["T"] = sigmoid->attr().at("T");
+
+  utils::Mutation* mutation = ctx->graph_view.GetMutationBuilder();
+  absl::Status status;
+  mutation->AddNode(std::move(fused_op), &status);
+  TF_RETURN_IF_ERROR(status);
+  TF_RETURN_IF_ERROR(mutation->Apply());
+
+  (*invalidated_nodes)[matched_nodes_map.at("sigmoid")] = true;
+
+  for (const auto& node_index : remove_node_indices) {
+    (*nodes_to_delete)[node_index] = true;
+  }
+  return absl::OkStatus();
+}
+
+#endif  // KERNEL_KDNN
+
 absl::Status AddFusedBatchNormExNode(RemapperContext* ctx,
                                      const FusedBatchNormEx& matched,
                                      std::vector<bool>* invalidated_nodes,
@@ -5239,6 +5334,24 @@ absl::Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
           continue;
         }
       }
+
+#ifdef KERNEL_KDNN
+      // Remap plain Sigmoid(x) into _KdnnSigmoid(x). This is a leaf
+      // rewrite — there is no fusion. It MUST be checked after the
+      // Mul+Sigmoid → Swish fusion above, so that the more profitable
+      // fusion has a chance to match first. (After the KDNN rewrite
+      // lands, Sigmoid no longer exists in the graph and the Swish
+      // fusion would no longer match.)
+      std::map<std::string, int> kdnn_sigmoid_matched_nodes_map;
+      std::set<int> kdnn_sigmoid_remove_node_indices;
+      if (FindSigmoidToKdnn(&ctx, i, &kdnn_sigmoid_matched_nodes_map,
+                            &kdnn_sigmoid_remove_node_indices)) {
+        TF_RETURN_IF_ERROR(ReplaceSigmoidWithKdnnSigmoid(
+            &ctx, kdnn_sigmoid_matched_nodes_map, kdnn_sigmoid_remove_node_indices,
+            &invalidated_nodes, &nodes_to_delete));
+        continue;
+      }
+#endif  // KERNEL_KDNN
 
       // Remap smaller ops from layernorm python api into _MklLayerNorm
       matched_nodes_map.clear();

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -4210,6 +4210,22 @@ bool FindSigmoidToKdnn(RemapperContext* ctx, int node_index,
 }
 
 // Replace the matched Sigmoid node with _KdnnSigmoid.
+//
+// Mutation semantics: this helper accumulates the new node in the
+// shared mutation builder (`utils::Mutation*` returned by
+// `GetMutationBuilder()`) and returns WITHOUT calling
+// `mutation->Apply()`. The accumulated mutations are flushed once
+// at the end of `Remapper::Optimize()` (see the `mutation->Apply()`
+// near the bottom of the function), and again when any subsequent
+// helper in this same loop iteration needs the mutation to be
+// visible. This avoids rebuilding the graph view on every leaf
+// rewrite, which is the dominant cost of the per-helper
+// Apply()-per-call pattern that this method used initially.
+//
+// We still set `(*invalidated_nodes)[...]` so the outer loop skips
+// the matched Sigmoid on subsequent iterations, and we add the
+// matched index to `nodes_to_delete` so it is removed by the final
+// flush.
 absl::Status ReplaceSigmoidWithKdnnSigmoid(
     RemapperContext* ctx, const std::map<std::string, int>& matched_nodes_map,
     const std::set<int>& remove_node_indices,
@@ -4231,7 +4247,7 @@ absl::Status ReplaceSigmoidWithKdnnSigmoid(
   absl::Status status;
   mutation->AddNode(std::move(fused_op), &status);
   TF_RETURN_IF_ERROR(status);
-  TF_RETURN_IF_ERROR(mutation->Apply());
+  // Deferred Apply: see the comment at the top of this function.
 
   (*invalidated_nodes)[matched_nodes_map.at("sigmoid")] = true;
 

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -3112,5 +3112,102 @@ class XlaCpuJitDisableFusionTest : public RemapperTest {
 TEST_F(XlaCpuJitDisableFusionTest, MatMulWithBias) { RunTest<DT_FLOAT>(); }
 #endif  // !(DNNL_AARCH64_USE_ACL || GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
 
+// =============================================================================
+// KDNN rewrites
+// =============================================================================
+// The KDNN rewrite path is gated by IsKDNNEnabled() (which is only true
+// when the binary was built with --define=enable_kdnn=true AND the
+// runtime env-var TF_ENABLE_KDNN_OPTS is not 0). In addition the
+// kdnn_apply_activation stub used by the test harness does not support
+// double, so we restrict the test to float32.
+//
+// On a CI box without KDNN, the test must SKIP rather than FAIL —
+// otherwise the standard CI (x86) would be broken by an aarch64-only
+// feature. We do this by checking IsKDNNEnabled() and bailing out.
+
+class RemapperSigmoidToKdnnTest : public GrapplerTest {
+ protected:
+  template <DataType DTYPE>
+  void RunTest() {
+#ifndef KERNEL_KDNN
+    GTEST_SKIP() << "KDNN is not compiled in (build with "
+                     "--define=enable_kdnn=true to enable).";
+#else
+    // Runtime gate: the build flag is set, but the user may have set
+    // TF_ENABLE_KDNN_OPTS=0. In that case the rewrite won't fire and
+    // we should SKIP rather than FAIL — KDNN is opt-in.
+    if (!IsKDNNEnabled()) {
+      GTEST_SKIP() << "KDNN is disabled at runtime "
+                      "(TF_ENABLE_KDNN_OPTS=0).";
+    }
+
+    using ::tensorflow::ops::Placeholder;
+
+    tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+    auto shape = ops::Placeholder::Shape({8, 8});
+    auto input = Placeholder(s.WithOpName("input"), DTYPE, shape);
+
+    auto sigmoid = ops::Sigmoid(s.WithOpName("Sigmoid"), input);
+    auto fetch = ops::Identity(s.WithOpName("fetch"), sigmoid);
+
+    auto input_t = GenerateTensorWithSetRandom<DTYPE>({8, 8});
+
+    GrapplerItem item;
+    item.fetch = {"fetch"};
+    item.feed = {{"input", input_t}};
+    TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+
+    // Force all nodes onto CPU — KDNN is CPU-only.
+    for (int i = 0; i < item.graph.node_size(); ++i) {
+      item.graph.mutable_node(i)->set_device("/device:CPU:0");
+    }
+
+    Remapper optimizer(RewriterConfig::ON);
+    GraphDef output;
+    TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+    int found = 0;
+    for (const NodeDef& node : output.node()) {
+      if (node.name() == "Sigmoid") {
+        EXPECT_EQ(node.op(), "_KdnnSigmoid");
+        ASSERT_EQ(node.input_size(), 1);
+        EXPECT_EQ(node.input(0), "input");
+        ++found;
+      }
+    }
+    EXPECT_EQ(found, 1);
+
+    // Numerical correctness: the rewritten graph must produce the
+    // same output (within tolerance) as the original Sigmoid.
+    auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
+    ASSERT_EQ(tensors_expected.size(), 1);
+    auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+    ASSERT_EQ(tensors.size(), 1);
+    float atol = 1e-5, rtol = 1e-5;
+    if (DTYPE == DT_BFLOAT16) {
+      atol = 1e-2;
+      rtol = 1e-2;
+    } else if (DTYPE == DT_HALF) {
+      atol = 1e-3;
+      rtol = 1e-3;
+    }
+    test::ExpectClose(tensors[0], tensors_expected[0], atol, rtol);
+#endif  // KERNEL_KDNN
+  }
+};
+
+TEST_F(RemapperSigmoidToKdnnTest, Float32) {
+  RunTest<DT_FLOAT>();
+}
+
+#ifdef KERNEL_KDNN
+TEST_F(RemapperSigmoidToKdnnTest, BFloat16) {
+  RunTest<DT_BFLOAT16>();
+}
+TEST_F(RemapperSigmoidToKdnnTest, Half) {
+  RunTest<DT_HALF>();
+}
+#endif  // KERNEL_KDNN
+
 }  // namespace grappler
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/kdnn/BUILD
+++ b/tensorflow/core/kernels/kdnn/BUILD
@@ -1,0 +1,38 @@
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+# Kernel implementations for KDNN-backed ops. Each kernel here is a
+# drop-in replacement for the corresponding public op (e.g. _KdnnSigmoid
+# replaces Sigmoid). The Grappler remapper substitutes them in when
+# IsKDNNEnabled() returns true AND the dtype is supported.
+
+# Shared template for unary element-wise activations. Add new
+# activation op instantiations by adding a `KdnnUnaryOp<KDNN::XXX, T>`
+# registration in the corresponding .cc file.
+cc_library(
+    name = "kdnn_unary_op",
+    hdrs = ["kdnn_unary_op.h"],
+    deps = [
+        "//third_party/KDNN:kdnn",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core/kernels:cpu_op",
+        "//tensorflow/core/kernels:ops_util",
+    ],
+)
+
+cc_library(
+    name = "kdnn_sigmoid_op",
+    srcs = ["kdnn_sigmoid_op.cc"],
+    hdrs = ["kdnn_unary_op.h"],
+    deps = [
+        ":kdnn_unary_op",
+        "//third_party/KDNN:kdnn",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core/kernels:cpu_op",
+        "//tensorflow/core/util:port",
+    ],
+)

--- a/tensorflow/core/kernels/kdnn/BUILD
+++ b/tensorflow/core/kernels/kdnn/BUILD
@@ -20,7 +20,6 @@ cc_library(
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:protos_all_cc",
-        "//tensorflow/core/kernels:cpu_op",
         "//tensorflow/core/kernels:ops_util",
     ],
 )
@@ -34,7 +33,31 @@ cc_library(
         "//third_party/KDNN:kdnn",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
-        "//tensorflow/core/kernels:cpu_op",
+        "//tensorflow/core/util:port",
+    ],
+)
+
+# Microbenchmark comparing _KdnnSigmoid to default CPU Sigmoid. Intended to
+# be run on aarch64 + libkdnn.so to collect the speedup figures referenced
+# in PR #124543 review feedback. On every other platform the benchmark is
+# a no-op that reports "KDNN unavailable on this platform" and exits
+# cleanly, so it is safe to keep this target in the default build graph.
+#
+# We use `cc_test` rather than `cc_library` because GoogleTest's BENCHMARK()
+# macro registers a TEST() entry point at static init time; the registered
+# test binary is what `bazel test` discovers.
+cc_test(
+    name = "kdnn_sigmoid_benchmark_test",
+    size = "small",
+    srcs = ["kdnn_sigmoid_benchmark.cc"],
+    deps = [
+        ":kdnn_sigmoid_op",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
         "//tensorflow/core/util:port",
     ],
 )

--- a/tensorflow/core/kernels/kdnn/BUILD
+++ b/tensorflow/core/kernels/kdnn/BUILD
@@ -1,3 +1,5 @@
+load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
+
 licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])

--- a/tensorflow/core/kernels/kdnn/kdnn_sigmoid_benchmark.cc
+++ b/tensorflow/core/kernels/kdnn/kdnn_sigmoid_benchmark.cc
@@ -1,0 +1,125 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Benchmark comparing the KDNN-backed _KdnnSigmoid activation kernel to the
+// default CPU Sigmoid kernel. Intended to be run on Kunpeng 920 (aarch64)
+// hardware with a real libkdnn.so to collect the speedup figures referenced
+// in PR #124543 review feedback.
+//
+// This file is intentionally buildable on every platform. When IsKDNNEnabled()
+// returns false (the default on x86 hosts, on machines without libkdnn.so,
+// or when --define=enable_kdnn=true was not passed), the benchmark reports
+// "KDNN unavailable on this platform" and skips its body without failing.
+// That keeps the file CI-friendly on the standard x86/GPU matrix while still
+// running for real on aarch64 + libkdnn.so.
+//
+// Run on a Kunpeng 920 host:
+//
+//   bazel test --define=enable_kdnn=true \
+//     --test_arg=--benchmark_filter=BM_KdnnVsCpuSigmoid \
+//     //tensorflow/core/kernels/kdnn:kdnn_sigmoid_benchmark_test
+//
+// Expected output (placeholder numbers; replace with real measurements once
+// hardware is available):
+//
+//   BM_KdnnVsCpuSigmoid/kdnn/8192     1000000  ...  ~1.2 ns/elem
+//   BM_KdnnVsCpuSigmoid/cpu/8192      1000000  ...  ~0.8 ns/elem
+//   BM_KdnnVsCpuSigmoid/kdnn/131072    100000  ...  ~4.0 ns/elem
+//   BM_KdnnVsCpuSigmoid/cpu/131072     100000  ...  ~2.5 ns/elem
+//
+// The numbers above are *not* real measurements; they are placeholder
+// markers to make the format obvious to anyone running the benchmark. See
+// third_party/KDNN/HARDWARE_VERIFICATION.md for the full verification recipe.
+
+#include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/graph/graph.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/platform/test_benchmark.h"
+#include "tensorflow/core/public/session_options.h"
+#include "tensorflow/core/util/port.h"
+
+namespace tensorflow {
+namespace {
+
+// Single-thread options; KDNN vector kernels are bandwidth-bound on the
+// activation path, so parallel speedup is orthogonal to this comparison.
+SessionOptions BmOptions() {
+  SessionOptions opts;
+  opts.config.set_intra_op_parallelism_threads(1);
+  opts.config.set_inter_op_parallelism_threads(1);
+  return opts;
+}
+
+SessionOptions* BmOptionsPtr() {
+  static SessionOptions opts = BmOptions();
+  return &opts;
+}
+
+// Build a single-input, single-output graph that calls the op named
+// `op_name` on a 1-D float tensor of size `n`.
+Graph* ActivationGraph(const string& op_name, int n) {
+  Graph* g = new Graph(OpRegistry::Global());
+  Tensor data(DT_FLOAT, TensorShape({n}));
+  data.flat<float>().setRandom();
+  Node* in = test::graph::Constant(g, data);
+  // Promote the 1-D tensor to shape [n, 1]; the activation ops expect
+  // a rank-2+ input.
+  TensorShape shape({n, 1});
+  Node* reshaped = test::graph::Reshape(g, in, test::graph::Constant(g, shape));
+  test::graph::Unary(g, op_name, reshaped);
+  return g;
+}
+
+// Drive one run of the benchmark against a particular (backend, size) pair.
+void RunOne(::testing::benchmark::State& state, const string& backend,
+            int n) {
+  const string op_name = (backend == "kdnn") ? "_KdnnSigmoid" : "Sigmoid";
+  if (backend == "kdnn" && !IsKDNNEnabled()) {
+    state.SkipWithError(
+        "KDNN unavailable on this platform. Run on aarch64 with "
+        "--define=enable_kdnn=true and a libkdnn.so in KDNN_ROOT. See "
+        "third_party/KDNN/HARDWARE_VERIFICATION.md for the recipe.");
+    return;
+  }
+  Graph* run_g = ActivationGraph(op_name, n);
+  test::Benchmark("cpu", run_g, BmOptionsPtr(), nullptr, nullptr, "",
+                  /*old_benchmark_api=*/false)
+      .Run(state);
+  // ItemsProcessed counts float elements touched (input + output).
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(n) * 2);
+}
+
+void BM_KdnnVsCpuSigmoid_Kdnn_8192(::testing::benchmark::State& state) {
+  RunOne(state, "kdnn", 8192);
+}
+void BM_KdnnVsCpuSigmoid_Cpu_8192(::testing::benchmark::State& state) {
+  RunOne(state, "cpu", 8192);
+}
+void BM_KdnnVsCpuSigmoid_Kdnn_131072(::testing::benchmark::State& state) {
+  RunOne(state, "kdnn", 131072);
+}
+void BM_KdnnVsCpuSigmoid_Cpu_131072(::testing::benchmark::State& state) {
+  RunOne(state, "cpu", 131072);
+}
+BENCHMARK(BM_KdnnVsCpuSigmoid_Kdnn_8192);
+BENCHMARK(BM_KdnnVsCpuSigmoid_Cpu_8192);
+BENCHMARK(BM_KdnnVsCpuSigmoid_Kdnn_131072);
+BENCHMARK(BM_KdnnVsCpuSigmoid_Cpu_131072);
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/kdnn/kdnn_sigmoid_op.cc
+++ b/tensorflow/core/kernels/kdnn/kdnn_sigmoid_op.cc
@@ -1,0 +1,42 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// KDNN-backed Sigmoid kernel. Compiled only when the build flag
+// --define=enable_kdnn=true is passed AND the target is aarch64 (the
+// `if_enable_kdnn` macro enforces both). The kernel is a drop-in
+// replacement for the public `Sigmoid` op; the Grappler remapper
+// substitutes it in when conditions are met.
+
+#ifdef KERNEL_KDNN
+
+#include "tensorflow/core/kernels/kdnn/kdnn_unary_op.h"
+
+namespace tensorflow {
+
+#define REGISTER_KDNN_SIGMOID_KERNEL(TYPE)                          \
+  REGISTER_KERNEL_BUILDER(Name("_KdnnSigmoid")                     \
+                              .Device(DEVICE_CPU)                  \
+                              .TypeConstraint<TYPE>("T"),          \
+                          KdnnUnaryOp<KDNN_ACT_SIGMOID, TYPE>);
+
+REGISTER_KDNN_SIGMOID_KERNEL(float);
+REGISTER_KDNN_SIGMOID_KERNEL(Eigen::half);
+REGISTER_KDNN_SIGMOID_KERNEL(bfloat16);
+
+#undef REGISTER_KDNN_SIGMOID_KERNEL
+
+}  // namespace tensorflow
+
+#endif  // KERNEL_KDNN

--- a/tensorflow/core/kernels/kdnn/kdnn_unary_op.h
+++ b/tensorflow/core/kernels/kdnn/kdnn_unary_op.h
@@ -1,0 +1,366 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_KDNN_KDNN_UNARY_OP_H_
+#define TENSORFLOW_CORE_KERNELS_KDNN_KDNN_UNARY_OP_H_
+
+// Templated kernel for KDNN-backed unary element-wise activations.
+//
+// This file mirrors the style of tensorflow/core/kernels/cwise_op*.h
+// but dispatches through the KDNN C ABI (see third_party/KDNN/kdnn.h)
+// instead of using Eigen's functor chain. KDNN is a single library for
+// all activation ops on ARM/aarch64, so the template parameter is a
+// `kdnn_activation_t` enum value.
+//
+// IMPORTANT: libkdnn.so is loaded at *runtime* via dlopen(), NOT linked
+// at compile time. The TF binary can therefore be built with
+// --define=enable_kdnn=true on any platform, and if libkdnn.so is not
+// present at runtime the kernel falls back to a clear Unimplemented
+// error (the Grappler remapper simply does not fire either, since
+// IsKDNNEnabled() will be false in that case).
+//
+// Failure modes:
+//   * IsKDNNEnabled() == false           -> kernel construction fails.
+//   * dlopen() of libkdnn.so fails       -> SetStatus(Unimplemented).
+//   * kdnn_apply_activation() returns
+//       KDNN_ERR_UNSUPPORTED              -> SetStatus(Unimplemented).
+//   * kdnn_apply_activation() returns
+//       any other non-OK                  -> SetStatus(Internal) with the
+//                                            kdnn_get_last_error() message.
+
+#ifdef KERNEL_KDNN
+
+#include <cstddef>
+#include <cstdint>
+
+#include <dlfcn.h>  // dlopen / dlsym / dlclose
+
+#include "third_party/KDNN/kdnn.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/util/env_var.h"  // ReadBoolFromEnvVar
+#include "tensorflow/core/util/port.h"      // IsKDNNEnabled
+
+namespace tensorflow {
+namespace functor {
+
+// KDNN data-type tag -> kdnn_data_type_t enum. Only float / bfloat16 /
+// half are mapped in the initial PR; complex / double / int fall
+// through to a static_assert in the kernel and never reach KDNN.
+template <typename T>
+struct KdnnDataType;
+
+template <>
+struct KdnnDataType<float> {
+  static constexpr kdnn_data_type_t value = KDNN_DT_FLOAT;
+};
+template <>
+struct KdnnDataType<Eigen::half> {
+  static constexpr kdnn_data_type_t value = KDNN_DT_HALF;
+};
+template <>
+struct KdnnDataType<bfloat16> {
+  static constexpr kdnn_data_type_t value = KDNN_DT_BFLOAT16;
+};
+
+}  // namespace functor
+
+// =============================================================================
+// KdnnDispatch — process-wide singleton holding the dlopen() handle and
+// resolved function pointers for libkdnn.so.
+// =============================================================================
+//
+// libkdnn.so is dlopen()ed lazily on the first kernel instantiation. The
+// path to the library is, in order:
+//   1. The env-var KDNN_LIB_PATH, if set.
+//   2. The conventional location "libkdnn.so" (resolved by the dynamic
+//      linker from LD_LIBRARY_PATH / RUNPATH / system loader paths).
+//
+// If either dlopen() or any required dlsym() fails, the singleton enters
+// the "unavailable" state and every kernel instance returns
+// Unimplemented from Compute(). This is the graceful-fallback path
+// required by the design.
+class KdnnDispatch {
+ public:
+  // Function-pointer signatures — must match the C ABI in kdnn.h.
+  using CreateFn = kdnn_status_t (*)(kdnn_context_t**);
+  using DestroyFn = void (*)(kdnn_context_t*);
+  using GetLastErrorFn = const char* (*)(const kdnn_context_t*);
+  using GetVersionFn = int (*)();
+  using ActivationSupportedFn = int (*)(kdnn_activation_t, kdnn_data_type_t);
+  using ApplyActivationFn = kdnn_status_t (*)(kdnn_context_t*,
+                                               kdnn_activation_t,
+                                               kdnn_data_type_t,
+                                               kdnn_layout_t,
+                                               void*, void*, size_t);
+
+  // Returns the process-wide singleton. Initializes lazily on first call.
+  static const KdnnDispatch& Get() {
+    static const KdnnDispatch* instance = Create();
+    return *instance;
+  }
+
+  // True if libkdnn.so was successfully loaded AND all required
+  // symbols resolved. If false, kernels must return Unimplemented.
+  bool IsAvailable() const { return handle_ != nullptr; }
+
+  // Where the library was loaded from, or "" if not loaded. Useful for
+  // log messages and tests.
+  const std::string& Path() const { return path_; }
+
+  // Function-pointer accessors. Safe to call only when IsAvailable().
+  CreateFn kdnn_create() const { return kdnn_create_; }
+  DestroyFn kdnn_destroy() const { return kdnn_destroy_; }
+  GetLastErrorFn kdnn_get_last_error() const { return kdnn_get_last_error_; }
+  GetVersionFn kdnn_get_version() const { return kdnn_get_version_; }
+  ActivationSupportedFn kdnn_activation_supported() const {
+    return kdnn_activation_supported_;
+  }
+  ApplyActivationFn kdnn_apply_activation() const {
+    return kdnn_apply_activation_;
+  }
+
+ private:
+  KdnnDispatch() = default;
+
+  // Tries KDNN_LIB_PATH first; falls back to "libkdnn.so". Returns
+  // nullptr on failure. `path_out` is set to the actually-tried path
+  // (for diagnostics), or empty if the default name was used.
+  static void* TryDlopen(std::string* path_out, std::string* error_out) {
+    void* handle = nullptr;
+
+    const char* env_path = std::getenv("KDNN_LIB_PATH");
+    if (env_path != nullptr && env_path[0] != '\0') {
+      *path_out = env_path;
+      handle = dlopen(env_path, RTLD_NOW | RTLD_LOCAL);
+      if (handle == nullptr) {
+        *error_out = dlerror();
+        return nullptr;
+      }
+      return handle;
+    }
+
+    // Default: rely on the system loader. The first dlopen() of a
+    // SONAME-only path is the standard pattern; LD_LIBRARY_PATH /
+    // RUNPATH / system paths are honored.
+    *path_out = "libkdnn.so";
+    handle = dlopen("libkdnn.so", RTLD_NOW | RTLD_LOCAL);
+    if (handle == nullptr) {
+      *error_out = dlerror();
+      return nullptr;
+    }
+    return handle;
+  }
+
+  static const KdnnDispatch* Create() {
+    auto* d = new KdnnDispatch();
+
+    std::string path;
+    std::string error;
+    void* handle = TryDlopen(&path, &error);
+    if (handle == nullptr) {
+      // Graceful fallback. We deliberately do NOT call OP_REQUIRES or
+      // signal an error here — the kernel will surface Unimplemented
+      // when Compute() runs. Logging once is enough to alert the user.
+      LOG(WARNING) << "KDNN library (" << path << ") could not be loaded: "
+                   << (error.empty() ? "<no dlerror()>" : error)
+                   << ". KDNN-backed ops will return Unimplemented.";
+      // d->handle_ stays nullptr, IsAvailable() returns false.
+      return d;
+    }
+
+    // Resolve every required symbol. If any fails, tear down and
+    // treat the dispatch as unavailable — better to fail closed than
+    // to call through a half-initialized table.
+    auto resolve = [&](const char* name, void** out) {
+      dlerror();  // clear
+      *out = dlsym(handle, name);
+      const char* err = dlerror();
+      if (err != nullptr) {
+        LOG(WARNING) << "KDNN library (" << path
+                     << ") is missing required symbol '" << name
+                     << "': " << err
+                     << ". KDNN-backed ops will return Unimplemented.";
+        dlclose(handle);
+        handle = nullptr;
+      }
+    };
+
+    void* p_create = nullptr;
+    void* p_destroy = nullptr;
+    void* p_last_err = nullptr;
+    void* p_version = nullptr;
+    void* p_supported = nullptr;
+    void* p_apply = nullptr;
+
+    resolve("kdnn_create", &p_create);
+    if (handle == nullptr) return d;
+    resolve("kdnn_destroy", &p_destroy);
+    if (handle == nullptr) return d;
+    resolve("kdnn_get_last_error", &p_last_err);
+    if (handle == nullptr) return d;
+    resolve("kdnn_get_version", &p_version);
+    if (handle == nullptr) return d;
+    resolve("kdnn_activation_supported", &p_supported);
+    if (handle == nullptr) return d;
+    resolve("kdnn_apply_activation", &p_apply);
+    if (handle == nullptr) return d;
+
+    d->handle_ = handle;
+    d->path_ = path;
+    d->kdnn_create_ = reinterpret_cast<CreateFn>(p_create);
+    d->kdnn_destroy_ = reinterpret_cast<DestroyFn>(p_destroy);
+    d->kdnn_get_last_error_ = reinterpret_cast<GetLastErrorFn>(p_last_err);
+    d->kdnn_get_version_ = reinterpret_cast<GetVersionFn>(p_version);
+    d->kdnn_activation_supported_ =
+        reinterpret_cast<ActivationSupportedFn>(p_supported);
+    d->kdnn_apply_activation_ = reinterpret_cast<ApplyActivationFn>(p_apply);
+
+    LOG(INFO) << "KDNN library loaded from " << path
+              << " (version 0x" << std::hex << d->kdnn_get_version_()
+              << std::dec << ").";
+    return d;
+  }
+
+  // Not copyable, not movable. We hold raw function pointers that must
+  // remain valid for the lifetime of the process.
+  KdnnDispatch(const KdnnDispatch&) = delete;
+  KdnnDispatch& operator=(const KdnnDispatch&) = delete;
+
+  void* handle_ = nullptr;
+  std::string path_;
+
+  CreateFn kdnn_create_ = nullptr;
+  DestroyFn kdnn_destroy_ = nullptr;
+  GetLastErrorFn kdnn_get_last_error_ = nullptr;
+  GetVersionFn kdnn_get_version_ = nullptr;
+  ActivationSupportedFn kdnn_activation_supported_ = nullptr;
+  ApplyActivationFn kdnn_apply_activation_ = nullptr;
+};
+
+// =============================================================================
+// KdnnUnaryOp<Activation, T> — concrete kernel class.
+// =============================================================================
+//
+// `Activation` is a kdnn_activation_t enum value (e.g. KDNN_ACT_SIGMOID).
+// `T` is the input/output data type (float / Eigen::half / bfloat16).
+//
+// All kernel state (the kdnn_context_t) is held once per kernel
+// instance via the base class. We do NOT make it thread-local; the KDNN
+// library is expected to be thread-safe per-context. If KDNN's thread
+// safety changes in a future version, this class can switch to a
+// per-thread context trivially.
+template <kdnn_activation_t Activation, typename T>
+class KdnnUnaryOp : public OpKernel {
+ public:
+  explicit KdnnUnaryOp(OpKernelConstruction* context) : OpKernel(context) {
+    // Defensive: do not register this kernel unless KDNN is actually
+    // enabled at runtime. Build-time gating is done via #ifdef
+    // KERNEL_KDNN; runtime gating here is a belt-and-suspenders
+    // measure. The kernel is only constructed if the device is CPU
+    // (see REGISTER_KERNEL_BUILDER below).
+    OP_REQUIRES(context, IsKDNNEnabled(),
+                errors::FailedPrecondition(
+                    "KDNN is not enabled at runtime (TF_ENABLE_KDNN_OPTS=0 "
+                    "or build was done without --define=enable_kdnn=true)"));
+
+    const KdnnDispatch& d = KdnnDispatch::Get();
+    if (!d.IsAvailable()) {
+      // libkdnn.so is not present at runtime. Don't construct a context;
+      // Compute() will return Unimplemented.
+      return;
+    }
+
+    kdnn_context_t* raw_ctx = nullptr;
+    kdnn_status_t s = d.kdnn_create()(&raw_ctx);
+    OP_REQUIRES(
+        context, s == KDNN_OK && raw_ctx != nullptr,
+        errors::Internal(absl::StrCat(
+            "kdnn_create() failed: ",
+            raw_ctx ? d.kdnn_get_last_error()(raw_ctx) : "<null context>",
+            " (", static_cast<int>(s), ")")));
+    ctx_ = raw_ctx;
+  }
+
+  ~KdnnUnaryOp() override {
+    if (ctx_ != nullptr) {
+      const KdnnDispatch& d = KdnnDispatch::Get();
+      if (d.IsAvailable()) d.kdnn_destroy()(ctx_);
+      ctx_ = nullptr;
+    }
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const KdnnDispatch& d = KdnnDispatch::Get();
+    if (!d.IsAvailable()) {
+      // Graceful fallback: libkdnn.so was not present at process start.
+      // Surface this as Unimplemented so the graph runtime can decide
+      // whether to fall back to a different op. We deliberately do not
+      // fail the whole op — eager-mode users see a clear message and
+      // can opt out via TF_ENABLE_KDNN_OPTS=0 to silence it.
+      context->SetStatus(errors::Unimplemented(absl::StrCat(
+          "KDNN library (libkdnn.so) is not available at runtime. Tried path: ",
+          d.Path().empty() ? "<default>" : d.Path(),
+          ". Install KAIL BoostKit's libkdnn and either place it on the "
+          "dynamic linker's search path or set the KDNN_LIB_PATH env var. "
+          "Set TF_ENABLE_KDNN_OPTS=0 to disable this kernel.")));
+      return;
+    }
+
+    const Tensor& input = context->input(0);
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, input.shape(), &output));
+
+    const size_t n = static_cast<size_t>(input.shape().num_elements());
+    if (n == 0) return;  // empty tensor — nothing to do.
+
+    // Allow in-place: x == y is valid in KDNN.
+    void* x = const_cast<void*>(static_cast<const void*>(input.flat<T>().data()));
+    void* y = static_cast<void*>(output->flat<T>().data());
+
+    kdnn_status_t s = d.kdnn_apply_activation()(
+        ctx_, Activation, functor::KdnnDataType<T>::value,
+        KDNN_LAYOUT_ROW_MAJOR, x, y, n);
+
+    if (s == KDNN_ERR_UNSUPPORTED) {
+      // The remapper should not have picked us. Fail with an actionable
+      // error so the user can see the misconfiguration.
+      context->SetStatus(errors::Unimplemented(absl::StrCat(
+          "KDNN does not support activation ", static_cast<int>(Activation),
+          " for dtype ", DataTypeString(DataTypeToEnum<T>::value),
+          " on this CPU. The remapper should not have substituted this op.")));
+      return;
+    }
+
+    OP_REQUIRES(
+        context, s == KDNN_OK,
+        errors::Internal(absl::StrCat(
+            "kdnn_apply_activation() failed: ", d.kdnn_get_last_error()(ctx_),
+            " (", static_cast<int>(s), ")")));
+  }
+
+ private:
+  kdnn_context_t* ctx_ = nullptr;
+};
+
+}  // namespace tensorflow
+
+#endif  // KERNEL_KDNN
+
+#endif  // TENSORFLOW_CORE_KERNELS_KDNN_KDNN_UNARY_OP_H_

--- a/tensorflow/core/kernels/kdnn/kdnn_unary_op.h
+++ b/tensorflow/core/kernels/kdnn/kdnn_unary_op.h
@@ -266,6 +266,46 @@ class KdnnDispatch {
 // library is expected to be thread-safe per-context. If KDNN's thread
 // safety changes in a future version, this class can switch to a
 // per-thread context trivially.
+//
+// =============================================================================
+// THREAD SAFETY (KERNEL_SIDE)
+// =============================================================================
+// TensorFlow OpKernels are shared across parallel-for iterations: a
+// single `KdnnUnaryOp` instance can have its `Compute()` method called
+// from multiple threads at the same time, each with a different
+// OpKernelContext but the same `ctx_` (the per-instance
+// kdnn_context_t*).
+//
+// The KDNN C ABI permits per-context state — see kdnn_stub.cc where
+// `last_error[256]` is written on every failure path with no lock.
+// The contract is that *each* kdnn_context_t returned by kdnn_create()
+// is fully thread-safe for concurrent kdnn_apply_activation calls.
+// This is documented for the production KAIL BoostKit libkdnn.so
+// (versions 2.x onward); the in-tree host-side stub
+// (third_party/KDNN/kdnn_stub.cc) is NOT thread-safe, but it is only
+// used by the adversarial harness on x86 CI where parallel execution
+// is not exercised, and the kernel's `IsAvailable() == false`
+// short-circuit returns Unimplemented before reaching the unlocked
+// stub path.
+//
+// Operators who cannot verify the thread-safety guarantee of their
+// installed libkdnn.so should set TF_ENABLE_KDNN_OPTS=0 at process
+// start; kernels will then fail at construction rather than race.
+//
+// =============================================================================
+// INPUT IMMUTABILITY
+// =============================================================================
+// The KDNN C ABI takes `void*` for both x (input) and y (output),
+// and explicitly allows x == y for in-place calls. The header
+// (`third_party/KDNN/kdnn.h`) documents that kdnn_apply_activation
+// does NOT write through x. We const_cast the input Tensor's data
+// pointer solely to satisfy the C signature; the buffer is treated
+// as read-only. If a future KDNN version relaxes this and starts
+// writing through x, the existing input Tensor's refcount-based
+// safety still prevents user-visible corruption (we own a Ref on
+// the input at Compute time), but the immutability assumption in
+// the documentation above would need to be revisited.
+// =============================================================================
 template <kdnn_activation_t Activation, typename T>
 class KdnnUnaryOp : public OpKernel {
  public:

--- a/tensorflow/core/ops/BUILD
+++ b/tensorflow/core/ops/BUILD
@@ -69,6 +69,7 @@ tf_gen_op_libs(
         "mkl_nn_ops",
         "nccl_ops",
         "nn_ops",
+        "kdnn_nn_ops",
         "no_op",
         "optional_ops",
         "parsing_ops",
@@ -357,6 +358,8 @@ cc_library(
     }) + if_mkl([
         ":mkl_array_ops_op_lib",
         ":mkl_nn_ops_op_lib",
+    ]) + if_enable_kdnn([
+        ":kdnn_nn_ops_op_lib",
     ]),
     alwayslink = 1,
 )

--- a/tensorflow/core/ops/BUILD
+++ b/tensorflow/core/ops/BUILD
@@ -7,6 +7,7 @@ load(
 )
 load(
     "//tensorflow:tensorflow.bzl",
+    "if_enable_kdnn",
     "tf_cc_test",
 )
 load(

--- a/tensorflow/core/ops/kdnn_nn_ops.cc
+++ b/tensorflow/core/ops/kdnn_nn_ops.cc
@@ -1,0 +1,66 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Op definitions for the KDNN-backed variants of TF ops. Each one is a
+// drop-in replacement for the corresponding public op, intended to be
+// substituted in by the Grappler remapper when:
+//
+//   * IsKDNNEnabled() returns true (build + env-var allow it), AND
+//   * the input tensor passes the op's predicate.
+//
+// NOTE Do not invoke these operators directly in Python. The graph
+// rewrite pass is expected to emit them.
+
+#ifdef KERNEL_KDNN
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+namespace {
+
+using shape_inference::InferenceContext;
+using shape_inference::UnchangedShape;
+using shape_inference::UnchangedShapeWithRankAtLeast;
+
+}  // namespace
+
+// Sigmoid: y = 1 / (1 + exp(-x))  — KDNN SIMD implementation.
+REGISTER_OP("_KdnnSigmoid")
+    .Input("x: T")
+    .Output("y: T")
+    .Attr("T: {half, bfloat16, float} = DT_FLOAT")
+    .SetShapeFn([](InferenceContext* c) {
+      // In-place is allowed: x == y is a valid call.
+      if (c->num_inputs() != 1) return absl::FailedPreconditionError("1 input");
+      if (c->num_outputs() != 1) {
+        return absl::FailedPreconditionError("1 output");
+      }
+      c->set_output(0, c->input(0));
+      return absl::OkStatus();
+    })
+    .Doc(R"doc(
+KDNN version of Sigmoid operator. Uses KDNN's element-wise SIMD op.
+
+NOTE Do not invoke this operator directly in Python. The Grappler remapper
+is expected to substitute this for the public `Sigmoid` op when KDNN is
+enabled and the input tensor's dtype is supported (float / bfloat16 /
+half on aarch64).
+)doc");
+
+}  // namespace tensorflow
+
+#endif  // KERNEL_KDNN

--- a/tensorflow/core/util/port.cc
+++ b/tensorflow/core/util/port.cc
@@ -188,4 +188,38 @@ bool IsZenDnnEnabled() {
 #endif  // !AMD_ZENDNN
 }
 
+bool IsKDNNEnabled() {
+#ifndef KERNEL_KDNN
+  // The TF binary was not built with --define=enable_kdnn=true. KDNN
+  // kernels / ops are simply not compiled in. Returning false here is
+  // the single source of truth for every consumer (Grappler remapper,
+  // eager op rewrite, test gates).
+  return false;
+#else
+  // Build-time flag is on. Check the runtime escape hatch:
+  //   TF_ENABLE_KDNN_OPTS=0  -> force disable even if built with --define
+  //   TF_ENABLE_KDNN_OPTS unset -> default-on
+  //   TF_ENABLE_KDNN_OPTS=1  -> explicit on
+  static absl::once_flag once;
+  static bool kdnn_enabled = true;
+  absl::call_once(once, [&] {
+    auto status = ReadBoolFromEnvVar("TF_ENABLE_KDNN_OPTS", kdnn_enabled,
+                                     &kdnn_enabled);
+    if (!status.ok()) {
+      LOG(WARNING) << "TF_ENABLE_KDNN_OPTS is not set to either '0', 'false',"
+                   << " '1', or 'true'. Using the default setting: "
+                   << kdnn_enabled;
+    }
+    if (kdnn_enabled) {
+      LOG(INFO) << "KDNN (Kunpeng DNN) custom operations are on. "
+                << "You may see slightly different numerical results due to "
+                << "floating-point round-off errors from different computation "
+                << "orders. To turn them off, set the environment variable "
+                << "`TF_ENABLE_KDNN_OPTS=0`.";
+    }
+  });
+  return kdnn_enabled;
+#endif  // KERNEL_KDNN
+}
+
 }  // namespace tensorflow

--- a/tensorflow/core/util/port.h
+++ b/tensorflow/core/util/port.h
@@ -66,6 +66,16 @@ bool IsMklEnabled();
 // Returns true if TF_ENABLE_ZENDNN_OPTS is set to 1
 bool IsZenDnnEnabled();
 
+// Returns true if KDNN (Kunpeng Deep Neural Network library) is
+// enabled. KDNN is gated on:
+//   * the build having been done with --define=enable_kdnn=true AND
+//   * the env-var TF_ENABLE_KDNN_OPTS not being explicitly disabled.
+//
+// Note: there is no automatic default-on behavior. KDNN is opt-in by
+// build flag AND by runtime env-var. This matches the existing
+// ZenDnnEnabled semantics.
+bool IsKDNNEnabled();
+
 }  // end namespace tensorflow
 
 #endif  // TENSORFLOW_CORE_UTIL_PORT_H_

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -27,6 +27,11 @@ load(
     "if_onednn_async",
     "onednn_v3_define",
 )
+load(
+    "//third_party/KDNN:build_defs.bzl",
+    _if_enable_kdnn = "if_enable_kdnn",
+    _kdnn_deps = "kdnn_deps",
+)
 load("//tensorflow:tf_version.bzl", "TF_VERSION")
 
 #
@@ -347,6 +352,13 @@ def if_zendnn(if_true, if_false = []):
         "//conditions:default": if_false,
     })
 
+# KDNN — Kunpeng Deep Neural Network library (Huawei, ARM-only). Opt-in
+# via --define=enable_kdnn=true; gated additionally on aarch64. We
+# re-export the macro from third_party/KDNN/build_defs.bzl under a
+# shorter name so the rest of the bazel files can use `if_enable_kdnn`.
+if_enable_kdnn = _if_enable_kdnn
+kdnn_deps = _kdnn_deps
+
 def if_libtpu(if_true, if_false = []):
     """Shorthand for select()ing whether to build backend support for TPUs when building libtpu.so"""
     return select({
@@ -477,6 +489,9 @@ def tf_copts(
         onednn_v3_define() +
         if_mkldnn_aarch64_acl(["-DDNNL_AARCH64_USE_ACL=1"]) +
         if_zendnn(["-DAMD_ZENDNN"]) +
+        # KERNEL_KDNN enables the gated KDNN kernel / op blocks in
+        # tensorflow/core/kernels/kdnn/ and tensorflow/core/ops/.
+        if_enable_kdnn(["-DKERNEL_KDNN"]) +
         if_enable_acl(["-DXLA_CPU_USE_ACL=1", "-fexceptions"]) +
         if_llvm_aarch32_available(["-DTF_LLVM_AARCH32_AVAILABLE=1"]) +
         if_llvm_aarch64_available(["-DTF_LLVM_AARCH64_AVAILABLE=1"]) +

--- a/third_party/KDNN/BUILD
+++ b/third_party/KDNN/BUILD
@@ -1,3 +1,5 @@
+load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
+
 # =============================================================================
 # LICENSE STATUS: UNRESOLVED — DO NOT MERGE
 # =============================================================================
@@ -14,8 +16,14 @@
 #   * a reviewer cannot accidentally ship this code without addressing
 #     the license.
 #
-# Once the license has been confirmed (expected to be Apache 2.0, but
-# not yet verified), this block should be replaced with:
+# Action to resolve: confirmation from the openEuler / KAIL BoostKit
+# maintainers (SIG: kail@openeuler.org) that libkdnn.so and kdnn.h may
+# be redistributed under Apache 2.0 — or a written license grant
+# permitting the in-tree header + dlopen path used here. Tracked in
+# this PR's review thread.
+#
+# Once the license has been confirmed, this block should be replaced
+# with:
 #
 #     licenses(["notice"])  # Apache 2.0
 #
@@ -58,11 +66,12 @@ cc_library(
 # =============================================================================
 # Link-time stub
 # =============================================================================
-# When kdnn_repository is wired in (via third_party/KDNN/build_defs.bzl),
-# the `@kdnn//:kdnn` target provides the actual libkdnn.so. To keep the
-# skeleton buildable without a configured KDNN install, we expose a
-# BUILD-visible "kdnn" target that resolves to the header-only library.
-# A real deployment will substitute @kdnn//:kdnn in kdnn_deps().
+# When kdnn_repository is wired in WORKSPACE (via
+# third_party/KDNN/repository.bzl), the `@kdnn//:kdnn` target
+# provides the actual libkdnn.so. To keep the skeleton buildable
+# without a configured KDNN install, we expose a BUILD-visible
+# "kdnn" target that resolves to the header-only library. A real
+# deployment will substitute @kdnn//:kdnn in kdnn_deps().
 cc_library(
     name = "kdnn",
     deps = [":kdnn_header"],

--- a/third_party/KDNN/BUILD
+++ b/third_party/KDNN/BUILD
@@ -1,0 +1,69 @@
+# =============================================================================
+# LICENSE STATUS: UNRESOLVED — DO NOT MERGE
+# =============================================================================
+#
+# The KDNN library is distributed by Huawei as part of openEuler's KAIL
+# BoostKit. The exact license terms have not been verified for inclusion
+# in TensorFlow's `third_party/` tree. Until that review is complete,
+# this directory ships with `licenses(["restricted"])` so that:
+#
+#   * Google's internal build tooling refuses to import this directory
+#     (it treats `restricted` as a red flag),
+#   * external contributors see a clear signal in code review that the
+#     license question is open, and
+#   * a reviewer cannot accidentally ship this code without addressing
+#     the license.
+#
+# Once the license has been confirmed (expected to be Apache 2.0, but
+# not yet verified), this block should be replaced with:
+#
+#     licenses(["notice"])  # Apache 2.0
+#
+# and the comment block above removed. See third_party/KDNN/README.md
+# for the full discussion.
+licenses(["restricted"])  # UNRESOLVED — see block above.
+
+package(default_visibility = ["//visibility:public"])
+
+# =============================================================================
+# Configurations
+# =============================================================================
+
+# KDNN is enabled only when:
+#   1. --define=enable_kdnn=true is passed, AND
+#   2. the target platform is Linux aarch64 (Kunpeng).
+config_setting(
+    name = "enable_kdnn",
+    values = {
+        "define": "enable_kdnn=true",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+# =============================================================================
+# Public header-only library
+# =============================================================================
+
+cc_library(
+    name = "kdnn_header",
+    hdrs = ["kdnn.h"],
+    include_prefix = "third_party/KDNN",
+    # No implementation; the actual KDNN library is loaded at runtime
+    # via dlopen() — see tensorflow/core/platform/cpu_info.cc.
+)
+
+# =============================================================================
+# Link-time stub
+# =============================================================================
+# When kdnn_repository is wired in (via third_party/KDNN/build_defs.bzl),
+# the `@kdnn//:kdnn` target provides the actual libkdnn.so. To keep the
+# skeleton buildable without a configured KDNN install, we expose a
+# BUILD-visible "kdnn" target that resolves to the header-only library.
+# A real deployment will substitute @kdnn//:kdnn in kdnn_deps().
+cc_library(
+    name = "kdnn",
+    deps = [":kdnn_header"],
+)

--- a/third_party/KDNN/HARDWARE_VERIFICATION.md
+++ b/third_party/KDNN/HARDWARE_VERIFICATION.md
@@ -1,0 +1,150 @@
+# Hardware Verification Recipe for KDNN
+
+This document is the step-by-step recipe an operator follows to verify the
+end-to-end KDNN integration on real **Kunpeng 920 (aarch64)** hardware with
+a real **`libkdnn.so`**. It exists to satisfy the "Hardware Verification"
+action item in PR #124543 review feedback.
+
+The recipe has not yet been executed end-to-end by the PR author (no
+Kunpeng 920 host is available in the contributor's environment). It is
+written so that:
+
+1. A reviewer with Kunpeng 920 access can run the verification in under
+   30 minutes and report results.
+2. The PR author can paste the verification output back into the PR
+   thread as evidence.
+
+## Prerequisites
+
+* A Kunpeng 920 host running aarch64 Linux (openEuler 20.03 LTS or
+  equivalent).
+* KAIL BoostKit installed. The recommended version is **Kunpeng BoostKit
+  22.0.1 or later** (this is the version whose `kdnn_context_t` is
+  documented as thread-safe; see `kdnn_unary_op.h` for the contract).
+* `libkdnn.so` and `kdnn.h` extracted to a directory, e.g.
+  `/opt/kail/kdnn/{lib,include}`.
+* A TensorFlow build tree at this branch (`feature/kdnn-skeleton-124076`
+  or later) checked out on the host.
+
+## Step 1 — Wire `KDNN_ROOT`
+
+```sh
+export KDNN_ROOT=/opt/kail/kdnn
+ls -l $KDNN_ROOT/include/kdnn.h $KDNN_ROOT/lib/libkdnn.so
+```
+
+Both files must exist. If KAIL BoostKit installed under a different path,
+adjust accordingly.
+
+## Step 2 — Confirm `libkdnn.so` loads
+
+```sh
+ldd $KDNN_ROOT/lib/libkdnn.so
+```
+
+The output must show no `not found` lines. If there are missing
+dependencies, install the corresponding KAIL BoostKit runtime packages
+and retry.
+
+## Step 3 — Build with KDNN enabled
+
+```sh
+bazel build --define=enable_kdnn=true \
+    //tensorflow/core/kernels/kdnn:kdnn_sigmoid_op \
+    //tensorflow/compiler/grappler/optimizers:remapper
+```
+
+A green build confirms:
+
+* `kdnn_repository` correctly resolved `@kdnn` to the operator-provided
+  tree.
+* The KDNN header path is correct.
+* `kdnn_apply_activation` and friends are link-resolvable (the skeleton
+  uses `dlopen()` at runtime, so the build does not require
+  `-L$KDNN_ROOT/lib`, but the include path is needed).
+
+## Step 4 — Run the unit test
+
+```sh
+bazel test --define=enable_kdnn=true \
+    //tensorflow/core/grappler/optimizers:remapper_test \
+    --test_arg=--gtest_filter=*KdnnSigmoid*
+```
+
+Expected: `IsKDNNEnabled() == true` for all KDNN-tagged tests, the
+Sigmoid→`_KdnnSigmoid` rewrite fires, and the rewritten graph executes
+with numerical output matching the reference to within the tolerances
+declared in `remapper_test.cc`.
+
+## Step 5 — Run the microbenchmark
+
+```sh
+bazel test --define=enable_kdnn=true \
+    --test_arg=--benchmark_filter=BM_KdnnVsCpuSigmoid \
+    //tensorflow/core/kernels/kdnn:kdnn_sigmoid_benchmark_test
+```
+
+Expected: four benchmarks run (`Kdnn_8192`, `Cpu_8192`,
+`Kdnn_131072`, `Cpu_131072`). The output must include the `_KdnnSigmoid`
+runs at non-zero items/sec; if they report "KDNN unavailable on this
+platform", `IsKDNNEnabled()` is returning false and steps 1–3 need
+debugging.
+
+The headline numbers (bytes/sec, ns/element) should be recorded in the
+PR thread. The current skeleton does not include numbers because no
+hardware was available to the author.
+
+## Step 6 — Verify the Grappler rewrite fires
+
+```sh
+bazel test --define=enable_kdnn=true \
+    //tensorflow/compiler/grappler/optimizers:remapper_test \
+    --test_arg=--gtest_filter=*RemapperSigmoid*
+```
+
+Expected: at least one test asserts that `tf.math.sigmoid` in a 2-D
+float32 graph gets rewritten to `_KdnnSigmoid`. The rewrite is gated
+on `IsKDNNEnabled()` and on `pass_config_` allowing the rewrite, so
+both must be true.
+
+## Step 7 — End-to-end model smoke test
+
+Build and run a small `.pb` model that contains a Sigmoid activation,
+with `TF_ENABLE_KDNN_OPTS=1` in the process environment and the
+Grappler remapper enabled. Confirm via `tf.compat.v1.RunMetadata` that
+the optimized graph contains `_KdnnSigmoid` nodes (not `Sigmoid`).
+
+```sh
+TF_ENABLE_KDNN_OPTS=1 \
+bazel-bin/tensorflow/python/platform/bfloat16/_pywrap_tensorflow_internal \
+    /tmp/sigmoid_model_test.py
+```
+
+A test script `kdnn_e2e_smoke.py` is provided alongside this recipe at
+`third_party/KDNN/kdnn_e2e_smoke.py` for exactly this purpose.
+
+## Reporting results back to the PR
+
+Run all six steps and capture their output. The format expected in the
+PR review thread is:
+
+```
+Step 1: KDNN_ROOT=/opt/kail/kdnn → include and lib verified
+Step 2: ldd clean
+Step 3: bazel build green
+Step 4: remapper_test_kdnn_sigmoid ... PASS in 0.83s
+Step 5: BM_KdnnVsCpuSigmoid_Kdnn_8192 ... 1.20 ns/elem
+        BM_KdnnVsCpuSigmoid_Cpu_8192 ...  0.85 ns/elem
+        BM_KdnnVsCpuSigmoid_Kdnn_131072 ... 4.10 ns/elem
+        BM_KdnnVsCpuSigmoid_Cpu_131072 ...  2.55 ns/elem
+Step 6: RemapperSigmoidRewrite ... PASS in 0.41s, _KdnnSigmoid nodes=1
+Step 7: kdnn_e2e_smoke ... PASS in 1.20s, optimized graph contains _KdnnSigmoid
+```
+
+The headline result for the PR description is the **speedup ratio**
+from Step 5:
+
+    speedup = (BM_KdnnVsCpuSigmoid_Cpu_<N>_ns_per_elem) /
+              (BM_KdnnVsCpuSigmoid_Kdnn_<N>_ns_per_elem)
+
+reported separately for `N=8192` and `N=131072`.

--- a/third_party/KDNN/README.md
+++ b/third_party/KDNN/README.md
@@ -1,0 +1,58 @@
+# KDNN — Kunpeng Deep Neural Network Library
+
+This directory holds the integration glue for the third-party **KDNN** library
+developed by Huawei as part of openEuler's **KAIL (Kunpeng AI Library) BoostKit**.
+KDNN targets the **Kunpeng 920** (ARMv8) CPU.
+
+This is intentionally a **header + BUILD skeleton** — the actual shared library
+(`libkdnn.so`) is expected to be provided by the operator. See the
+*Distribution* section below.
+
+## What is here
+
+| File | Purpose |
+|---|---|
+| `kdnn.h` | Minimal C API header (declarations only). Mirrors the public surface of KAIL's KDNN. No implementation. |
+| `build_defs.bzl` | Bazel macros: `if_enable_kdnn`, `kdnn_deps`. |
+| `BUILD` | Minimal `cc_library` rules for the header + a stubbed implementation. |
+
+## What is NOT here
+
+- The KDNN implementation itself (`.c`, `.cpp`, `.s` ARM assembly).
+- The actual `libkdnn.so` binary.
+- Any KAIL BoostKit packaging.
+
+Those are downloaded or symlinked into this tree at *build time* via the
+`KDNN_ROOT` environment variable (analogous to the existing `TF_MKL_ROOT`).
+See the `kdnn_repository` rule.
+
+## Build flag
+
+```sh
+# Explicit opt-in; default off.
+bazel build --define=enable_kdnn=true //tensorflow/...
+```
+
+The flag is a TRANSITIVE — both `tensorflow/tensorflow.bzl` and the
+Kunpeng-aarch64 `config_setting` (declared in `tensorflow/workspace.bzl`)
+must be satisfied for the KDNN kernels to compile.
+
+## Distribution
+
+The KDNN source is distributed by Huawei under the openEuler BoostKit. The
+TF integration expects one of two models:
+
+1. **Pre-built binary** (recommended for the initial PR): the operator places
+   `libkdnn.so` and `kdnn.h` under a directory pointed to by `KDNN_ROOT`.
+2. **Source build** (future work): the operator runs a build script that
+   produces `libkdnn.so` and places it under `KDNN_ROOT/lib`.
+
+Either model lands the artifacts where the `kdnn_repository` rule can find
+them.
+
+## Why this is a separate third_party directory
+
+KDNN is **not** a generic x86 backend — it is ARM-only. The existing MKL
+tree would be misleading because the activation is gated by a different
+`config_setting` (aarch64 + opt-in flag vs. x86 + default-on). Keeping it
+separate also makes it easy to backport independently of MKL.

--- a/third_party/KDNN/README.md
+++ b/third_party/KDNN/README.md
@@ -16,6 +16,8 @@ This is intentionally a **header + BUILD skeleton** — the actual shared librar
 | `build_defs.bzl` | Bazel macros: `if_enable_kdnn`, `kdnn_deps`. Loaded from BUILD files via `tensorflow/tensorflow.bzl`. |
 | `repository.bzl` | `kdnn_repository` rule (loaded only from `WORKSPACE` / `MODULE.bazel`). |
 | `BUILD` | `cc_library` rules for the header + an in-tree stub target. |
+| `HARDWARE_VERIFICATION.md` | Step-by-step recipe for end-to-end verification on Kunpeng 920 + libkdnn.so. See "Hardware verification" below. |
+| `kdnn_e2e_smoke.py` | Step-7 of the recipe: builds a Sigmoid graph, runs Grappler, asserts `_KdnnSigmoid` appears and matches eager numerically. |
 
 ## What is NOT here
 
@@ -78,3 +80,30 @@ To resolve:
 3. Once confirmed, change `licenses(["restricted"])` to
    `licenses(["notice"])` in `BUILD` and remove the corresponding
    comment block.
+
+## Hardware verification
+
+The skeleton PR has been authored without access to Kunpeng 920 hardware,
+so it cannot ship benchmark numbers or end-to-end execution evidence. To
+unblock the "Hardware Verification" and "Benchmark Results" action items
+in the review thread, this directory ships:
+
+* **`HARDWARE_VERIFICATION.md`** — a 7-step recipe that takes a reviewer
+  from a fresh KAIL BoostKit install to a populated PR comment with
+  numbers. Designed to be runnable in under 30 minutes by anyone with
+  Kunpeng 920 access.
+* **`tensorflow/core/kernels/kdnn/kdnn_sigmoid_benchmark.cc`** — a
+  microbenchmark target (`//tensorflow/core/kernels/kdnn:kdnn_sigmoid_benchmark_test`)
+  that compares `_KdnnSigmoid` against the default CPU `Sigmoid`. On
+  non-KDNN platforms it is a no-op that reports "KDNN unavailable on
+  this platform" and exits cleanly, so it is safe to keep in the default
+  build graph.
+* **`kdnn_e2e_smoke.py`** — Step 7 of the recipe. Builds a small
+  Sigmoid graph, runs Grappler, asserts the rewrite to `_KdnnSigmoid`
+  fires and the rewritten op executes without numerical drift.
+
+When the PR author (or a reviewer with hardware access) runs the recipe,
+the resulting numbers and pass/fail lines should be pasted back into the
+PR thread. Until then, this directory explicitly does **not** claim
+performance figures; the placeholder numbers in
+`kdnn_sigmoid_benchmark.cc` are illustrative format markers only.

--- a/third_party/KDNN/README.md
+++ b/third_party/KDNN/README.md
@@ -13,8 +13,9 @@ This is intentionally a **header + BUILD skeleton** — the actual shared librar
 | File | Purpose |
 |---|---|
 | `kdnn.h` | Minimal C API header (declarations only). Mirrors the public surface of KAIL's KDNN. No implementation. |
-| `build_defs.bzl` | Bazel macros: `if_enable_kdnn`, `kdnn_deps`. |
-| `BUILD` | Minimal `cc_library` rules for the header + a stubbed implementation. |
+| `build_defs.bzl` | Bazel macros: `if_enable_kdnn`, `kdnn_deps`. Loaded from BUILD files via `tensorflow/tensorflow.bzl`. |
+| `repository.bzl` | `kdnn_repository` rule (loaded only from `WORKSPACE` / `MODULE.bazel`). |
+| `BUILD` | `cc_library` rules for the header + an in-tree stub target. |
 
 ## What is NOT here
 
@@ -24,7 +25,7 @@ This is intentionally a **header + BUILD skeleton** — the actual shared librar
 
 Those are downloaded or symlinked into this tree at *build time* via the
 `KDNN_ROOT` environment variable (analogous to the existing `TF_MKL_ROOT`).
-See the `kdnn_repository` rule.
+See the `kdnn_repository` rule in `repository.bzl`.
 
 ## Build flag
 
@@ -56,3 +57,24 @@ KDNN is **not** a generic x86 backend — it is ARM-only. The existing MKL
 tree would be misleading because the activation is gated by a different
 `config_setting` (aarch64 + opt-in flag vs. x86 + default-on). Keeping it
 separate also makes it easy to backport independently of MKL.
+
+## License status (UNRESOLVED)
+
+This directory ships with `licenses(["restricted"])` in `BUILD`. Until
+that line is changed to `licenses(["notice"])`, the entire directory is
+flagged by Google's internal tooling as not safe to import. The blocker
+is independent of this code review and cannot be resolved inside this
+PR — it requires confirmation from the openEuler / KAIL BoostKit
+maintainers that libkdnn.so and kdnn.h may be redistributed under
+Apache 2.0 (or a compatible permissive license).
+
+To resolve:
+
+1. File an issue in the openEuler community tracker asking KAIL SIG
+   (kail@openeuler.org) to clarify the KDNN distribution terms.
+2. Either obtain a written license grant permitting the in-tree
+   header + dlopen() integration path used here, OR confirm KDNN is
+   released under Apache 2.0.
+3. Once confirmed, change `licenses(["restricted"])` to
+   `licenses(["notice"])` in `BUILD` and remove the corresponding
+   comment block.

--- a/third_party/KDNN/build_defs.bzl
+++ b/third_party/KDNN/build_defs.bzl
@@ -7,9 +7,16 @@ if_enable_kdnn is a `select` that is true IFF:
   - --define=enable_kdnn=true was passed, AND
   - the target platform is Linux aarch64 (Kunpeng class).
 
-kdnn_deps returns the link-time dependency on libkdnn.so.
-kdnn_repository is the analog of mkl_repository: it locates the libkdnn
-install via the KDNN_ROOT environment variable.
+kdnn_deps returns the link-time dependency on libkdnn.so via the
+@kdnn repository (declared in WORKSPACE via kdnn_repository, which
+lives in the companion file repository.bzl so that loading this
+file from a BUILD graph does not transitively pull in
+`repository_rule`).
+
+The kdnn_repository rule itself is in third_party/KDNN/repository.bzl
+and is loaded only from WORKSPACE / MODULE.bazel. This split mirrors
+the modern Bazel pattern of keeping BUILD-loadable macros separate
+from WORKSPACE-loadable repository rules.
 """
 
 def if_enable_kdnn(if_true, if_false = []):
@@ -37,47 +44,22 @@ def if_enable_kdnn(if_true, if_false = []):
 def kdnn_deps():
     """Returns the link-time dependency on libkdnn.
 
+    Resolves to ["@kdnn//:kdnn"] when KDNN is enabled AND the
+    `@kdnn` repository has been declared in WORKSPACE via
+    `kdnn_repository` (from third_party/KDNN/repository.bzl). When
+    KDNN is not enabled, returns an empty list.
+
+    If the operator has not configured KDNN_ROOT and called
+    `kdnn_repository` in WORKSPACE, this macro will fail at
+    build-rule analysis time on the `@kdnn//:kdnn` label — the same
+    behaviour as `mkl_deps()` on an unconfigured TF build.
+
     Returns:
-      A select() that resolves to ["@kdnn//:kdnn"] when KDNN is enabled
-      and an empty list otherwise. Use as a `deps = [...]` entry.
+      A select() that resolves to ["@kdnn//:kdnn"] when KDNN is
+      enabled and an empty list otherwise. Use as a `deps = [...]`
+      entry.
     """
     return select({
         Label("//third_party/KDNN:enable_kdnn"): ["@kdnn//:kdnn"],
         "//conditions:default": [],
     })
-
-_KDNN_ROOT = "KDNN_ROOT"
-
-def _kdnn_autoconf_impl(repository_ctx):
-    """Implementation of the kdnn_repository rule.
-
-    Mirrors the mkl_repository pattern: if KDNN_ROOT is set, use the
-    header + lib from that directory; otherwise fail with a clear error
-    instructing the user to obtain KDNN from openEuler BoostKit.
-    """
-    if _KDNN_ROOT in repository_ctx.os.environ:
-        root = repository_ctx.os.environ[_KDNN_ROOT]
-        repository_ctx.symlink(root + "/include", "include")
-        repository_ctx.symlink(root + "/lib", "lib")
-        repository_ctx.symlink(
-            repository_ctx.attr.build_file,
-            "BUILD",
-        )
-    else:
-        # We do NOT auto-download KDNN: the upstream is gated behind
-        # openEuler's package distribution model and is not an
-        # open-source Apache repo we can clone. Fail with an actionable
-        # error message.
-        fail(
-            "KDNN_ROOT is not set. To enable KDNN, install the KAIL " +
-            "BoostKit from openEuler and set KDNN_ROOT to the install " +
-            "directory. See third_party/KDNN/README.md for details.",
-        )
-
-kdnn_repository = repository_rule(
-    implementation = _kdnn_autoconf_impl,
-    environ = [_KDNN_ROOT],
-    attrs = {
-        "build_file": attr.label(),
-    },
-)

--- a/third_party/KDNN/build_defs.bzl
+++ b/third_party/KDNN/build_defs.bzl
@@ -1,0 +1,83 @@
+"""Starlark macros for KDNN (Kunpeng Deep Neural Network) library.
+
+KDNN is the third-party library developed by Huawei as part of openEuler's
+KAIL BoostKit, targeting Kunpeng 920 (ARMv8) CPUs.
+
+if_enable_kdnn is a `select` that is true IFF:
+  - --define=enable_kdnn=true was passed, AND
+  - the target platform is Linux aarch64 (Kunpeng class).
+
+kdnn_deps returns the link-time dependency on libkdnn.so.
+kdnn_repository is the analog of mkl_repository: it locates the libkdnn
+install via the KDNN_ROOT environment variable.
+"""
+
+def if_enable_kdnn(if_true, if_false = []):
+    """Shorthand to select() if KDNN is enabled at build time.
+
+    Mirrors the style of `if_zendnn` in tensorflow/tensorflow.bzl but
+    *additionally* gates on aarch64. KDNN on x86 is meaningless (the
+    library is Kunpeng 920 only).
+
+    Args:
+      if_true: list of attrs / deps to include when KDNN is enabled.
+      if_false: list to include otherwise. Defaults to [].
+
+    Returns:
+      A select() that evaluates to if_true only when both:
+        * --define=enable_kdnn=true is set, AND
+        * the platform is Linux aarch64.
+      Otherwise evaluates to if_false.
+    """
+    return select({
+        Label("//third_party/KDNN:enable_kdnn"): if_true,
+        "//conditions:default": if_false,
+    })
+
+def kdnn_deps():
+    """Returns the link-time dependency on libkdnn.
+
+    Returns:
+      A select() that resolves to ["@kdnn//:kdnn"] when KDNN is enabled
+      and an empty list otherwise. Use as a `deps = [...]` entry.
+    """
+    return select({
+        Label("//third_party/KDNN:enable_kdnn"): ["@kdnn//:kdnn"],
+        "//conditions:default": [],
+    })
+
+_KDNN_ROOT = "KDNN_ROOT"
+
+def _kdnn_autoconf_impl(repository_ctx):
+    """Implementation of the kdnn_repository rule.
+
+    Mirrors the mkl_repository pattern: if KDNN_ROOT is set, use the
+    header + lib from that directory; otherwise fail with a clear error
+    instructing the user to obtain KDNN from openEuler BoostKit.
+    """
+    if _KDNN_ROOT in repository_ctx.os.environ:
+        root = repository_ctx.os.environ[_KDNN_ROOT]
+        repository_ctx.symlink(root + "/include", "include")
+        repository_ctx.symlink(root + "/lib", "lib")
+        repository_ctx.symlink(
+            repository_ctx.attr.build_file,
+            "BUILD",
+        )
+    else:
+        # We do NOT auto-download KDNN: the upstream is gated behind
+        # openEuler's package distribution model and is not an
+        # open-source Apache repo we can clone. Fail with an actionable
+        # error message.
+        fail(
+            "KDNN_ROOT is not set. To enable KDNN, install the KAIL " +
+            "BoostKit from openEuler and set KDNN_ROOT to the install " +
+            "directory. See third_party/KDNN/README.md for details.",
+        )
+
+kdnn_repository = repository_rule(
+    implementation = _kdnn_autoconf_impl,
+    environ = [_KDNN_ROOT],
+    attrs = {
+        "build_file": attr.label(),
+    },
+)

--- a/third_party/KDNN/kdnn.h
+++ b/third_party/KDNN/kdnn.h
@@ -1,0 +1,107 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Minimal public C-API header for the KDNN (Kunpeng Deep Neural Network)
+// library distributed by Huawei as part of openEuler's KAIL BoostKit.
+//
+// This header is INTENTIONALLY a thin wrapper. It exposes only the
+// 7-8 entry points that the TensorFlow KDNN kernel templates need.
+// The full KDNN API surface (matmul, softmax, sparse, RNN, etc.) is
+// much larger and is *not* vendored here yet — each op is added as a
+// separate PR with its own benchmark.
+
+#ifndef TENSORFLOW_THIRD_PARTY_KDNN_KDNN_H_
+#define TENSORFLOW_THIRD_PARTY_KDNN_KDNN_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Opaque handle to a KDNN runtime context. Lifetime is managed by the
+// caller; typically one per (process, device) pair.
+typedef struct kdnn_context kdnn_context_t;
+
+// Element-wise / activation function tags. The numeric values are
+// stable; new tags are added at the end.
+typedef enum {
+  KDNN_ACT_SIGMOID = 0,
+  KDNN_ACT_TANH = 1,
+  KDNN_ACT_RELU = 2,
+  KDNN_ACT_GELU = 3,
+  KDNN_ACT_SWISH = 4,
+} kdnn_activation_t;
+
+// Data type tags. Mirrors the layout used by KAIL.
+typedef enum {
+  KDNN_DT_FLOAT = 0,
+  KDNN_DT_BFLOAT16 = 1,
+  KDNN_DT_HALF = 2,
+} kdnn_data_type_t;
+
+// Layout tag. KDNN is row-major; we always pass NHWC-equivalent row-major
+// contiguous tensors and the library handles any internal blocking.
+typedef enum {
+  KDNN_LAYOUT_ROW_MAJOR = 0,
+} kdnn_layout_t;
+
+// Status codes returned by every KDNN entry point. KDNN_OK (== 0) is
+// success; any non-zero value indicates failure and the caller MAY
+// query kdnn_get_last_error() for a human-readable string.
+typedef enum {
+  KDNN_OK = 0,
+  KDNN_ERR_INVALID_ARG = 1,
+  KDNN_ERR_UNSUPPORTED = 2,
+  KDNN_ERR_RUNTIME = 3,
+  KDNN_ERR_OOM = 4,
+} kdnn_status_t;
+
+// Library lifecycle.
+kdnn_status_t kdnn_create(kdnn_context_t** ctx);
+void kdnn_destroy(kdnn_context_t* ctx);
+const char* kdnn_get_last_error(const kdnn_context_t* ctx);
+int kdnn_get_version(void);  // returns e.g. 0x00010000 for 1.0
+
+// Element-wise activation: y = activation(x), element-wise,
+// in-place (x == y) is allowed.
+//
+// Returns KDNN_OK on success. Returns KDNN_ERR_UNSUPPORTED if the
+// requested activation / dtype combination is not implemented in the
+// loaded library — the kernel MUST fall back to the native TF op in
+// that case.
+kdnn_status_t kdnn_apply_activation(
+    kdnn_context_t* ctx,
+    kdnn_activation_t activation,
+    kdnn_data_type_t dtype,
+    kdnn_layout_t layout,
+    void* x,
+    void* y,
+    size_t n);
+
+// Returns 1 if the given activation+dt combination is supported on the
+// current CPU, 0 otherwise. Cheaper than kdnn_apply_activation; the
+// kernel uses this in the shape-inference path to decide whether to
+// emit the rewrite.
+int kdnn_activation_supported(
+    kdnn_activation_t activation,
+    kdnn_data_type_t dtype);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // TENSORFLOW_THIRD_PARTY_KDNN_KDNN_H_

--- a/third_party/KDNN/kdnn_e2e_smoke.py
+++ b/third_party/KDNN/kdnn_e2e_smoke.py
@@ -1,0 +1,97 @@
+"""End-to-end smoke test for the KDNN integration.
+
+Run on a Kunpeng 920 host with --define=enable_kdnn=true to verify that
+tf.math.sigmoid in a real GraphDef gets rewritten to _KdnnSigmoid by the
+Grappler remapper. Documented as Step 7 of
+third_party/KDNN/HARDWARE_VERIFICATION.md.
+
+Exits 0 if the rewrite fires (i.e. _KdnnSigmoid appears in the optimized
+graph) and the rewritten op executes without numerical drift greater than
+the remapper's internal tolerance. Exits 1 otherwise.
+
+Usage:
+    TF_ENABLE_KDNN_OPTS=1 python3 third_party/KDNN/kdnn_e2e_smoke.py
+"""
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+  if os.environ.get("TF_ENABLE_KDNN_OPTS") != "1":
+    print(
+        "ERROR: TF_ENABLE_KDNN_OPTS=1 is required to enable the KDNN "
+        "rewrite path. Re-run with that env var set.",
+        file=sys.stderr,
+    )
+    return 1
+
+  import tensorflow as tf  # noqa: E402  (import after env var check)
+  from tensorflow.core.protobuf import config_pb2  # noqa: E402
+
+  # Build a small graph: y = sigmoid(W @ x + b).
+  x = tf.compat.v1.placeholder(tf.float32, shape=(4,), name="x")
+  w = tf.constant(np.random.RandomState(0).randn(4, 4).astype(np.float32))
+  b = tf.constant(np.random.RandomState(1).randn(4).astype(np.float32))
+  y = tf.nn.sigmoid(tf.linalg.matvec(w, x) + b, name="y")
+
+  # Run Grappler with the optimizer turned on at L1. We capture the
+  # post-optimization graph via RunMetadata.partitioned_graphs, which is
+  # the documented way to inspect what Grappler produced for a given run.
+  config = tf.compat.v1.ConfigProto()
+  config.graph_options.optimizer_options.opt_level = (
+      tf.compat.v1.training.OptimizerOptions.L1
+  )
+  run_options = config_pb2.RunOptions(
+      trace_level=config_pb2.RunOptions.FULL_TRACE
+  )
+  run_metadata = config_pb2.RunMetadata()
+  test_x = np.random.RandomState(2).randn(4).astype(np.float32)
+  with tf.compat.v1.Session(config=config) as sess:
+    sess.run(tf.compat.v1.global_variables_initializer())
+    actual = sess.run(
+        y,
+        feed_dict={x: test_x},
+        options=run_options,
+        run_metadata=run_metadata,
+    )
+
+  # Walk the executed graph and look for _KdnnSigmoid. RunMetadata captures
+  # one GraphDef per partition; on a single-CPU graph there is exactly one.
+  has_kdnn_sigmoid = False
+  for partition in run_metadata.partitioned_graphs:
+    for node in partition.node:
+      if node.op == "_KdnnSigmoid":
+        has_kdnn_sigmoid = True
+        break
+  if not has_kdnn_sigmoid:
+    print(
+        "FAIL: optimized graph does not contain _KdnnSigmoid. The Grappler "
+        "remapper did not fire; either IsKDNNEnabled() returned false, "
+        "the rewrite's dtype/shape constraints excluded this graph, or "
+        "the rewrite was eliminated by a later pass.",
+        file=sys.stderr,
+    )
+    return 1
+
+  # Compare the rewritten op's output to the eager-mode reference.
+  expected = 1.0 / (1.0 + np.exp(-(test_x @ w.numpy() + b.numpy())))
+  max_abs_err = float(np.max(np.abs(actual - expected)))
+  if max_abs_err > 1e-4:
+    print(
+        f"FAIL: numerical drift exceeds 1e-4: max_abs_err={max_abs_err:.3e}",
+        file=sys.stderr,
+    )
+    return 1
+
+  print(
+      "PASS: optimized graph contains _KdnnSigmoid, "
+      f"max_abs_err={max_abs_err:.3e}"
+  )
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/third_party/KDNN/kdnn_stub.cc
+++ b/third_party/KDNN/kdnn_stub.cc
@@ -1,0 +1,89 @@
+// Standalone stub implementation used for HOST-SIDE testing of the
+// TF integration code paths. This file is NOT compiled into the
+// production TF binary — it is only used by the harness in
+// tensorflow/core/kernels/kdnn/kdnn_test_harness.cc (and the
+// adversarial test scripts) to verify that:
+//
+//   * the C ABI matches between kdnn.h and the library,
+//   * the dispatch path works (create / apply / destroy),
+//   * graceful fallback (unsupported activation) returns KDNN_ERR_UNSUPPORTED.
+//
+// Real KDNN is shipped as libkdnn.so — see third_party/KDNN/README.md.
+
+// Real production path uses the BUILD include_prefix:
+//   #include "third_party/KDNN/kdnn.h"
+// For the host-side test harness we use the relative path so we can
+// compile with `-I third_party/KDNN`.
+#include "kdnn.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+extern "C" {
+
+struct kdnn_context {
+  char last_error[256];
+};
+
+kdnn_status_t kdnn_create(kdnn_context_t** ctx) {
+  if (ctx == nullptr) return KDNN_ERR_INVALID_ARG;
+  *ctx = static_cast<kdnn_context_t*>(std::calloc(1, sizeof(kdnn_context_t)));
+  return KDNN_OK;
+}
+
+void kdnn_destroy(kdnn_context_t* ctx) {
+  if (ctx != nullptr) std::free(ctx);
+}
+
+const char* kdnn_get_last_error(const kdnn_context_t* ctx) {
+  if (ctx == nullptr) return "null context";
+  return ctx->last_error;
+}
+
+int kdnn_get_version(void) {
+  return 0x00010000;  // 1.0
+}
+
+int kdnn_activation_supported(kdnn_activation_t activation,
+                              kdnn_data_type_t dtype) {
+  // Stub: only float32 sigmoid is supported in the test harness.
+  if (activation == KDNN_ACT_SIGMOID && dtype == KDNN_DT_FLOAT) return 1;
+  return 0;
+}
+
+kdnn_status_t kdnn_apply_activation(
+    kdnn_context_t* ctx,
+    kdnn_activation_t activation,
+    kdnn_data_type_t dtype,
+    kdnn_layout_t /*layout*/,
+    void* x,
+    void* y,
+    size_t n) {
+  if (ctx == nullptr || x == nullptr || y == nullptr) {
+    // KDNN_ERR_INVALID_ARG == 1
+    return static_cast<kdnn_status_t>(1);
+  }
+  if (!kdnn_activation_supported(activation, dtype)) {
+    // snprintf is in <cstdio> as a non-std:: name; in <stdio.h> as
+    // a global. Calling std::snprintf is invalid because no std::
+    // overload is declared. Use the global name from <cstdio>.
+    snprintf(ctx->last_error, sizeof(ctx->last_error),
+             "activation %d / dtype %d not supported", activation, dtype);
+    return KDNN_ERR_UNSUPPORTED;
+  }
+  // Only float32 sigmoid is implemented in the stub.
+  if (dtype != KDNN_DT_FLOAT) return KDNN_ERR_UNSUPPORTED;
+  if (activation != KDNN_ACT_SIGMOID) return KDNN_ERR_UNSUPPORTED;
+
+  const float* xf = static_cast<const float*>(x);
+  float* yf = static_cast<float*>(y);
+  for (size_t i = 0; i < n; ++i) {
+    // 1 / (1 + exp(-x)) — naive but sufficient for harness tests.
+    yf[i] = 1.0f / (1.0f + std::exp(-xf[i]));
+  }
+  return KDNN_OK;
+}
+
+}  // extern "C"

--- a/third_party/KDNN/repository.bzl
+++ b/third_party/KDNN/repository.bzl
@@ -1,0 +1,66 @@
+"""repository_rule for KDNN (Kunpeng Deep Neural Network) library.
+
+This file is INTENTIONALLY separate from build_defs.bzl. `repository_rule`
+is a Bazel primitive that only makes sense in WORKSPACE / MODULE.bazel
+evaluation contexts; loading it from a `.bzl` that is itself loaded by
+BUILD files (as build_defs.bzl is, via tensorflow/tensorflow.bzl) is
+legal but conflates two namespaces. Keeping the repository rule in its
+own file means:
+
+  * `tensorflow/tensorflow.bzl` does not see `repository_rule` at all,
+    which matches the modern pattern of separating BUILD-loadable
+    macros from WORKSPACE-loadable repository rules.
+  * Operators adding this PR to their fork only need to load one
+    additional file in WORKSPACE.
+
+Usage from WORKSPACE:
+
+    load("//third_party/KDNN:repository.bzl", "kdnn_repository")
+
+    kdnn_repository(
+        name = "kdnn",
+        build_file = "//third_party/KDNN:BUILD",
+    )
+
+The `_kdnn_autoconf_impl` below mirrors the pattern of TF's
+`mkl_repository`: it consumes the `KDNN_ROOT` environment variable to
+locate the operator-supplied KAIL BoostKit install, and fails loudly
+otherwise (the KDNN source is not auto-downloaded because the upstream
+distribution is gated behind openEuler's package model).
+"""
+
+_KDNN_ROOT = "KDNN_ROOT"
+
+def _kdnn_autoconf_impl(repository_ctx):
+    """Implementation of the kdnn_repository rule.
+
+    Mirrors the mkl_repository pattern: if KDNN_ROOT is set, use the
+    header + lib from that directory; otherwise fail with a clear error
+    instructing the user to obtain KDNN from openEuler BoostKit.
+    """
+    if _KDNN_ROOT in repository_ctx.os.environ:
+        root = repository_ctx.os.environ[_KDNN_ROOT]
+        repository_ctx.symlink(root + "/include", "include")
+        repository_ctx.symlink(root + "/lib", "lib")
+        repository_ctx.symlink(
+            repository_ctx.attr.build_file,
+            "BUILD",
+        )
+    else:
+        # We do NOT auto-download KDNN: the upstream is gated behind
+        # openEuler's package distribution model and is not an
+        # open-source Apache repo we can clone. Fail with an actionable
+        # error message.
+        fail(
+            "KDNN_ROOT is not set. To enable KDNN, install the KAIL " +
+            "BoostKit from openEuler and set KDNN_ROOT to the install " +
+            "directory. See third_party/KDNN/README.md for details.",
+        )
+
+kdnn_repository = repository_rule(
+    implementation = _kdnn_autoconf_impl,
+    environ = [_KDNN_ROOT],
+    attrs = {
+        "build_file": attr.label(),
+    },
+)

--- a/third_party/KDNN/repository.bzl
+++ b/third_party/KDNN/repository.bzl
@@ -24,9 +24,11 @@ Usage from WORKSPACE:
 
 The `_kdnn_autoconf_impl` below mirrors the pattern of TF's
 `mkl_repository`: it consumes the `KDNN_ROOT` environment variable to
-locate the operator-supplied KAIL BoostKit install, and fails loudly
-otherwise (the KDNN source is not auto-downloaded because the upstream
-distribution is gated behind openEuler's package model).
+locate the operator-supplied KAIL BoostKit install. When KDNN_ROOT is
+unset (the default for upstream CI), it produces a no-op @kdnn repo
+so that @kdnn//:kdnn resolves to an empty cc_library and default
+builds are unaffected. The KDNN source is not auto-downloaded because
+the upstream distribution is gated behind openEuler's package model.
 """
 
 _KDNN_ROOT = "KDNN_ROOT"
@@ -34,28 +36,61 @@ _KDNN_ROOT = "KDNN_ROOT"
 def _kdnn_autoconf_impl(repository_ctx):
     """Implementation of the kdnn_repository rule.
 
-    Mirrors the mkl_repository pattern: if KDNN_ROOT is set, use the
-    header + lib from that directory; otherwise fail with a clear error
-    instructing the user to obtain KDNN from openEuler BoostKit.
+    Three modes:
+      1. KDNN_ROOT unset: write a no-op @kdnn repo (empty kdnn.h + a
+         BUILD file with an empty cc_library) so that labels like
+         @kdnn//:kdnn still resolve. This keeps default TF builds
+         (no --define=enable_kdnn=true) green on hosts that don't
+         have libkdnn.so installed, and keeps the WORKSPACE-level
+         `maybe(kdnn_repository, ...)` wrapper a true no-op.
+      2. KDNN_ROOT set but the path doesn't exist: same as mode 1,
+         but emit a warning so an operator who intended to enable
+         KDNN notices. We deliberately do NOT fail() here — a
+         misconfigured env var shouldn't break unrelated builds.
+      3. KDNN_ROOT set and the path exists: symlink the operator's
+         include/ and lib/ into the repo and use the supplied
+         BUILD file (the BUILD at //third_party/KDNN:BUILD declares
+         a `kdnn` cc_library that depends on @kdnn//:kdnn_header,
+         which in turn points at kdnn.h).
+
+    The mode 1 + mode 2 behavior is what the rest of the tree relies
+    on: `kdnn_deps()` resolves to ["@kdnn//:kdnn"] only when the
+    `enable_kdnn` config_setting matches (which requires both
+    --define=enable_kdnn=true AND aarch64), and the corresponding
+    kdnn kernels live behind `#ifdef KERNEL_KDNN`. So even when
+    @kdnn is a no-op stub, default builds see only an empty
+    cc_library and the kernels compile to nothing.
     """
-    if _KDNN_ROOT in repository_ctx.os.environ:
-        root = repository_ctx.os.environ[_KDNN_ROOT]
-        repository_ctx.symlink(root + "/include", "include")
-        repository_ctx.symlink(root + "/lib", "lib")
+    kdnn_root = repository_ctx.os.environ.get(_KDNN_ROOT, "")
+    if kdnn_root and repository_ctx.path(kdnn_root).exists:
+        repository_ctx.symlink(kdnn_root + "/include", "include")
+        repository_ctx.symlink(kdnn_root + "/lib", "lib")
         repository_ctx.symlink(
             repository_ctx.attr.build_file,
             "BUILD",
         )
-    else:
-        # We do NOT auto-download KDNN: the upstream is gated behind
-        # openEuler's package distribution model and is not an
-        # open-source Apache repo we can clone. Fail with an actionable
-        # error message.
-        fail(
-            "KDNN_ROOT is not set. To enable KDNN, install the KAIL " +
-            "BoostKit from openEuler and set KDNN_ROOT to the install " +
-            "directory. See third_party/KDNN/README.md for details.",
+        return
+
+    # KDNN_ROOT unset, or set to a path that doesn't resolve. Provide
+    # an empty @kdnn repo so that @kdnn//:kdnn resolves to a no-op
+    # cc_library and unrelated build targets don't break.
+    if kdnn_root:
+        # Don't silently swallow a misconfiguration: print to the
+        # build's progress stream so the operator sees it in CI logs.
+        print(
+            "WARNING: KDNN_ROOT is set to '%s' but that path does " %
+            kdnn_root +
+            "not exist. Falling back to a no-op @kdnn repo. KDNN " +
+            "kernels will not be linked; the rest of TF will build " +
+            "normally. See third_party/KDNN/README.md for setup.",
         )
+    repository_ctx.file(
+        "BUILD",
+        'licenses(["restricted"])\n' +
+        'package(default_visibility = ["//visibility:public"])\n' +
+        'cc_library(name = "kdnn", hdrs = [], srcs = [])\n',
+    )
+    repository_ctx.file("kdnn.h", "// no-op stub: KDNN_ROOT unset\n")
 
 kdnn_repository = repository_rule(
     implementation = _kdnn_autoconf_impl,


### PR DESCRIPTION
…upport

Adds the build-flag plumbing, op / kernel / Grappler-remapper scaffolding, and tests for an opt-in integration of the third-party KDNN library distributed by Huawei as part of openEuler KAIL BoostKit.

This is a skeleton / RFC-style contribution, NOT ready to merge. Outstanding blockers:

  * KDNN license status (third_party/KDNN/BUILD uses licenses(["restricted"]) with an explicit UNRESOLVED comment block until the openEuler / KAIL maintainers confirm the terms).
  * No aarch64 CI coverage — x86 hosts cannot exercise the real libkdnn.so path.
  * No real libkdnn.so tested — the adversarial harness uses a host-side stub for ABI verification.
  * No benchmark numbers yet on Kunpeng 920.
  * kdnn_repository Bazel rule defined but not yet wired into WORKSPACE / MODULE.bazel.

Architectural decisions:

  * Uses Grappler remapper (modern precedent — see remapper.cc:4119 ReplaceSigmoidMulWithSwish) rather than the legacy OptimizationPass layout pass used by the reference prototype.
  * libkdnn.so is dlopen()ed at runtime with graceful fallback to Unimplemented — the TF binary has NO link-time dependency on libkdnn.so, so it builds cleanly on any platform.
  * All KDNN code is #ifdef KERNEL_KDNN-gated, so default builds are unaffected.
  * Follow-up ops (Softmax, MatMul, Einsum, Concat, FloorMod) will be separate PRs per the original issue.

Issue: tensorflow/tensorflow#124076
Reference prototype: amaniyadunia/tensorflow@7f28db9

Progresses #124076