### PR TITLE
Fix experimental.numpy.hypot overflow for large finite float64 inputs

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -453,8 +453,7 @@ def hypot(x1, x2):  # pylint: disable=missing-function-docstring
     )
     return array_ops.where_v2(
         either_inf,
-        array_ops.ones_like(result)
-        * constant_op.constant(np.inf, dtype=result.dtype),
+        constant_op.constant(np.inf, dtype=result.dtype),
         result,
     )
 

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -429,8 +429,36 @@ def heaviside(x1, x2):  # pylint: disable=missing-function-docstring
 
 @tf_export.tf_export('experimental.numpy.hypot', v1=[])
 @np_utils.np_doc('hypot')
-def hypot(x1, x2):
-  return sqrt(square(x1) + square(x2))
+def hypot(x1, x2):  # pylint: disable=missing-function-docstring
+  def f(x1, x2):
+    # Promote non-floating inputs so scaling and sqrt stay accurate (matches
+    # the previous sqrt(square(x)+square(y)) float promotion via sqrt).
+    if not np.issubdtype(x1.dtype.as_numpy_dtype, np.inexact):
+      dtype = np_utils.result_type(float)
+      x1 = math_ops.cast(x1, dtype)
+      x2 = math_ops.cast(x2, dtype)
+    x1 = math_ops.abs(x1)
+    x2 = math_ops.abs(x2)
+    # C99/IEEE: hypot(±inf, y) == +inf even when y is NaN.
+    either_inf = math_ops.logical_or(math_ops.is_inf(x1), math_ops.is_inf(x2))
+    max_abs = math_ops.maximum(x1, x2)
+    min_abs = math_ops.minimum(x1, x2)
+    zero = constant_op.constant(0, dtype=max_abs.dtype)
+    one = constant_op.constant(1, dtype=max_abs.dtype)
+    # Scale by the larger magnitude to avoid intermediate overflow/underflow
+    # from square(x) + square(y) (e.g. hypot(1e200, 1e200) must stay finite).
+    safe_max = array_ops.where_v2(math_ops.equal(max_abs, zero), one, max_abs)
+    result = max_abs * math_ops.sqrt(
+        one + math_ops.square(min_abs / safe_max)
+    )
+    return array_ops.where_v2(
+        either_inf,
+        array_ops.ones_like(result)
+        * constant_op.constant(np.inf, dtype=result.dtype),
+        result,
+    )
+
+  return _bin_op(f, x1, x2)
 
 
 @tf_export.tf_export('experimental.numpy.kron', v1=[])

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -159,6 +159,24 @@ class MathTest(test.TestCase, parameterized.TestCase):
   def testSqrt(self):
     self._testUnaryOp(np_math_ops.sqrt, np.sqrt, 'sqrt')
 
+  def testHypot(self):
+    self._testBinaryOp(np_math_ops.hypot, np.hypot, 'hypot')
+
+  def testHypotLargeFiniteNoOverflow(self):
+    # Regression for large finite float64 inputs that overflow the naive
+    # sqrt(x*x + y*y) formulation (tensorflow/tensorflow#124774).
+    x = np.array(
+        [1e200, 1e300, 1e308, 1e200, 0.0, -1e200], dtype=np.float64
+    )
+    y = np.array(
+        [1e200, 1e300, 1e308, 1.0, 1e300, -1e200], dtype=np.float64
+    )
+    actual = np_math_ops.hypot(x, y)
+    expected = np.hypot(x, y)
+    self.assertTrue(np.all(np.isfinite(actual)))
+    self.assertTrue(np.all(np.isfinite(expected)))
+    self.match(actual, expected, msg='hypot large finite')
+
   def match(self, actual, expected, msg='', check_dtype=True):
     self.assertIsInstance(actual, np_arrays.ndarray)
     if check_dtype:

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -177,6 +177,17 @@ class MathTest(test.TestCase, parameterized.TestCase):
     self.assertTrue(np.all(np.isfinite(expected)))
     self.match(actual, expected, msg='hypot large finite')
 
+  def testHypotSpecialCases(self):
+    x = np.array(
+        [np.inf, -np.inf, np.nan, np.inf, 0.0, -3.0], dtype=np.float64
+    )
+    y = np.array(
+        [np.nan, np.nan, np.inf, 5.0, 0.0, -4.0], dtype=np.float64
+    )
+    actual = np_math_ops.hypot(x, y)
+    expected = np.hypot(x, y)
+    np.testing.assert_equal(actual.tolist(), expected.tolist())
+
   def match(self, actual, expected, msg='', check_dtype=True):
     self.assertIsInstance(actual, np_arrays.ndarray)
     if check_dtype:


### PR DESCRIPTION
## Description

`tensorflow.experimental.numpy.hypot` was implemented as `sqrt(square(x) + square(y))`, which overflows to `inf` for large but finite float64 inputs whose true hypotenuse is still finite (e.g. `hypot(1e200, 1e200)`).

This switches to the standard scaled form:

```text
max(|x|, |y|) * sqrt(1 + (min(|x|, |y|) / max(|x|, |y|))^2)
```

with a zero-safe max and C99/IEEE handling so `hypot(±inf, y) == +inf` even when `y` is NaN.

## Fixes

Fixes #124774

## Validation

Against TensorFlow **2.21.0** (CPU, Python 3.11):

1. **Before:** issue reproducer returns all-`inf` for the six float64 cases.
2. **After (same algorithm injected into installed `np_math_ops.hypot`):** finite results matching `numpy.hypot` to ~1e-15 relative error on the issue cases; additional checks for zeros, tiny float64 values, float32 large values, integer `3,4 -> 5`, and IEEE specials (`inf`/`nan`).
3. Naive `tf.sqrt(tf.square(x)+tf.square(y))` still overflows on the same inputs (confirms the bug class).

## Test plan

- [x] Added `testHypot` (binary op vs NumPy) and `testHypotLargeFiniteNoOverflow` (issue reproducer) in `np_math_ops_test.py`
- [x] Local numerical validation with installed TF 2.21.0 (full bazel suite not run; pure-Python change on the experimental numpy path)

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.