### PR TITLE
docs: Add 'Getting Help' section to improve beginner onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ discussion, and please direct specific questions to
 The TensorFlow project strives to abide by generally accepted best practices in
 open-source software development.
 
+## Getting Help
+
+If you're new to TensorFlow or need assistance:
+
+* **Start with the official [TensorFlow Tutorials](https://www.tensorflow.org/tutorials/)** - Perfect for beginners, with hands-on examples
+* **Join [TensorFlow Forum](https://discuss.tensorflow.org/)** - Ask questions, share projects, and connect with the community
+* **Search [Stack Overflow](https://stackoverflow.com/questions/tagged/tensorflow)** - Thousands of answered TensorFlow questions
+* **Check the [TensorFlow YouTube Channel](https://www.youtube.com/channel/UC0rqucBdTuFTjJiefW5t-IQ)** - Video tutorials and conference talks
+* **Read the [TensorFlow Blog](https://blog.tensorflow.org)** - Latest updates, techniques, and use cases
+
+For bugs and feature requests, please use [GitHub Issues](https://github.com/tensorflow/tensorflow/issues) after checking existing issues first.
+
 ## Patching guidelines
 
 Follow these steps to patch a specific version of TensorFlow, for example, to

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ open-source software development.
 
 If you're new to TensorFlow or need assistance:
 
-* **Start with the official [TensorFlow Tutorials](https://www.tensorflow.org/tutorials/)** - Perfect for beginners, with hands-on examples
-* **Join [TensorFlow Forum](https://discuss.tensorflow.org/)** - Ask questions, share projects, and connect with the community
-* **Search [Stack Overflow](https://stackoverflow.com/questions/tagged/tensorflow)** - Thousands of answered TensorFlow questions
-* **Check the [TensorFlow YouTube Channel](https://www.youtube.com/channel/UC0rqucBdTuFTjJiefW5t-IQ)** - Video tutorials and conference talks
-* **Read the [TensorFlow Blog](https://blog.tensorflow.org)** - Latest updates, techniques, and use cases
+* **Start with the official [TensorFlow Tutorials](https://www.tensorflow.org/tutorials/)** - Perfect for beginners, with hands-on examples.
+* **Join [TensorFlow Forum](https://discuss.tensorflow.org/)** - Ask questions, share projects, and connect with the community.
+* **Search [Stack Overflow](https://stackoverflow.com/questions/tagged/tensorflow)** - Thousands of answered TensorFlow questions.
+* **Check the [TensorFlow YouTube Channel](https://www.youtube.com/tensorflow)** - Video tutorials and conference talks.
+* **Read the [TensorFlow Blog](https://blog.tensorflow.org)** - Latest updates, techniques, and use cases.
 
 For bugs and feature requests, please use [GitHub Issues](https://github.com/tensorflow/tensorflow/issues) after checking existing issues first.
 


### PR DESCRIPTION
## Summary

This PR adds a new 'Getting Help' section to the README to improve the onboarding experience for newcomers to TensorFlow.

## What changed

- Added a clear 'Getting Help' section immediately after the Contribution Guidelines
- Organized key community resources with bullet points for better readability
- Helps newcomers quickly discover:
  - Official tutorials for hands-on learning
  - Community forums for questions and discussions  
  - Stack Overflow for technical Q&A
  - YouTube channel for video content
  - TensorFlow blog for latest updates
- Clarifies when to use GitHub Issues vs community forums

## Why this matters

Currently, the README lists community resources at the end. New users may miss critical help channels, leading to:
- Misuse of GitHub Issues for general questions
- Difficulty finding learning resources
- Lower engagement with the community

This change makes it immediately clear where beginners should go for help, improving the overall contributor and user experience.

## Testing

- [x] Verified markdown formatting renders correctly
- [x] All links are valid and point to correct resources
- [x] Section placement follows logical flow (after contribution guidelines)

Thank you for considering this contribution to help make TensorFlow more accessible to newcomers!