### PR TITLE
Fix stack overflow in DebugFileIO::RecursiveCreateDir for relative debug dump paths (#123114)

### DIFF
--- a/tensorflow/core/debug/debug_io_utils.cc
+++ b/tensorflow/core/debug/debug_io_utils.cc
@@ -694,6 +694,14 @@ absl::Status DebugFileIO::DumpTensorToEventFile(
 }
 
 absl::Status DebugFileIO::RecursiveCreateDir(Env* env, const std::string& dir) {
+  if (dir.empty()) {
+    // io::Dirname() returns "" for any path with no '/' component; this is
+    // a fixed point (Dirname("") == ""). It means there is no parent
+    // directory left to create: any remaining path is relative to the
+    // current working directory. Stop here instead of recursing forever.
+    return absl::OkStatus();
+  }
+
   if (env->FileExists(dir).ok() && env->IsDirectory(dir).ok()) {
     // The path already exists as a directory. Return OK right away.
     return absl::OkStatus();

--- a/tensorflow/core/debug/debug_io_utils_test.cc
+++ b/tensorflow/core/debug/debug_io_utils_test.cc
@@ -151,6 +151,58 @@ TEST_F(DebugIOUtilsTest, DumpFloatTensorToFileSunnyDay) {
   ASSERT_EQ(0, undeleted_dirs);
 }
 
+TEST_F(DebugIOUtilsTest, DumpTensorToDirWithRelativeDumpRootSunnyDay) {
+  Initialize();
+
+  // A relative directory with no path separator at all. io::Dirname() on a
+  // path like this returns "", and DebugFileIO::RecursiveCreateDir used to
+  // recurse on that empty result forever instead of treating it as "no
+  // parent directory left to create" (see GitHub issue #123114).
+  const std::string test_dir = "tfdbg_relative_dump_root_test";
+  if (env_->FileExists(test_dir).ok()) {
+    int64_t undeleted_files = 0;
+    int64_t undeleted_dirs = 0;
+    ASSERT_TRUE(
+        env_->DeleteRecursively(test_dir, &undeleted_files, &undeleted_dirs)
+            .ok());
+  }
+
+  const uint64_t wall_time = env_->NowMicros();
+  const DebugNodeKey kDebugNodeKey("/job:localhost/replica:0/task:0/cpu:0",
+                                   "foo/bar/qux/tensor_a", 0, "DebugIdentity");
+
+  std::string dump_file_path;
+  TF_ASSERT_OK(DebugFileIO::DumpTensorToDir(
+      kDebugNodeKey, *tensor_a_, wall_time, test_dir, &dump_file_path));
+
+  // Read the file into a Event proto.
+  Event event;
+  TF_ASSERT_OK(ReadEventFromFile(dump_file_path, &event));
+
+  ASSERT_GE(wall_time, event.wall_time());
+  ASSERT_EQ(1, event.summary().value().size());
+  ASSERT_EQ(kDebugNodeKey.debug_node_name,
+            event.summary().value(0).node_name());
+
+  Tensor a_prime(DT_FLOAT);
+  ASSERT_TRUE(a_prime.FromProto(event.summary().value(0).tensor()));
+
+  // Verify tensor shape and value.
+  ASSERT_EQ(tensor_a_->shape(), a_prime.shape());
+  for (int i = 0; i < a_prime.flat<float>().size(); ++i) {
+    ASSERT_EQ(tensor_a_->flat<float>()(i), a_prime.flat<float>()(i));
+  }
+
+  // Tear down temporary file and directories.
+  int64_t undeleted_files = 0;
+  int64_t undeleted_dirs = 0;
+  ASSERT_TRUE(
+      env_->DeleteRecursively(test_dir, &undeleted_files, &undeleted_dirs)
+          .ok());
+  ASSERT_EQ(0, undeleted_files);
+  ASSERT_EQ(0, undeleted_dirs);
+}
+
 TEST_F(DebugIOUtilsTest, DumpStringTensorToFileSunnyDay) {
   Initialize();
 

--- a/tensorflow/core/debug/debug_io_utils_test.cc
+++ b/tensorflow/core/debug/debug_io_utils_test.cc
@@ -15,9 +15,16 @@ limitations under the License.
 
 #include "tensorflow/core/debug/debug_io_utils.h"
 
+#include <cstdio>
 #include <cstdlib>
 #include <memory>
 #include <unordered_set>
+
+#if defined(PLATFORM_WINDOWS)
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
 
 #include "absl/synchronization/notification.h"
 #include "tensorflow/core/debug/debug_callback_registry.h"
@@ -32,10 +39,40 @@ limitations under the License.
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/util/event.pb.h"
 
 namespace tensorflow {
 namespace {
+
+#if defined(PLATFORM_WINDOWS)
+#define TFDBG_GETCWD _getcwd
+#define TFDBG_CHDIR _chdir
+#else
+#define TFDBG_GETCWD getcwd
+#define TFDBG_CHDIR chdir
+#endif
+
+// Temporarily changes the process's current working directory for the
+// lifetime of this object, then restores the original directory. Used by
+// tests that must exercise a bare relative (slash-less) path argument, which
+// otherwise depends on whatever the test runner's ambient CWD happens to be.
+class ScopedChdir {
+ public:
+  explicit ScopedChdir(const std::string& new_dir) {
+    char buf[FILENAME_MAX];
+    CHECK(TFDBG_GETCWD(buf, sizeof(buf)) != nullptr);
+    old_dir_ = buf;
+    CHECK_EQ(0, TFDBG_CHDIR(new_dir.c_str()));
+  }
+  ~ScopedChdir() { (void)TFDBG_CHDIR(old_dir_.c_str()); }
+
+ private:
+  std::string old_dir_;
+};
+
+#undef TFDBG_GETCWD
+#undef TFDBG_CHDIR
 
 class DebugIOUtilsTest : public ::testing::Test {
  public:
@@ -153,6 +190,10 @@ TEST_F(DebugIOUtilsTest, DumpFloatTensorToFileSunnyDay) {
 
 TEST_F(DebugIOUtilsTest, DumpTensorToDirWithRelativeDumpRootSunnyDay) {
   Initialize();
+  // Run inside a directory guaranteed to be writable, so the relative-path
+  // dump below doesn't depend on whatever the test runner's ambient current
+  // working directory happens to be.
+  ScopedChdir scoped_chdir(testing::TmpDir());
 
   // A relative directory with no path separator at all. io::Dirname() on a
   // path like this returns "", and DebugFileIO::RecursiveCreateDir used to

--- a/tensorflow/core/debug/debug_io_utils_test.cc
+++ b/tensorflow/core/debug/debug_io_utils_test.cc
@@ -162,9 +162,8 @@ TEST_F(DebugIOUtilsTest, DumpTensorToDirWithRelativeDumpRootSunnyDay) {
   if (env_->FileExists(test_dir).ok()) {
     int64_t undeleted_files = 0;
     int64_t undeleted_dirs = 0;
-    ASSERT_TRUE(
-        env_->DeleteRecursively(test_dir, &undeleted_files, &undeleted_dirs)
-            .ok());
+    TF_ASSERT_OK(
+        env_->DeleteRecursively(test_dir, &undeleted_files, &undeleted_dirs));
   }
 
   const uint64_t wall_time = env_->NowMicros();
@@ -196,9 +195,8 @@ TEST_F(DebugIOUtilsTest, DumpTensorToDirWithRelativeDumpRootSunnyDay) {
   // Tear down temporary file and directories.
   int64_t undeleted_files = 0;
   int64_t undeleted_dirs = 0;
-  ASSERT_TRUE(
-      env_->DeleteRecursively(test_dir, &undeleted_files, &undeleted_dirs)
-          .ok());
+  TF_ASSERT_OK(
+      env_->DeleteRecursively(test_dir, &undeleted_files, &undeleted_dirs));
   ASSERT_EQ(0, undeleted_files);
   ASSERT_EQ(0, undeleted_dirs);
 }


### PR DESCRIPTION
Fixes #123114

## Problem

SavedModels containing `tf.raw_ops.DebugIdentity`, `DebugIdentityV3`, `DebugNanCount`, or `DebugNumericSummary` with a relative `file://` debug URL (e.g. `debug_urls=["file://tfdbg_DebugIdentity"]`, no leading slash) segfault when loaded and run in a fresh process:

```python
import tensorflow as tf

class ReproModel(tf.Module):
  @tf.function(input_signature=[tf.TensorSpec(shape=[None], dtype=tf.float32)])
  def __call__(self, x):
    debug_op = tf.raw_ops.DebugIdentity(
        input=x, device_name="/device:CPU:0", tensor_name="sample_tensor:0",
        debug_urls=["file://tfdbg_DebugIdentity"], gated_grpc=False)
    return x + tf.reduce_sum(tf.cast(debug_op, tf.float32)) * 0.0

tf.saved_model.save(ReproModel(), "model")
```

Then, in a separate process:

```python
import tensorflow as tf

m = tf.saved_model.load("model")
print(m(tf.constant([10.0, -5.0, 0.0, 8.0])))
```

```
$ python load_and_run.py
Segmentation fault (core dumped)
```

## Root cause

`DebugFileIO::RecursiveCreateDir` (`tensorflow/core/debug/debug_io_utils.cc`) walks up a directory path calling `io::Dirname()` to find each parent, recursing until it finds one that already exists. For a relative, slash-less path (like `tfdbg_DebugIdentity`), `io::Dirname()` returns an empty string, and `io::Dirname("")` returns `""` again: a fixed point with no base case to stop the recursion. `RecursiveCreateDir(env, "")` calls itself with the identical empty argument forever.

Confirmed with gdb: about 29,100 identical recursive frames before the stack overflows and the process crashes. Call chain: `DebugIdentityOp::Compute` (and the sibling `DebugIdentityV3Op`, `DebugNanCountOp`, `DebugNumericSummaryOp`, all through the shared `BaseDebugOp::PublishTensor`) -> `DebugIO::PublishDebugTensor` -> `DebugFileIO::DumpTensorToEventFile` -> `DumpEventProtoToFile` -> `RecursiveCreateDir` (self-recursive).

## Fix

Add a base case: when the directory is empty, there is no parent left to create, so return immediately instead of recursing. The caller's own `CreateDir` call then proceeds normally, so relative debug dump paths still work, anchored at the current working directory instead of hitting an unreachable "parent."

```cpp
if (dir.empty()) {
  // io::Dirname() returns "" for any path with no '/' component; this is
  // a fixed point (Dirname("") == ""). It means there is no parent
  // directory left to create: any remaining path is relative to the
  // current working directory. Stop here instead of recursing forever.
  return absl::OkStatus();
}
```

Scope: only `RecursiveCreateDir` in `debug_io_utils.cc`. `io::Dirname`/`SplitPath` (in the TSL/XLA-mirrored `path.cc`) are untouched; their empty-string-on-no-separator behavior is relied on elsewhere and is correct as is. There's a separate, pre-existing TOCTOU race noted in a comment a few lines below this fix (the `CreateDir`-then-recheck pattern) that this PR does not address; it's a different issue from the one reported here.

## Testing

Added `DumpTensorToDirWithRelativeDumpRootSunnyDay` to `DebugIOUtilsTest` in `debug_io_utils_test.cc`, using a relative, slash-less dump root to exercise the exact path that used to crash, and asserting the dump succeeds and reads back correctly.

`bazel test //tensorflow/core/debug:debug_io_utils_test`: 15/15 tests pass, including the new one and all pre-existing cases (no regressions).
