### PR TITLE
Fix ELU gradient precision for negative inputs

### DIFF
--- a/tensorflow/python/eager/pywrap_gradient_exclusions.cc
+++ b/tensorflow/python/eager/pywrap_gradient_exclusions.cc
@@ -50,7 +50,7 @@ auto OpGradientInfoInit(const T &a) {
 
 absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
     const tensorflow::string &op_name) {
-  static std::array<OpIndexInfo, 367> a = {{
+  static std::array<OpIndexInfo, 366> a = {{
       {"Acosh"},
       {"AllToAll", 1, {0}},
       {"ApproximateEqual"},
@@ -111,7 +111,6 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
       {"DiagPart"},
       {"DrawBoundingBoxes"},
       {"EditDistance"},
-      {"Elu"},
       {"EncodeBase64"},
       {"EnsureShape"},
       {"Enter"},
@@ -430,7 +429,7 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
 
 absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedOutputIndices(
     const tensorflow::string &op_name) {
-  static std::array<OpIndexInfo, 486> a = {{
+  static std::array<OpIndexInfo, 487> a = {{
       {"Abs"},
       {"AccumulateNV2"},
       {"Acos"},
@@ -529,6 +528,7 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedOutputIndices(
       {"DynamicPartition"},
       {"EditDistance"},
       {"Einsum"},
+      {"Elu"},
       {"EluGrad"},
       {"EncodeBase64"},
       {"EncodeProto"},

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -458,7 +458,10 @@ def _LeakyReluGradGrad(op: ops.Operation, grad):
 
 @ops.RegisterGradient("Elu")
 def _EluGrad(op: ops.Operation, grad):
-  return gen_nn_ops.elu_grad(grad, op.outputs[0])
+  x = op.inputs[0]
+  # Computing the gradient from the ELU output loses precision when exp(x) is
+  # too small to affect -1. Compute it directly from the input instead.
+  return grad * math_ops.exp(math_ops.minimum(x, 0))
 
 
 @ops.RegisterGradient("Selu")

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -461,7 +461,7 @@ def _EluGrad(op: ops.Operation, grad):
   x = op.inputs[0]
   # Computing the gradient from the ELU output loses precision when exp(x) is
   # too small to affect -1. Compute it directly from the input instead.
-  return grad * math_ops.exp(math_ops.minimum(x, 0))
+  return grad * math_ops.exp(math_ops.minimum(x, 0.0))
 
 
 @ops.RegisterGradient("Selu")

--- a/tensorflow/python/ops/nn_grad_test.py
+++ b/tensorflow/python/ops/nn_grad_test.py
@@ -183,14 +183,21 @@ class EluGradOpTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def testEluGradPreservesSmallNegativeValues(self):
-    inputs = constant_op.constant(-40.0, dtype=dtypes.float64)
-    with backprop.GradientTape() as tape:
-      tape.watch(inputs)
-      elu = gen_nn_ops.elu(inputs)
+    test_cases = (
+        (dtypes.float32, -20.0, 1e-6),
+        (dtypes.float64, -40.0, 1e-14),
+    )
+    for dtype, value, rtol in test_cases:
+      with self.subTest(dtype=dtype.name):
+        inputs = constant_op.constant(value, dtype=dtype)
+        with backprop.GradientTape() as tape:
+          tape.watch(inputs)
+          elu = gen_nn_ops.elu(inputs)
 
-    elu_grad = tape.gradient(elu, inputs)
-    self.assertAllClose(
-        np.exp(-40.0), self.evaluate(elu_grad), rtol=1e-14, atol=0)
+        elu_grad = tape.gradient(elu, inputs)
+        expected = np.exp(dtype.as_numpy_dtype(value))
+        self.assertAllClose(
+            expected, self.evaluate(elu_grad), rtol=rtol, atol=0)
 
   @test_util.run_deprecated_v1
   def testEluGradGradWRTgrad_ys(self):

--- a/tensorflow/python/ops/nn_grad_test.py
+++ b/tensorflow/python/ops/nn_grad_test.py
@@ -181,6 +181,17 @@ class DepthwiseConv2dTest(test.TestCase):
 
 class EluGradOpTest(test.TestCase):
 
+  @test_util.run_in_graph_and_eager_modes
+  def testEluGradPreservesSmallNegativeValues(self):
+    inputs = constant_op.constant(-40.0, dtype=dtypes.float64)
+    with backprop.GradientTape() as tape:
+      tape.watch(inputs)
+      elu = gen_nn_ops.elu(inputs)
+
+    elu_grad = tape.gradient(elu, inputs)
+    self.assertAllClose(
+        np.exp(-40.0), self.evaluate(elu_grad), rtol=1e-14, atol=0)
+
   @test_util.run_deprecated_v1
   def testEluGradGradWRTgrad_ys(self):
     inputs = constant_op.constant(


### PR DESCRIPTION
Fixes #124833.

## What changed

- Compute the ELU derivative from the input as `exp(min(x, 0.0))` instead of reconstructing it as `output + 1`. The output rounds to exactly `-1` for sufficiently negative inputs even when the derivative is still representable.
- Update the generated GradientTape exclusion metadata so eager execution retains the ELU input and can release the now-unused output.
- Add `float32` and `float64` regression coverage in both graph and eager modes.

## Validation

- Confirmed the expanded regression fails with the previous TensorFlow 2.20 implementation for both dtypes in graph and eager modes (`0.0` instead of the finite analytic derivatives).
- Verified the stable derivative produces `2.0611537e-09` for `float32` at `-20` and `4.248354255291589e-18` for `float64` at `-40`.
- `python3 -m py_compile tensorflow/python/ops/nn_grad.py tensorflow/python/ops/nn_grad_test.py`
- TensorFlow PyLint configuration: 10.00/10 (excluding two unrelated existing inference false positives in `nn_grad.py`).
- `git diff --check`
