### PR TITLE
Fix tautological bounds check in StableHLO Scatter/Gather TFLite parsers

### DIFF
--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -2248,7 +2248,7 @@ TfLiteStatus ParseStablehloScatter(const Operator* op,
 
     if (schema_params->update_window_dims()) {
       TF_LITE_ENSURE_STATUS(FlatBufferIntVectorToArray<int64_t>(
-          schema_params->update_window_dims()->size() * sizeof(int64_t),
+          sizeof(params->update_window_dims),
           schema_params->update_window_dims(), params->update_window_dims,
           error_reporter, "stablehlo_scatter"));
       params->num_update_window_dims =
@@ -2257,7 +2257,7 @@ TfLiteStatus ParseStablehloScatter(const Operator* op,
 
     if (schema_params->inserted_window_dims()) {
       TF_LITE_ENSURE_STATUS(FlatBufferIntVectorToArray<int64_t>(
-          schema_params->inserted_window_dims()->size() * sizeof(int64_t),
+          sizeof(params->inserted_window_dims),
           schema_params->inserted_window_dims(), params->inserted_window_dims,
           error_reporter, "stablehlo_scatter"));
       params->num_inserted_window_dims =
@@ -2266,8 +2266,7 @@ TfLiteStatus ParseStablehloScatter(const Operator* op,
 
     if (schema_params->scatter_dims_to_operand_dims()) {
       TF_LITE_ENSURE_STATUS(FlatBufferIntVectorToArray<int64_t>(
-          schema_params->scatter_dims_to_operand_dims()->size() *
-              sizeof(int64_t),
+          sizeof(params->scatter_dims_to_operand_dims),
           schema_params->scatter_dims_to_operand_dims(),
           params->scatter_dims_to_operand_dims, error_reporter,
           "stablehlo_scatter"));
@@ -2332,8 +2331,7 @@ TfLiteStatus ParseStablehloGather(const Operator* op,
   if (schema_params != nullptr) {
     if (schema_params->offset_dims()) {
       TF_LITE_ENSURE_STATUS(FlatBufferIntVectorToArray<int64_t>(
-          /*max_size_of_buffer=*/schema_params->offset_dims()->size() *
-              sizeof(int64_t),
+          /*max_size_of_buffer=*/sizeof(params->offset_dims),
           /*flat_vector=*/schema_params->offset_dims(),
           /*buffer=*/params->offset_dims, /*error_reporter=*/error_reporter,
           /*op_name=*/"stablehlo_gather"));
@@ -2342,7 +2340,7 @@ TfLiteStatus ParseStablehloGather(const Operator* op,
 
     if (schema_params->collapsed_slice_dims()) {
       TF_LITE_ENSURE_STATUS(FlatBufferIntVectorToArray<int64_t>(
-          schema_params->collapsed_slice_dims()->size() * sizeof(int64_t),
+          sizeof(params->collapsed_slice_dims),
           schema_params->collapsed_slice_dims(), params->collapsed_slice_dims,
           error_reporter, "stablehlo_gather"));
       params->num_collapsed_slice_dims =
@@ -2351,7 +2349,7 @@ TfLiteStatus ParseStablehloGather(const Operator* op,
 
     if (schema_params->start_index_map()) {
       TF_LITE_ENSURE_STATUS(FlatBufferIntVectorToArray<int64_t>(
-          schema_params->start_index_map()->size() * sizeof(int64_t),
+          sizeof(params->start_index_map),
           schema_params->start_index_map(), params->start_index_map,
           error_reporter, "stablehlo_gather"));
       params->num_start_index_map = schema_params->start_index_map()->size();
@@ -2361,7 +2359,7 @@ TfLiteStatus ParseStablehloGather(const Operator* op,
 
     if (schema_params->slice_sizes()) {
       TF_LITE_ENSURE_STATUS(FlatBufferIntVectorToArray<int64_t>(
-          schema_params->slice_sizes()->size() * sizeof(int64_t),
+          sizeof(params->slice_sizes),
           schema_params->slice_sizes(), params->slice_sizes, error_reporter,
           "stablehlo_gather"));
       params->num_slice_sizes = schema_params->slice_sizes()->size();


### PR DESCRIPTION
## Summary
- `ParseStablehloScatter` and `ParseStablehloGather` passed the **source** FlatBuffer vector byte size (`vec->size() * sizeof(int64_t)`) as `max_size_of_buffer` into `FlatBufferIntVectorToArray`.
- That makes the capacity guard `N > (N*8)/8` → `N > N` **always false**, so oversized attacker-controlled `.tflite` attributes can heap-OOB-write past the fixed `int64_t[MAX_DIMENSION_COUNT]` arrays in the params structs.
- Fix: pass `sizeof(destination_array)` instead, matching `ParseStablehloReduceWindow` / `ParseStablehloPad` in the same file.

## Affected call sites
**Scatter:** `update_window_dims`, `inserted_window_dims`, `scatter_dims_to_operand_dims`  
**Gather:** `offset_dims`, `collapsed_slice_dims`, `start_index_map`, `slice_sizes`

## Test plan
- [ ] Existing TFLite / StableHLO unit tests continue to pass
- [ ] Load a `.tflite` with `STABLEHLO_SCATTER` whose `update_window_dims.length > TFLITE_STABLEHLO_SCATTER_PARAMS_MAX_DIMENSION_COUNT` and confirm parse fails cleanly (no ASAN heap-buffer-overflow WRITE)
- [ ] Same check for oversized Gather attribute vectors
