### PR TITLE
Reject scalar values in XLA TensorArrayScatterOp before RemoveDim(0)

### DIFF
--- a/tensorflow/compiler/tests/tensor_array_ops_test.py
+++ b/tensorflow/compiler/tests/tensor_array_ops_test.py
@@ -1166,17 +1166,17 @@ class TensorArrayTest(xla_test.XLATestCase):
       self.assertEqual(size1_v, 4)
 
   def testTensorArrayUnstackScalarRaisesError(self):
-    with self.session(), self.test_scope():
-      ta = tensor_array_ops.TensorArray(dtype=dtypes.float32, size=3)
-      scalar = constant_op.constant(1.0)
+    with self.session() as session, self.test_scope():
+      scalar = array_ops.placeholder(dtypes.float32, shape=None)
 
       def fn():
+        ta = tensor_array_ops.TensorArray(dtype=dtypes.float32, size=3)
         return ta.unstack(scalar)
 
       with self.assertRaisesRegex(
-          (errors.InvalidArgumentError, ValueError),
+          errors.InvalidArgumentError,
           "scatter/unstack requires value to have rank >= 1, got scalar"):
-        self.evaluate(xla.compile(fn))
+        session.run(xla.compile(fn), feed_dict={scalar: 1.0})
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/compiler/tests/tensor_array_ops_test.py
+++ b/tensorflow/compiler/tests/tensor_array_ops_test.py
@@ -1165,13 +1165,14 @@ class TensorArrayTest(xla_test.XLATestCase):
       self.assertEqual(size0_v, 2)
       self.assertEqual(size1_v, 4)
 
-  def testTensorArrayUnstackScalarRaisesError(self):
+  @test_util.disable_control_flow_v2("TensorArray.scatter in XLA")
+  def testTensorArrayScatterScalarRaisesError(self):
     with self.session() as session, self.test_scope():
       scalar = array_ops.placeholder(dtypes.float32, shape=None)
 
       def fn():
         ta = tensor_array_ops.TensorArray(dtype=dtypes.float32, size=3)
-        return ta.unstack(scalar)
+        return ta.scatter(indices=[0], value=scalar).flow
 
       with self.assertRaisesRegex(
           errors.InvalidArgumentError,

--- a/tensorflow/compiler/tests/tensor_array_ops_test.py
+++ b/tensorflow/compiler/tests/tensor_array_ops_test.py
@@ -1165,5 +1165,18 @@ class TensorArrayTest(xla_test.XLATestCase):
       self.assertEqual(size0_v, 2)
       self.assertEqual(size1_v, 4)
 
+  def testTensorArrayUnstackScalarRaisesError(self):
+    with self.session(), self.test_scope():
+      ta = tensor_array_ops.TensorArray(dtype=dtypes.float32, size=3)
+      scalar = constant_op.constant(1.0)
+
+      def fn():
+        return ta.unstack(scalar)
+
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError),
+          "scatter/unstack requires value to have rank >= 1, got scalar"):
+        self.evaluate(xla.compile(fn))
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/compiler/tf2xla/kernels/tensor_array_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/tensor_array_ops.cc
@@ -372,6 +372,10 @@ class TensorArrayScatterOp : public XlaOpKernel {
     xla::XlaBuilder* b = ctx->builder();
 
     const TensorShape value_shape = ctx->InputShape(2);
+    OP_REQUIRES(ctx, value_shape.dims() >= 1,
+                errors::InvalidArgument(
+                    "TensorArray scatter/unstack requires value to have rank >= 1, got scalar with shape ",
+                    value_shape.DebugString()));
 
     XlaResource* resource;
     OP_REQUIRES_OK(ctx, ctx->GetResourceInput(0, &resource));


### PR DESCRIPTION
Fixes #111438

TensorArrayScatterOp calls RemoveDim(0) on the input value shape without checking the rank first. When the value is a scalar (rank 0), this hits undefined behavior and segfaults under XLA. Added a rank check that raises InvalidArgumentError instead.