### PR TITLE
Validate axis lower bound in Dequantize and QuantizeV2 kernels

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_Dequantize.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Dequantize.pbtxt
@@ -13,6 +13,17 @@ The maximum scalar value possibly produced for the input.
 END
   }
   attr {
+    name: "axis"
+    description: <<END
+The index of the input dimension along which the dequantization ranges
+vary, for per-channel dequantization. When `axis` is -1 (the default),
+dequantization is per-tensor and `min_range`/`max_range` must be scalars.
+Otherwise `min_range` and `max_range` must be 1-D tensors with as many
+elements as the input's `axis` dimension. Negative values other than -1
+are invalid.
+END
+  }
+  attr {
     name: "dtype"
     description: <<END
 Type of the output tensor. Currently Dequantize supports float and bfloat16.

--- a/tensorflow/core/api_def/base_api/api_def_QuantizeV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_QuantizeV2.pbtxt
@@ -43,6 +43,17 @@ matches the `axis` dimension of the input and output tensors.
 END
   }
   attr {
+    name: "axis"
+    description: <<END
+The index of the input dimension along which the quantization ranges
+vary, for per-channel quantization. When `axis` is -1 (the default),
+quantization is per-tensor and `min_range`/`max_range` must be scalars.
+Otherwise `min_range` and `max_range` must be 1-D tensors with as many
+elements as the input's `axis` dimension. Negative values other than -1
+are invalid.
+END
+  }
+  attr {
     name: "round_mode"
     description: <<END
 `round_mode='HALF_TO_EVEN'` only supported for mode 'SCALED'.

--- a/tensorflow/core/kernels/dequantize_op.cc
+++ b/tensorflow/core/kernels/dequantize_op.cc
@@ -97,6 +97,10 @@ class DequantizeOp : public OpKernel {
     const Tensor& input_min_tensor = ctx->input(1);
     const Tensor& input_max_tensor = ctx->input(2);
 
+    OP_REQUIRES(ctx, axis_ >= -1,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Axis must be at least -1, where -1 selects per-tensor "
+                    "dequantization, got ", axis_)));
     OP_REQUIRES(ctx, axis_ < input.dims(),
                 absl::InvalidArgumentError(
                     absl::StrCat("Axis must be less than input dimension(",

--- a/tensorflow/core/kernels/quantize_op.cc
+++ b/tensorflow/core/kernels/quantize_op.cc
@@ -114,6 +114,11 @@ class QuantizeV2Op : public OpKernel {
     const Tensor& input_min_range = ctx->input(1);
     const Tensor& input_max_range = ctx->input(2);
 
+    OP_REQUIRES(ctx, axis_ >= -1,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Axis must be at least -1, where -1 selects per-tensor "
+                    "quantization, got ", axis_)));
+
     int num_slices = 1;
     if (axis_ > -1) {
       OP_REQUIRES(

--- a/tensorflow/python/kernel_tests/quantization_ops/quantization_ops_test.py
+++ b/tensorflow/python/kernel_tests/quantization_ops/quantization_ops_test.py
@@ -22,6 +22,7 @@ from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import googletest
@@ -407,6 +408,58 @@ class QuantizeDownAndShrinkRangeOpTest(test_util.TensorFlowTestCase):
           math_ops.quantize_down_and_shrink_range(
               input=inputs, input_min=[], input_max=4.0,
               out_type=dtypes.quint8))
+
+
+class DequantizeOpTest(test_util.TensorFlowTestCase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_axis_below_minus_one_raises(self):
+    # Regression test for GitHub issue 100175: the kernel accepted axis
+    # values below -1 in eager mode and silently treated them as per-tensor
+    # dequantization, while the shape function already rejected them at
+    # graph construction time.
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError), "at least -1"):
+      self.evaluate(
+          gen_array_ops.dequantize(
+              input=constant_op.constant(
+                  np.uint8(74), shape=[3], dtype=dtypes.quint8),
+              min_range=0.0,
+              max_range=1.0,
+              mode="MIN_COMBINED",
+              axis=-5))
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_per_tensor_sentinel_axis_valid(self):
+    # axis=-1 is the per-tensor sentinel at the op level and must keep
+    # working with scalar ranges.
+    output = self.evaluate(
+        gen_array_ops.dequantize(
+            input=constant_op.constant(
+                np.uint8(74), shape=[3], dtype=dtypes.quint8),
+            min_range=0.0,
+            max_range=1.0,
+            mode="MIN_COMBINED",
+            axis=-1))
+    self.assertEqual((3,), output.shape)
+
+
+class QuantizeV2OpTest(test_util.TensorFlowTestCase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_axis_below_minus_one_raises(self):
+    # Same missing lower-bound validation as Dequantize; see GitHub issue
+    # 100175.
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError), "at least -1"):
+      self.evaluate(
+          gen_array_ops.quantize_v2(
+              input=constant_op.constant([0.1, 0.5, 0.9]),
+              min_range=0.0,
+              max_range=1.0,
+              T=dtypes.quint8,
+              mode="MIN_COMBINED",
+              axis=-5))
 
 
 class QuantizeAndDequantizeV3OpTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
## Summary

Fixes #100175.

`tf.raw_ops.Dequantize` silently accepts `axis` values below -1 in eager execution and treats them as per-tensor dequantization. Probing the op family showed `tf.raw_ops.QuantizeV2` has the identical hole; `QuantizeAndDequantizeV2/V3/V4` already validate and are unaffected.

## Root cause

Both ops' shape functions already reject `axis < -1` at graph construction time (`axis should be at least -1`), but shape functions do not run in eager execution, and the kernels validate only the upper bound. At the op level, `axis=-1` is the per-tensor sentinel rather than a NumPy-style negative index, so values below -1 are invalid. (The Python-level `tf.quantization.dequantize` wrapper is a different, NumPy-style axis surface and normalizes negative axes before reaching the op, which is why this is reachable only via raw ops.)

This op-level/Python-level distinction is also the "axis=-1 has two meanings" confusion that stalled the earlier attempt in #102034, which tried to reinterpret negative axes NumPy-style inside the kernel. This PR takes the minimal path instead: make the kernels agree with what the shape functions already enforce.

## Changes

- `dequantize_op.cc`, `quantize_op.cc`: add the symmetric `axis >= -1` check with a clear error, so eager matches graph mode.
- `api_def_Dequantize.pbtxt`, `api_def_QuantizeV2.pbtxt`: document the previously undocumented `axis` attr, including per-channel semantics (the third point in the issue) and why `axis=0` with scalar ranges is rejected by design (the second point, which is working as intended).
- Regression tests in `quantization_ops_test.py` for both ops, running in graph and eager modes.

## Verification

On the unfixed 2.21.0 wheel, the new invalid-axis tests fail exactly and only in eager mode (where the bug lives) and pass in graph mode (where the shape function already validates), so they gate the fix precisely. The per-tensor sentinel test passes in both modes, and the full `quantization_ops_test.py` file shows no other changes in behavior.

Credit to @ILCSFNO for the report and the original analysis, and for the earlier attempt in #102034.