### PR TITLE
Fix bessel_i0 intermediate overflow for large finite |x|

### DIFF
--- a/tensorflow/core/kernels/special_math/special_math_op_misc_impl.h
+++ b/tensorflow/core/kernels/special_math/special_math_op_misc_impl.h
@@ -659,6 +659,38 @@ struct spence_op {
   }
 };
 
+// Overflow-safe modified Bessel I0.
+//
+// Eigen's scalar_bessel_i0_op computes exp(|x|) * i0e(x). For large |x| the
+// intermediate exp(|x|) overflows to +inf even when the product is still
+// representable (e.g. float64 x=713, true I0 ≈ 6.705e307). Compose in log
+// space when exp(|x|) would overflow: exp(|x| + log(i0e(x))).
+template <typename Scalar>
+struct bessel_i0_stable_op {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
+  operator()(const Scalar& x) const {
+    using numext::abs;
+    using numext::bessel_i0e;
+    using numext::exp;
+    using numext::log;
+
+    const Scalar ax = abs(x);
+    const Scalar i0e = bessel_i0e(x);
+    // log(highest) is the largest finite value of exp(); beyond this, the
+    // naive exp(ax)*i0e path overflows intermediate results.
+    const Scalar log_max = log(NumTraits<Scalar>::highest());
+    // NaN-safe: (ax >= log_max) is false when ax is NaN, so we keep the
+    // product path which propagates NaN.
+    if (!(ax >= log_max)) {
+      return exp(ax) * i0e;
+    }
+    if (i0e == Scalar(0)) {
+      return NumTraits<Scalar>::infinity();
+    }
+    return exp(ax + log(i0e));
+  }
+};
+
 }  // end namespace internal
 }  // end namespace Eigen
 
@@ -682,8 +714,9 @@ struct spence : base<T, Eigen::internal::spence_op<T>> {};
 
 // Bessel Functions
 
+// Use overflow-safe I0 (see Eigen::internal::bessel_i0_stable_op).
 template <typename T>
-struct bessel_i0 : base<T, Eigen::internal::scalar_bessel_i0_op<T>> {};
+struct bessel_i0 : base<T, Eigen::internal::bessel_i0_stable_op<T>> {};
 
 template <typename T>
 struct bessel_i0e : base<T, Eigen::internal::scalar_bessel_i0e_op<T>> {};

--- a/tensorflow/core/kernels/special_math/special_math_op_misc_impl.h
+++ b/tensorflow/core/kernels/special_math/special_math_op_misc_impl.h
@@ -19,7 +19,6 @@ limitations under the License.
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <functional>
-#include <limits>
 #include <type_traits>
 
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
@@ -686,7 +685,7 @@ struct bessel_i0_stable_op {
       return exp(ax) * i0e;
     }
     if (i0e == Scalar(0)) {
-      return std::numeric_limits<Scalar>::infinity();
+      return NumTraits<Scalar>::infinity();
     }
     return exp(ax + log(i0e));
   }

--- a/tensorflow/core/kernels/special_math/special_math_op_misc_impl.h
+++ b/tensorflow/core/kernels/special_math/special_math_op_misc_impl.h
@@ -19,7 +19,6 @@ limitations under the License.
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <functional>
-#include <limits>
 #include <type_traits>
 
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
@@ -686,7 +685,10 @@ struct bessel_i0_stable_op {
       return exp(ax) * i0e;
     }
     if (i0e == Scalar(0)) {
-      return std::numeric_limits<Scalar>::infinity();
+      // NumTraits::infinity() / numeric_limits::infinity() are host-only
+      // and fail CUDA. highest()*highest() overflows to +inf on device.
+      const Scalar hi = NumTraits<Scalar>::highest();
+      return hi * hi;
     }
     return exp(ax + log(i0e));
   }

--- a/tensorflow/core/kernels/special_math/special_math_op_misc_impl.h
+++ b/tensorflow/core/kernels/special_math/special_math_op_misc_impl.h
@@ -19,6 +19,7 @@ limitations under the License.
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <type_traits>
 
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
@@ -685,7 +686,7 @@ struct bessel_i0_stable_op {
       return exp(ax) * i0e;
     }
     if (i0e == Scalar(0)) {
-      return NumTraits<Scalar>::infinity();
+      return std::numeric_limits<Scalar>::infinity();
     }
     return exp(ax + log(i0e));
   }

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -415,6 +415,26 @@ class BesselTest(test.TestCase, parameterized.TestCase):
         np.isnan(self.evaluate(special_math_ops.bessel_i1e(np.nan))))
 
   @test_util.run_in_graph_and_eager_modes
+  def test_bessel_i0_avoids_intermediate_overflow(self):
+    # Regression for https://github.com/tensorflow/tensorflow/issues/124772
+    # Eigen's i0 = exp(|x|)*i0e(x) overflows exp(|x|) while the product is still
+    # finite. Reference values from high-precision I0 rounded to the dtype.
+    x64 = np.array([713.0, -713.0], dtype=np.float64)
+    y64 = self.evaluate(special_math_ops.bessel_i0(x64))
+    self.assertTrue(np.all(np.isfinite(y64)))
+    truth64 = 6.705128263670996e307
+    self.assertAllClose(y64, [truth64, truth64], rtol=1e-12, atol=0.0)
+
+    # float32: exp overflows near ~88.7; I0(90) remains finite (~5.14e37).
+    x32 = np.array([90.0, -90.0], dtype=np.float32)
+    y32 = self.evaluate(special_math_ops.bessel_i0(x32))
+    self.assertTrue(np.all(np.isfinite(y32)))
+    # Stable reference: exp(|x| + log(i0e(x))) evaluated in float64.
+    i0e32 = self.evaluate(special_math_ops.bessel_i0e(x32)).astype(np.float64)
+    truth32 = np.exp(np.abs(x32.astype(np.float64)) + np.log(i0e32))
+    self.assertAllClose(y32, truth32.astype(np.float32), rtol=1e-5, atol=0.0)
+
+  @test_util.run_in_graph_and_eager_modes
   def test_besselj_boundary(self):
     self.assertAllClose(1., special_math_ops.bessel_j0(0.))
     self.assertAllClose(0., special_math_ops.bessel_j1(0.))


### PR DESCRIPTION
## Description

Fixes #124772

`tf.math.bessel_i0` currently overflows to `+inf` for float64 inputs near the top of the finite range (e.g. `713.0`) even though the correctly rounded float64 result is still finite (`≈ 6.705e307`).

### Root cause

Eigen's `scalar_bessel_i0_op` evaluates `i0(x) = exp(|x|) * i0e(x)`. For large `|x|`, the intermediate `exp(|x|)` overflows before the multiply by the small `i0e(x)`, producing `inf` even when the product is representable.

The same pattern hits float32 around `|x| ≈ 90` (true `I0(90) ≈ 5.14e37` is finite).

### Fix

Add `Eigen::internal::bessel_i0_stable_op` in `special_math_op_misc_impl.h` and wire `functor::bessel_i0` to it:

- Common path (`|x| < log(highest)`): keep `exp(|x|) * i0e(x)` (same as Eigen, full precision).
- Overflow path: `exp(|x| + log(i0e(x)))`, which stays finite whenever the mathematical result is representable.
- NaN / zero-`i0e` edge cases preserved.

Applies to both CPU and GPU registrations (same functor). Packet path intentionally disabled (scalar only), matching other special-math ops like `dawsn`.

### Test

`BesselTest.test_bessel_i0_avoids_intermediate_overflow` covers:

- float64 `±713.0` vs high-precision reference `6.705128263670996e307`
- float32 `±90.0` vs stable `exp(|x|+log(i0e(x)))` reference

### Local validation

Formula checked against SciPy `i0e` plus log-space composition (relative error about 5e-14 at 713). New kernel test: `BesselTest.test_bessel_i0_avoids_intermediate_overflow`.

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.
