### PR TITLE
Fix tf.transpose rejecting negative perm indices under XLA compilation

### DIFF
--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -1527,6 +1527,16 @@ class BinaryOpsTest(xla_test.XLATestCase):
           np.array([[1, 2], [3, 4]], dtype=dtype),
           np.array([1, 0], dtype=np.int32),
           expected=np.array([[1, 3], [2, 4]], dtype=dtype))
+      self._testBinary(
+          array_ops.transpose,
+          np.array([[1, 2], [3, 4]], dtype=dtype),
+          np.array([-1, 0], dtype=np.int32),
+          expected=np.array([[1, 3], [2, 4]], dtype=dtype))
+      self._testBinary(
+          array_ops.transpose,
+          np.zeros(shape=[1, 0, 4], dtype=dtype),
+          np.array([-2, -1, -3], dtype=np.int32),
+          expected=np.zeros(shape=[0, 4, 1], dtype=dtype))
 
   def testConjugateTranspose(self):
     for dtype in self.complex_types:
@@ -1544,6 +1554,11 @@ class BinaryOpsTest(xla_test.XLATestCase):
           array_ops.conjugate_transpose,
           np.array([[1 - 1j, 2 + 2j], [3 - 3j, 4 + 4j]], dtype=dtype),
           np.array([1, 0], dtype=np.int32),
+          expected=np.array([[1 + 1j, 3 + 3j], [2 - 2j, 4 - 4j]], dtype=dtype))
+      self._testBinary(
+          array_ops.conjugate_transpose,
+          np.array([[1 - 1j, 2 + 2j], [3 - 3j, 4 + 4j]], dtype=dtype),
+          np.array([-1, 0], dtype=np.int32),
           expected=np.array([[1 + 1j, 3 + 3j], [2 - 2j, 4 - 4j]], dtype=dtype))
 
   def testCross(self):

--- a/tensorflow/compiler/tf2xla/kernels/transpose_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/transpose_op.cc
@@ -71,7 +71,11 @@ class TransposeOp : public XlaOpKernel {
     absl::InlinedVector<bool, 8> bits(dims);
     bool is_identity = true;
     for (int i = 0; i < dims; ++i) {
-      const int64_t d = perm[i];
+      int64_t d = perm[i];
+      // Wrap negative indices, matching the behavior of the non-XLA kernel.
+      if (d < 0) {
+        d += dims;
+      }
       OP_REQUIRES(
           ctx, 0 <= d && d < dims,
           errors::InvalidArgument(d, " is out of range [0 .. ", dims, ")"));


### PR DESCRIPTION
`tf.transpose(x, perm=(-1, 0))` works in eager mode, which normalizes negative `perm` entries by adding the tensor rank, but fails XLA compilation (`jit_compile=True`) with `InvalidArgumentError: -1 is out of range [0 .. 2)`. The tf2xla kernel validated `perm` entries without normalizing them first.

This wraps negative indices in the XLA Transpose kernel before validation, matching the eager kernel and the TF MLIR dialect verifier, which already accepts `perm` values in `[-rank, rank)`. The normalized index flows into the duplicate check and the permutation order, so genuinely out-of-range or duplicate entries are still rejected with the same errors as eager. `ConjugateTranspose` shares this kernel and is fixed as well.

Fixes #124303.

## Testing

Added negative-`perm` cases to `testTranspose` and `testConjugateTranspose` in `compiler/tests/binary_ops_test.py`, mirroring the existing positive-`perm` cases. Verified the validation logic against the eager kernel's behavior in a standalone harness (repro case, all-negative perm, out-of-range and duplicate rejection all match), and the expected test values against numpy.