### PR TITLE
Fix tf.math.igamma to return NaN for out-of-domain inputs (a <= 0, x == 0)

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -844,6 +844,42 @@ struct functor_traits<scalar_erfinv_op<float>> {
   };
 };
 
+// igamma(a, x) = P(a, x) is defined only for a > 0, x >= 0.  Eigen's
+// scalar_igamma_op short-circuits to 0 when x == 0 before the domain check
+// fires, so a <= 0 with x == 0 silently returns 0 instead of NaN.  The
+// wrapper restores the mathematically correct NaN for out-of-domain inputs.
+template <typename Scalar>
+struct igamma_op {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
+  operator()(const Scalar& a, const Scalar& x) const {
+    if (x == Scalar(0) && a <= Scalar(0)) {
+      return Eigen::NumTraits<Scalar>::quiet_NaN();
+    }
+    return Eigen::internal::scalar_igamma_op<Scalar>()(a, x);
+  }
+  template <typename Packet>
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
+  packetOp(const Packet& a, const Packet& x) const {
+    Packet zeros = pzero(x);
+    Packet x_is_zero = pcmp_eq(x, zeros);
+    Packet a_le_zero = por(pcmp_lt(a, zeros), pcmp_eq(a, zeros));
+    Packet domain_error = pand(x_is_zero, a_le_zero);
+    Packet nan = pset1<Packet>(Eigen::NumTraits<Scalar>::quiet_NaN());
+    Packet igamma_val =
+        Eigen::internal::scalar_igamma_op<Scalar>().packetOp(a, x);
+    return pselect(domain_error, nan, igamma_val);
+  }
+};
+
+template <typename Scalar>
+struct functor_traits<igamma_op<Scalar>> {
+  enum {
+    Cost = functor_traits<scalar_igamma_op<Scalar>>::Cost +
+           Eigen::NumTraits<Scalar>::AddCost,
+    PacketAccess = functor_traits<scalar_igamma_op<Scalar>>::PacketAccess,
+  };
+};
+
 }  // end namespace internal
 }  // end namespace Eigen
 
@@ -1177,7 +1213,7 @@ struct minimum
     : base<T, Eigen::internal::scalar_min_op<T, T, Eigen::PropagateNaN>> {};
 
 template <typename T>
-struct igamma : base<T, Eigen::internal::scalar_igamma_op<T>> {};
+struct igamma : base<T, Eigen::internal::igamma_op<T>> {};
 
 template <typename T>
 struct random_gamma_grad

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -852,7 +852,7 @@ template <typename Scalar>
 struct igamma_op {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& a, const Scalar& x) const {
-    if (x == Scalar(0) && a <= Scalar(0)) {
+    if (x == Scalar(0) && !(a > Scalar(0))) {
       return Eigen::NumTraits<Scalar>::quiet_NaN();
     }
     return Eigen::internal::scalar_igamma_op<Scalar>()(a, x);
@@ -862,8 +862,8 @@ struct igamma_op {
   packetOp(const Packet& a, const Packet& x) const {
     Packet zeros = pzero(x);
     Packet x_is_zero = pcmp_eq(x, zeros);
-    Packet a_le_zero = por(pcmp_lt(a, zeros), pcmp_eq(a, zeros));
-    Packet domain_error = pand(x_is_zero, a_le_zero);
+    Packet a_gt_zero = pcmp_gt(a, zeros);
+    Packet domain_error = pandnot(x_is_zero, a_gt_zero);
     Packet nan = pset1<Packet>(Eigen::NumTraits<Scalar>::quiet_NaN());
     Packet igamma_val =
         Eigen::internal::scalar_igamma_op<Scalar>().packetOp(a, x);

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -849,7 +849,7 @@ struct functor_traits<scalar_erfinv_op<float>> {
 // fires, so a <= 0 with x == 0 silently returns 0 instead of NaN.  The
 // wrapper restores the mathematically correct NaN for out-of-domain inputs.
 template <typename Scalar>
-struct igamma_op {
+struct igamma_op : binary_op_base<Scalar, Scalar> {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& a, const Scalar& x) const {
     if (x == Scalar(0) && !(a > Scalar(0))) {
@@ -862,7 +862,7 @@ struct igamma_op {
   packetOp(const Packet& a, const Packet& x) const {
     Packet zeros = pzero(x);
     Packet x_is_zero = pcmp_eq(x, zeros);
-    Packet a_gt_zero = pcmp_gt(a, zeros);
+    Packet a_gt_zero = pcmp_lt(zeros, a);
     Packet domain_error = pandnot(x_is_zero, a_gt_zero);
     Packet nan = pset1<Packet>(Eigen::NumTraits<Scalar>::quiet_NaN());
     Packet igamma_val =

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
@@ -306,6 +306,30 @@ class BinaryOpTest(test.TestCase):
     except ImportError as e:
       tf_logging.warn("Cannot test special functions: %s" % str(e))
 
+  @test_util.run_deprecated_v1
+  def testIgammaDomainEdgeCases(self):
+    # P(a, x) is undefined for a <= 0; x == 0 short-circuits before the domain
+    # check in Eigen, so the kernel must return NaN for those inputs explicitly.
+    for dtype in [np.float32, np.float64]:
+      a_vals = np.array([-0.1, -1.0, 0.0], dtype=dtype)
+      x_vals = np.array([0.0, 0.0, 0.0], dtype=dtype)
+      with self.cached_session():
+        result = math_ops.igamma(
+            constant_op.constant(a_vals),
+            constant_op.constant(x_vals))
+        result_np = self.evaluate(result)
+        self.assertTrue(
+            np.all(np.isnan(result_np)),
+            "Expected NaN for out-of-domain (a<=0, x==0), got %s" % result_np)
+      # P(a, 0) == 0 for a > 0; the fix must not disturb this identity.
+      a_pos = np.array([0.5, 1.0, 2.0], dtype=dtype)
+      x_zero = np.array([0.0, 0.0, 0.0], dtype=dtype)
+      with self.cached_session():
+        result_pos = math_ops.igamma(
+            constant_op.constant(a_pos),
+            constant_op.constant(x_zero))
+        self.assertAllEqual(self.evaluate(result_pos), np.zeros(3, dtype=dtype))
+
   def testBfloat16Basic(self):
     bf16_np = dtypes_lib.bfloat16.as_numpy_dtype
     x = np.linspace(-5, 20, 15).reshape(1, 3, 5).astype(bf16_np)  # pylint: disable=too-many-function-args

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
@@ -311,8 +311,8 @@ class BinaryOpTest(test.TestCase):
     # P(a, x) is undefined for a <= 0; x == 0 short-circuits before the domain
     # check in Eigen, so the kernel must return NaN for those inputs explicitly.
     for dtype in [np.float32, np.float64]:
-      a_vals = np.array([-0.1, -1.0, 0.0], dtype=dtype)
-      x_vals = np.array([0.0, 0.0, 0.0], dtype=dtype)
+      a_vals = np.array([-0.1, -1.0, 0.0, np.nan], dtype=dtype)
+      x_vals = np.array([0.0, 0.0, 0.0, 0.0], dtype=dtype)
       with self.cached_session():
         result = math_ops.igamma(
             constant_op.constant(a_vals),


### PR DESCRIPTION
Fixes #108641

tf.math.igamma(a, x) returns 0 when a <= 0 and x == 0, but the regularized incomplete gamma function P(a, x) is mathematically undefined for a <= 0. The correct result is NaN.

Root cause: Eigen's scalar_igamma_op short-circuits to 0 when x == 0 before the domain check (a <= 0) fires. The XLA path (jit_compile=True) is already correct; this only affects CPU eager execution.

Added igamma_op<Scalar> wrapper in Eigen::internal inside cwise_ops.h following the digamma pole fix pattern. The scalar branch returns NaN when x == 0 && a <= 0 and delegates to scalar_igamma_op otherwise. The packet branch uses pcmp_eq/pcmp_lt/pand/pselect to apply the same guard vectorized.

Added testIgammaDomainEdgeCases to cwise_ops_binary_test.py covering both the NaN path (a <= 0, x == 0) and the unchanged zero path (a > 0, x == 0) for float32 and float64.