### PR TITLE
[TFLite] Prevent high-rank broadcast stack overflow

### DIFF
--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -521,6 +521,7 @@ cc_library(
         ":types",
         "//tensorflow/lite:macros",
         "//tensorflow/lite/core/c:common",
+        "@com_google_absl//absl/container:inlined_vector",
     ],
 )
 
@@ -645,6 +646,7 @@ cc_library(
         "//tensorflow/lite/kernels:kernel_util",
         "//tensorflow/lite/kernels:op_macros",
         "//tensorflow/lite/kernels/internal/utils:sparsity_format_converter",
+        "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/types:span",
         "@eigen_archive//:eigen3",
         "@gemmlowp//:fixedpoint",
@@ -745,6 +747,7 @@ cc_library(
         "//tensorflow/lite/core/c:common",
         "//tensorflow/lite/kernels:op_macros",
         "//tensorflow/lite/kernels/internal/utils:sparsity_format_converter",
+        "@com_google_absl//absl/container:inlined_vector",
         "@eigen_archive//:eigen3",
         "@gemmlowp",
         "@ruy//ruy/profiler:instrumentation",
@@ -1382,6 +1385,15 @@ cc_test(
     srcs = ["optimized/reduce_utils_test.cc"],
     deps = [
         ":reduce_utils",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "broadcast_loop_test",
+    srcs = ["broadcast_loop_test.cc"],
+    deps = [
+        ":reference_comparisons",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/lite/kernels/internal/broadcast_loop_test.cc
+++ b/tensorflow/lite/kernels/internal/broadcast_loop_test.cc
@@ -1,0 +1,69 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/broadcast_loop.h"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+namespace tflite {
+namespace reference_ops {
+namespace {
+
+TEST(BroadcastLoopTest, SupportsRankGreaterThanInlineRank) {
+  const RuntimeShape input1_shape({2, 1, 2, 1, 2, 1, 2, 1, 2});
+  const RuntimeShape input2_shape({1, 2, 1, 2, 1, 2, 1, 2, 1});
+  const RuntimeShape output_shape({2, 2, 2, 2, 2, 2, 2, 2, 2});
+
+  std::vector<int> input1(input1_shape.FlatSize());
+  std::vector<int> input2(input2_shape.FlatSize());
+  std::vector<int> output(output_shape.FlatSize());
+  std::iota(input1.begin(), input1.end(), 0);
+  std::iota(input2.begin(), input2.end(), 100);
+
+  BroadcastBinaryOpSimple(input1_shape, input1.data(), input2_shape,
+                          input2.data(), output_shape, output.data(),
+                          [](int a, int b) { return a + b; });
+
+  for (size_t output_index = 0; output_index < output.size(); ++output_index) {
+    size_t remaining_index = output_index;
+    size_t input1_index = 0;
+    size_t input2_index = 0;
+    size_t input1_stride = 1;
+    size_t input2_stride = 1;
+    for (int dim = output_shape.DimensionsCount() - 1; dim >= 0; --dim) {
+      const size_t output_dim = static_cast<size_t>(output_shape.Dims(dim));
+      const size_t coordinate = remaining_index % output_dim;
+      remaining_index /= output_dim;
+      if (input1_shape.Dims(dim) != 1) {
+        input1_index += coordinate * input1_stride;
+      }
+      if (input2_shape.Dims(dim) != 1) {
+        input2_index += coordinate * input2_stride;
+      }
+      input1_stride *= static_cast<size_t>(input1_shape.Dims(dim));
+      input2_stride *= static_cast<size_t>(input2_shape.Dims(dim));
+    }
+    EXPECT_EQ(output[output_index], input1[input1_index] + input2[input2_index])
+        << "output index " << output_index;
+  }
+}
+
+}  // namespace
+}  // namespace reference_ops
+}  // namespace tflite

--- a/tensorflow/lite/kernels/internal/reference/broadcast_loop.h
+++ b/tensorflow/lite/kernels/internal/reference/broadcast_loop.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 
+#include "absl/container/inlined_vector.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/internal/runtime_shape.h"
 
@@ -93,7 +94,7 @@ inline void BroadcastBinaryOpSimple(const RuntimeShape& input1_shape,
                                     Pointer2 input2_data,
                                     const RuntimeShape& output_shape,
                                     OutputType* output_data, BinaryOp op) {
-  constexpr int kMaxRank = 8;
+  constexpr size_t kInlineRank = 8;
 
   int dims_count = std::max(
       output_shape.DimensionsCount(),
@@ -103,8 +104,6 @@ inline void BroadcastBinaryOpSimple(const RuntimeShape& input1_shape,
     *output_data = op(*input1_data, *input2_data);
     return;
   }
-
-  TFLITE_DCHECK_LE(dims_count, kMaxRank);
 
   const RuntimeShape extended_output_shape =
       RuntimeShape::ExtendedShape(dims_count, output_shape);
@@ -119,10 +118,11 @@ inline void BroadcastBinaryOpSimple(const RuntimeShape& input1_shape,
   // - For all remaining dimensions, if the loop can be fused with the previous
   //   loop do that.
   // - Otherwise, make a new loop.
-  size_t a_strides[kMaxRank];
-  size_t b_strides[kMaxRank];
-  size_t o_strides[kMaxRank];
-  size_t o_shape[kMaxRank];
+  const size_t rank = static_cast<size_t>(dims_count);
+  absl::InlinedVector<size_t, kInlineRank> a_strides(rank);
+  absl::InlinedVector<size_t, kInlineRank> b_strides(rank);
+  absl::InlinedVector<size_t, kInlineRank> o_strides(rank);
+  absl::InlinedVector<size_t, kInlineRank> o_shape(rank);
 
   size_t a_accum_stride = 1;
   size_t b_accum_stride = 1;
@@ -162,8 +162,9 @@ inline void BroadcastBinaryOpSimple(const RuntimeShape& input1_shape,
     o_accum_stride *= output_dim;
   }
 
-  RunBinaryOp(input1_data, input2_data, output_data, a_strides, b_strides,
-              o_strides, o_shape, next_dim_idx, op);
+  RunBinaryOp(input1_data, input2_data, output_data, a_strides.data(),
+              b_strides.data(), o_strides.data(), o_shape.data(), next_dim_idx,
+              op);
 }
 
 }  // namespace reference_ops


### PR DESCRIPTION
## Summary

- replace the fixed rank-8 broadcast metadata arrays with `absl::InlinedVector`
- retain inline storage and zero heap allocation for the common rank <= 8 path while safely growing for higher ranks
- add a rank-9 alternating-broadcast regression test that requires nine independent loop levels

## Testing

- standalone C++ regression test in release mode (`-O2 -DNDEBUG`)
- standalone C++ regression test with UndefinedBehaviorSanitizer and bounds checking
- ClangFormat check
- Buildifier check
- `git diff --check`

Fixes #124845