### PR TITLE
Remove lit_script_with_xla_gpu_cuda_data_dir from TOSA glob_lit_test.bzl

### DIFF
--- a/tensorflow/compiler/mlir/tosa/glob_lit_test.bzl
+++ b/tensorflow/compiler/mlir/tosa/glob_lit_test.bzl
@@ -114,7 +114,7 @@ def glob_lit_tests(
 
         # Instantiate this test with updated parameters.
         _run_lit_test(
-            name = final_test_name + ".test",
+            name = curr_test + ".test",
             data = data + [curr_test] +
                    per_test_extra_data.get(curr_test, []),
             size = size_override.get(curr_test, default_size),

--- a/tensorflow/compiler/mlir/tosa/glob_lit_test.bzl
+++ b/tensorflow/compiler/mlir/tosa/glob_lit_test.bzl
@@ -7,10 +7,6 @@
 """
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(
-    "@xla//xla:lit.bzl",
-    "lit_script_with_xla_gpu_cuda_data_dir",
-)
 
 # Default values used by the test runner.
 _default_test_file_exts = ["mlir", ".pbtxt", ".td"]
@@ -81,8 +77,7 @@ def glob_lit_tests(
         driver = _default_driver,
         features = [],
         exec_properties = {},
-        use_lit_test_suite = None,  # @unused
-        hermetic_cuda_data_dir = None):
+        use_lit_test_suite = None):  # @unused
     """Creates all plausible Lit tests (and their inputs) under this directory.
 
     Args:
@@ -100,8 +95,6 @@ def glob_lit_tests(
               and specifying a default driver will abort the tests.
       features: [str], list of extra features to enable.
       exec_properties: a dictionary of properties to pass on.
-      hermetic_cuda_data_dir: string. If set, the tests will be run with a
-        `--xla_gpu_cuda_data_dir` flag set to the hermetic CUDA data directory.
       use_lit_test_suite: unused. For compatibility.
     """
 
@@ -117,23 +110,12 @@ def glob_lit_tests(
     # failure.
     all_tests = []
     for curr_test in tests:
-        final_test_name = curr_test
-        if hermetic_cuda_data_dir:
-            output_file = "with_xla_gpu_cuda_data_dir_{}".format(curr_test)
-            rule_name = "script_{}".format(output_file)
-            lit_script_with_xla_gpu_cuda_data_dir(
-                rule_name,
-                curr_test,
-                output_file,
-                hermetic_cuda_data_dir,
-            )
-            final_test_name = output_file
-        all_tests.append(final_test_name + ".test")
+        all_tests.append(curr_test + ".test")
 
         # Instantiate this test with updated parameters.
         _run_lit_test(
             name = final_test_name + ".test",
-            data = data + [final_test_name] +
+            data = data + [curr_test] +
                    per_test_extra_data.get(curr_test, []),
             size = size_override.get(curr_test, default_size),
             tags = default_tags + tags_override.get(curr_test, []),


### PR DESCRIPTION
In XLA, the hermetic CUDA data directory (`--xla_gpu_cuda_data_dir`) is now dynamically resolved at test runtime in `sh_test_with_runfiles.py`. The legacy `lit_script_with_xla_gpu_cuda_data_dir` macro and static genrule wrappers have been removed from `@xla//xla:lit.bzl` and TensorFlow's other `glob_lit_test.bzl` files. This PR cleans up `tensorflow/compiler/mlir/tosa/glob_lit_test.bzl` by:
- Removing the obsolete load of `lit_script_with_xla_gpu_cuda_data_dir` from `@xla//xla:lit.bzl`.
- Removing the unused `hermetic_cuda_data_dir` parameter and genrule generation block from `glob_lit_tests`.