### PR TITLE
Fix tf.tuple() to reject nested structures consistently

### DIFF
--- a/tensorflow/python/ops/control_flow_ops.py
+++ b/tensorflow/python/ops/control_flow_ops.py
@@ -2135,8 +2135,16 @@ def tuple(tensors, name=None, control_inputs=None):  # pylint: disable=redefined
     ValueError: If `tensors` does not contain any `Tensor` or `IndexedSlices`.
     TypeError: If `control_inputs` is not a list of `Operation` or `Tensor`
       objects.
+    TypeError: If `tensors` contains a nested list, tuple, or dict instead of
+      a flat sequence of `Tensor`, `IndexedSlices`, `Operation`, or `None`.
 
   """
+  if any(nest.is_nested(t) for t in tensors):
+    raise TypeError(
+        "'tensors' must be a flat list of Tensor, IndexedSlices, Operation, "
+        "or None. tf.tuple() does not flatten nested structures. "
+        f"Received: {tensors}"
+    )
   if context.executing_eagerly():
     return tensors
   with ops.name_scope(name, "tuple", tensors) as name:

--- a/tensorflow/python/ops/control_flow_ops_test.py
+++ b/tensorflow/python/ops/control_flow_ops_test.py
@@ -197,6 +197,38 @@ class WithDependenciesTestCase(test_util.TensorFlowTestCase):
     self.assertEqual(1, self.evaluate(counter))
 
 
+class TupleTestCase(test_util.TensorFlowTestCase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def testNestedTupleRaisesTypeError(self):
+    a = constant_op.constant(1.0)
+    b = constant_op.constant(2.0)
+    c = constant_op.constant(3.0)
+    with self.assertRaises(TypeError):
+      control_flow_ops.tuple(((a, b), c))
+
+  @test_util.run_in_graph_and_eager_modes
+  def testNestedListRaisesTypeError(self):
+    a = constant_op.constant(1.0)
+    b = constant_op.constant(2.0)
+    with self.assertRaises(TypeError):
+      control_flow_ops.tuple([[a, b]])
+
+  @test_util.run_in_graph_and_eager_modes
+  def testDictElementRaisesTypeError(self):
+    a = constant_op.constant(1.0)
+    b = constant_op.constant(2.0)
+    with self.assertRaises(TypeError):
+      control_flow_ops.tuple([{"x": a}, b])
+
+  @test_util.run_in_graph_and_eager_modes
+  def testFlatSequenceSucceeds(self):
+    a = constant_op.constant(1.0)
+    b = constant_op.constant(2.0)
+    res = control_flow_ops.tuple([a, b])
+    self.assertLen(res, 2)
+
+
 class SwitchTestCase(test_util.TensorFlowTestCase):
 
   @test_util.run_deprecated_v1


### PR DESCRIPTION
Fixes #124879 

tf.tuple() only supports a flat list of tensors (per its docstring), but
eager mode skips validation entirely while graph/XLA mode implicitly stacks
nested elements via convert_to_tensor, causing a confusing Pack shape error.
Both eager and graph modes now raise the same clear TypeError for nested input
via a nest.is_nested() check applied before the eager/graph branch. Flat-list
(documented) usage is unaffected.

Added TupleTest in control_flow_ops_test.py covering nested tuple, nested list,
and dict-element cases in both eager and graph mode.