### PR TITLE
Use compiler-rt instead of libgcc on s390x

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1312,6 +1312,9 @@ def main():
       if environ_cp.get('TF_NEED_CLANG') == '1':
         clang_compiler_path = set_clang_compiler_path(environ_cp)
         clang_version = retrieve_clang_version(clang_compiler_path)
+        if is_s390x():
+          write_to_bazelrc('build --linkopt=-rtlib=compiler-rt')
+          write_to_bazelrc('build --host_linkopt=-rtlib=compiler-rt')
         disable_clang_offsetof_extension(clang_version)
     if is_windows():
       environ_cp['TF_NEED_CLANG'] = str(choose_compiler_Win(environ_cp))

--- a/configure.py
+++ b/configure.py
@@ -1314,7 +1314,6 @@ def main():
         clang_version = retrieve_clang_version(clang_compiler_path)
         if is_s390x():
           write_to_bazelrc('build --linkopt=-rtlib=compiler-rt')
-          write_to_bazelrc('build --host_linkopt=-rtlib=compiler-rt')
         disable_clang_offsetof_extension(clang_version)
     if is_windows():
       environ_cp['TF_NEED_CLANG'] = str(choose_compiler_Win(environ_cp))


### PR DESCRIPTION
libgcc (clang's default runtime library) on s390x is missing runtime symbols (__extendhfsf2 and __truncsfhf2), causing some test cases to fail with "Symbols not found". These symbols are present in libgcc on x86, which is why Intel builds are unaffected.

Added --linkopt/--host_linkopt=-rtlib=compiler-rt to the Bazelrc for s390x so clang links against compiler-rt instead, which provides these symbols.