### PR TITLE
Fix tf.math.erf NaN for very large finite float64 inputs

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -876,6 +876,38 @@ struct functor_traits<scalar_erfinv_op<float>> {
   };
 };
 
+// Specialization of Eigen's scalar_erf_op for double.
+//
+// Eigen's generic_fast_erf for double (as of the Eigen pin used by TensorFlow)
+// does not clamp large inputs the way generic_fast_erfc does.  For |x| large
+// enough that intermediate x*x overflows, the result is NaN instead of +/-1.
+// Upstream Eigen fixed this in 3e5a2f9 ("Fix vectorized erf returning NaN at
+// +/-inf instead of +/-1"); specialize here until TensorFlow's Eigen pin
+// includes that fix.  See tensorflow/tensorflow#124773.
+//
+// Clamp domain matches Eigen erfc: beyond |x| >= 28, |erf(x)| is 1 within
+// double precision (erfc underflows).
+template <>
+struct scalar_erf_op<double> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const double operator()(
+      const double& a) const {
+    // Saturate outside the safe domain.  Comparisons with NaN are false, so
+    // NaN falls through to numext::erf and stays NaN.  +/-inf saturate to +/-1.
+    constexpr double kClamp = 28.0;
+    if (a >= kClamp) return 1.0;
+    if (a <= -kClamp) return -1.0;
+    return numext::erf(a);
+  }
+  template <typename Packet>
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet& a) const {
+    // Match Eigen erfc / upstream erf clamp for the vectorized path.
+    constexpr double kClamp = 28.0;
+    const Packet x =
+        pmin(pmax(a, pset1<Packet>(-kClamp)), pset1<Packet>(kClamp));
+    return pselect(pcmp_eq(a, a), perf(x), a);
+  }
+};
+
 }  // end namespace internal
 }  // end namespace Eigen
 

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -268,6 +268,33 @@ class UnaryOpTest(test.TestCase):
     self.assertTrue(np.isnan(y[2]))
     self.assertTrue(np.isnan(y[3]))
 
+  def testDoubleErfLargeFinite(self):
+    # Regression test for GitHub issue #124773: Eigen's double erf used to
+    # return NaN for very large finite inputs (and +/-inf) because intermediate
+    # x*x overflowed.  erf should saturate to +/-1 for these values, matching
+    # math.erf / scipy / peer libraries.
+    x = np.array(
+        [1e200, 1e300, -1e200, -1e300, np.inf, -np.inf], dtype=np.float64
+    )
+    with self.cached_session():
+      y = self.evaluate(math_ops.erf(ops.convert_to_tensor(x)))
+    self.assertAllEqual(np.array([1.0, 1.0, -1.0, -1.0, 1.0, -1.0]), y)
+    # Still finite for the large-but-finite cases.
+    self.assertTrue(np.all(np.isfinite(y[:4])))
+    # NaN input remains NaN (scalar path).
+    nan_y = self.evaluate(
+        math_ops.erf(
+            ops.convert_to_tensor(np.array([np.nan], dtype=np.float64))
+        )
+    )
+    self.assertTrue(np.isnan(nan_y[0]))
+    # NaN input remains NaN (vectorized packet path).
+    nan_x = np.array(
+        [np.nan, 1.0, np.nan, 1e300, np.nan] * 8, dtype=np.float64
+    )
+    nan_y_vec = self.evaluate(math_ops.erf(ops.convert_to_tensor(nan_x)))
+    self.assertAllEqual(np.isnan(nan_x), np.isnan(nan_y_vec))
+
   @test_util.run_deprecated_v1
   def testFloatTanhEdge(self):
     x = np.arange(40, 40 + 6).reshape(6).astype(np.float32)


### PR DESCRIPTION
## Description

Fixes #124773: large finite double-precision inputs to `tf.math.erf`, and infinities, could produce NaN instead of saturating to +1 or -1.

Specializes `scalar_erf_op<double>` in `cwise_ops.h` to clamp large values before the approximation and preserve NaN inputs on both scalar and packet paths.

## Test Plan

`UnaryOpTest.testDoubleErfLargeFinite` covers positive and negative extreme values, infinities, scalar NaN and a mixed multi-element array that exercises the vectorized path.

### AI disclosure
AI coding tools, including Grok and Codex, assisted with the implementation and description.
