### PR TITLE
Validate TensorList buffer dtype in XLA read kernels

### DIFF
--- a/tensorflow/compiler/tests/tensor_list_ops_test.py
+++ b/tensorflow/compiler/tests/tensor_list_ops_test.py
@@ -165,6 +165,36 @@ class ListOpsTest(parameterized.TestCase, xla_test.XLATestCase):
       t = list_ops.tensor_list_stack(l, element_dtype=dtypes.float32)
       self.assertAllEqual(t, [[3.0, 4.0], [0., 0.]])
 
+  def testStackReservedMismatchedElementDtype(self):
+    # Regression test for GitHub issue 124872. A list reserved with an unknown
+    # element shape is uninitialized, so its buffer is built from the first
+    # element written to it. Writing an element whose dtype disagrees with the
+    # list's declared element_dtype produced a buffer of the element's dtype;
+    # reading it back as the declared, wider dtype reinterpreted the buffer's
+    # bytes and read past its end, returning uninitialized memory instead of
+    # raising the error the non-XLA kernels raise.
+    with self.session(), self.test_scope():
+      l = list_ops.tensor_list_reserve(
+          element_dtype=dtypes.int64, element_shape=None, num_elements=2)
+      l = list_ops.tensor_list_set_item(
+          l, 0, constant_op.constant([1, 2], dtype=dtypes.int32))
+      with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                  "Invalid data types"):
+        self.evaluate(
+            list_ops.tensor_list_stack(l, element_dtype=dtypes.int64))
+
+  def testGetItemReservedMismatchedElementDtype(self):
+    # Companion to the above for the TensorListGetItem read path.
+    with self.session(), self.test_scope():
+      l = list_ops.tensor_list_reserve(
+          element_dtype=dtypes.int64, element_shape=None, num_elements=2)
+      l = list_ops.tensor_list_set_item(
+          l, 0, constant_op.constant([1, 2], dtype=dtypes.int32))
+      with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                  "Invalid data types"):
+        self.evaluate(
+            list_ops.tensor_list_get_item(l, 0, element_dtype=dtypes.int64))
+
   def testPushInEmptyListWithUnknownElementShape(self):
     with self.session(), self.test_scope():
       l = list_ops.empty_tensor_list(

--- a/tensorflow/compiler/tf2xla/kernels/tensor_list_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/tensor_list_ops.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/op_requires.h"
 #include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
@@ -45,6 +46,31 @@ limitations under the License.
 namespace tensorflow {
 
 namespace {
+
+// Verifies that the element type of an initialized TensorList's buffer matches
+// the element dtype the reading op expects.
+//
+// An uninitialized TensorList does not carry its element dtype: it is built by
+// BuildUninitializedTensorList(), which drops the `element_dtype` attr the
+// list was created with. Such a list is instead given a buffer derived from
+// the first element written to it, so a write whose dtype disagrees with the
+// list's declared dtype silently produces a buffer of the wrong element type
+// rather than failing the way the non-XLA kernels do. Reading that buffer back
+// as the declared dtype would reinterpret its bytes and, when the declared
+// dtype is wider, read past the end of the buffer.
+absl::Status VerifyBufferDataType(xla::XlaOp list, DataType expected_dtype) {
+  xla::Shape buffer_shape;
+  TF_RETURN_IF_ERROR(GetTensorListBufferShape(list, &buffer_shape));
+  TF_ASSIGN_OR_RETURN(
+      DataType buffer_dtype,
+      EncodePrimitiveTypeAsDataType(buffer_shape.element_type()));
+  if (buffer_dtype != expected_dtype) {
+    return errors::InvalidArgument(
+        "Invalid data types; op elements ", DataTypeString(expected_dtype),
+        " but list elements ", DataTypeString(buffer_dtype));
+  }
+  return absl::OkStatus();
+}
 
 // GetTensorListDynamicDims collects the dynamic dimensions that a tensorlist
 // may carry and returns them in a 2D vector: XlaOp[ElementSize][DimSize]. If a
@@ -374,6 +400,8 @@ class TensorListGetItemOp : public XlaOpKernel {
     xla::XlaOp list = ctx->Input(0);
     xla::XlaOp index = ctx->Input(1);
 
+    OP_REQUIRES_OK(ctx, VerifyBufferDataType(list, dtype_));
+
     xla::XlaOp result;
     OP_REQUIRES_OK(ctx, ExecuteTensorListGetItem(list, index, &result));
 
@@ -461,6 +489,9 @@ class TensorListStackOp : public XlaOpKernel {
     OP_REQUIRES(ctx, !is_nested,
                 errors::Unimplemented("Only non-nested TensorList is supported "
                                       "for TensorListGetItem."));
+
+    OP_REQUIRES_OK(ctx, VerifyBufferDataType(ctx->Input(0),
+                                             ctx->expected_output_dtype(0)));
 
     xla::XlaOp buffer;
     OP_REQUIRES_OK(ctx, GetTensorListBuffer(ctx->Input(0), &buffer));


### PR DESCRIPTION
## Summary

Fixes #124872.

Under `jit_compile=True`, a `tf.map_fn` whose function returns a different dtype than `elems` returns garbage instead of raising. Eager and autoclustered graph execution both reject the same program with `Invalid data types; op elements int32 but list elements int64`.

Reinterpreting the returned `int64` tensor as `int32` shows what is happening:

```
[1 2 3 4 5 | 1 1 3 4 5 | 1 2 1 4 5 | 1 2 3 1 5 | 0 0 0 ... | -1987057855 -1309176207 1022776 ...]
```

The first 20 `int32` slots are the correct results packed two per `int64`; the remaining 20 are past the end of the real buffer. Reproduced on the stock 2.21.0 CPU wheel.

## Root cause

An uninitialized TensorList does not carry its element dtype. `BuildUninitializedTensorList()` hardcodes `xla::PrimitiveType::S32` and takes no dtype argument, so the `element_dtype` attr that `TensorListReserve` read into `dtype_` is dropped. (This path is taken whenever the element shape is not a compile-time constant, as in the repro, where it derives from `tf.shape`.)

On the first write, `TensorListSetItemOp` calls `GetInitializedTensorListForElement()`, which sees an uninitialized list and builds the buffer from the *element's* shape and dtype. The `ShapeUtil::Compatible` check that would catch the mismatch sits inside the already-initialized branch and never runs. The buffer is therefore created with the element's dtype while the surrounding computation's output is typed with the declared dtype, so reading it back reinterprets the bytes and, for a wider declared dtype, reads past the end of the buffer.

The non-XLA kernel does have this check, at `tensorflow/core/kernels/list_kernels.cc:460`, which is where the eager and autoclustered error messages come from.

## Fix

Validate the buffer's element type against the expected element dtype in `TensorListStack` and `TensorListGetItem`, reusing the exact message the non-XLA kernel produces so the three execution paths agree. This makes `TensorListGetItemOp` use the `element_dtype` attr it already read but never used.

This rejects the mismatch at the read site rather than repairing the dropped dtype at its source. The deeper fix would be to thread the dtype into `BuildUninitializedTensorList()` so the write-site comparison can happen; that changes the uninitialized-list representation shared with while-loop carries, which seemed worth separating from a fix that stops uninitialized memory reaching callers. Happy to follow up with that if the XLA owners prefer it here.

## Tests

Two regression tests in `tensorflow/compiler/tests/tensor_list_ops_test.py` covering both read paths, modeled on the existing `testSetStackReservedUnknownElementShape` so they exercise the uninitialized-list path where the bug lives.

Note on verification: the C++ change is not locally compiled (no Bazel on this machine), so CI is the first build. The error message and type asserted by the tests were confirmed against the 2.21.0 wheel on the CPU path, which produces the identical `InvalidArgumentError` and message this change emits.

Credit to @MRiffiAslett for the report and the byte-level analysis of the packed output.