### PR TITLE
Fix XLA TensorArray.unstack segfault on scalar input

### DIFF
--- a/tensorflow/compiler/tests/tensor_array_ops_test.py
+++ b/tensorflow/compiler/tests/tensor_array_ops_test.py
@@ -1165,5 +1165,18 @@ class TensorArrayTest(xla_test.XLATestCase):
       self.assertEqual(size0_v, 2)
       self.assertEqual(size1_v, 4)
 
+  def testTensorArrayUnstackScalarRaisesError(self):
+    with self.session(), self.test_scope():
+      ta = tensor_array_ops.TensorArray(dtype=dtypes.float32, size=3)
+      scalar = constant_op.constant(1.0)
+
+      def fn():
+        return ta.unstack(scalar)
+
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError),
+          "scatter/unstack requires value to have rank >= 1, got scalar"):
+        self.evaluate(xla.compile(fn))
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/compiler/tf2xla/kernels/tensor_array_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/tensor_array_ops.cc
@@ -372,6 +372,10 @@ class TensorArrayScatterOp : public XlaOpKernel {
     xla::XlaBuilder* b = ctx->builder();
 
     const TensorShape value_shape = ctx->InputShape(2);
+    OP_REQUIRES(ctx, value_shape.dims() >= 1,
+                errors::InvalidArgument(
+                    "TensorArray scatter/unstack requires value to have rank >= 1, got scalar with shape ",
+                    value_shape.DebugString()));
 
     XlaResource* resource;
     OP_REQUIRES_OK(ctx, ctx->GetResourceInput(0, &resource));


### PR DESCRIPTION
Fixes #111438

## Problem

When TensorArray.unstack is called on a scalar tensor under XLA compilation, it triggers a segfault. The root cause is in TensorArrayScatterOp::Compile (tensor_array_ops.cc:379), where RemoveDim(0) is called on the value shape without checking if the tensor has at least rank 1. For scalar inputs (rank 0), this causes undefined behavior.

## Fix

Added validation in TensorArrayScatterOp::Compile to check that the input value has rank >= 1 before calling RemoveDim(0). When the input is a scalar, the kernel now raises InvalidArgumentError with a clear message instead of segfaulting.

## Testing

Added testTensorArrayUnstackScalarRaisesError to tensor_array_ops_test.py to verify that calling unstack on a scalar tensor under XLA compilation raises InvalidArgumentError with an appropriate error message.