### PR TITLE
Fix stateless RNG ops rejecting `alg='threefry'`

### DIFF
--- a/tensorflow/core/kernels/stateless_random_ops_v2_util.h
+++ b/tensorflow/core/kernels/stateless_random_ops_v2_util.h
@@ -57,9 +57,14 @@ GetKeyCounterAlgFromInputs(OpKernelContext* ctx, int key_input_idx,
   if (alg == RNG_ALG_AUTO_SELECT) {
     alg = RNG_ALG_PHILOX;
   }
+  if (alg != RNG_ALG_PHILOX && alg != RNG_ALG_THREEFRY) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Unsupported algorithm id: ", alg));
+  }
 
-  TF_RETURN_IF_ERROR(
-      CheckKeyCounterShape(alg, key_t.shape(), counter_t.shape()));
+  TF_RETURN_IF_ERROR(CheckKeyCounterShape(
+      GetCounterSize(ConcreteRngAlgorithm(alg)), key_t.shape(),
+      counter_t.shape()));
   return std::make_tuple(key_t, counter_t, alg);
 }
 

--- a/tensorflow/python/kernel_tests/random/stateless_random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/stateless_random_ops_test.py
@@ -431,6 +431,19 @@ class StatelessOpsTest(test.TestCase, parameterized.TestCase):
     seed = (7, 17)
     self._test_explicit_alg(case, seed)
 
+  @test_util.run_v2_only
+  def testThreefryAlg(self):
+    """Tests that alg='threefry' is accepted by the kernels."""
+    # ThreeFry's counter has length 1, unlike Philox's length-2 counter, so a
+    # counter-size check that assumes Philox would wrongly reject ThreeFry.
+    with ops.device('CPU'):
+      x = stateless.stateless_random_uniform(
+          shape=[5], seed=[1, 2], alg='threefry')
+      self.assertAllEqual(x.shape, [5])
+      y = stateless.stateless_shuffle(
+          math_ops.range(5), seed=[1, 2], alg='threefry')
+      self.assertAllEqual(y.shape, [5])
+
   @parameterized.named_parameters(
       ('_%s_%s_%s' % (case[0], seed_type.name, case_id), case, seed_type)  # pylint: disable=g-complex-comprehension
       for seed_type in SEED_TYPES


### PR DESCRIPTION
## Summary

`tf.random.stateless_uniform(..., alg='threefry')` has never worked in the non-XLA path — it fails unconditionally with `counter must be a vector with length at least 2; got shape: [1]`. The cause is an enum accidentally being used as a size. This fixes that and adds a regression test.

> [!IMPORTANT]
> **I was not able to build or run this locally**, so the C++ change has not been through a compiler. My environment has no usable TensorFlow (no wheel for Python 3.14) and a full Bazel build wasn't feasible. The diagnosis below is derived from reading the source, and the arithmetic is checkable by inspection, but please treat CI as the first real verification. Happy to iterate on anything it turns up.

## Root cause

`GetKeyCounterAlgFromInputs` in `stateless_random_ops_v2_util.h` passes the algorithm enum straight into `CheckKeyCounterShape`:

```cpp
CheckKeyCounterShape(alg, key_t.shape(), counter_t.shape());
```

That parameter is `int minimum_counter_size`, so the `Algorithm` enum converts implicitly and silently becomes the required counter length. The two quantities are exactly inverted (`core/framework/rng_alg.h`):

| Algorithm | enum value | counter size |
|---|---|---|
| `RNG_ALG_PHILOX` | 1 | 2 |
| `RNG_ALG_THREEFRY` | 2 | 1 |

- **ThreeFry** — requires counter >= `2`, but `random_ops_util.py` builds `counter = array_ops.zeros([1], dtypes.uint64)`. Always fails, exactly as reported.
- **Philox** — requires counter >= `1` and gets 2, so it passes by coincidence with a bound one element looser than intended.

The tf2xla kernels already get this right (`tf2xla/kernels/stateless_random_ops_v2.cc` passes `xla::GetCounterSize(alg)`), which is why the documented ThreeFry support appears to work under XLA but not in eager execution.

Introduced in 62d7bdff60c (2022-05-03) and unchanged since. Because three kernels share this helper, `alg='threefry'` is broken for all of them: `StatelessRandomUniformV2` and friends, `StatelessShuffle`, and `StochasticCast`.

## Changes

- `tensorflow/core/kernels/stateless_random_ops_v2_util.h` — derive the minimum counter size via `GetCounterSize(ConcreteRngAlgorithm(alg))` instead of passing the enum. Also reject unsupported algorithm ids up front: `GetCounterSize` documents that callers must not pass non-enumerator values, and `alg` originates from a user-supplied input tensor, so an out-of-range id would otherwise fall off the end of its `switch`. These ids were already rejected slightly further down in `FillRandomTensor` with the same message, so the error text is unchanged.
- `tensorflow/python/kernel_tests/random/stateless_random_ops_test.py` — add `testThreefryAlg`, covering `stateless_random_uniform` and `stateless_shuffle` with `alg='threefry'`. Scoped to CPU.

## Testing

The new test fails before this change with the error from the issue and should pass after it. As noted above I could not execute it locally — `testThreefryAlg` is written to be the check, and I'm relying on CI to run it.

Two things a reviewer may want to weigh in on:

1. The new test is CPU-only. The original report is from a GPU device, but I couldn't confirm ThreeFry kernel registration on GPU, so I scoped it conservatively rather than guess.
2. `CheckKeyCounterShape` compares with `>=`. Now that the bound is correct, `==` is arguably right, and the length-2 counter Philox receives would still satisfy it. I left it alone since tightening it is a behavior change beyond this bug.

Fixes #100252