### PR TITLE
Honor an explicit `dtype` in `tf.experimental.numpy.linspace` and `logspace`

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1242,15 +1242,24 @@ def logical_not(x):
 def linspace(  # pylint: disable=missing-docstring
     start, stop, num=50, endpoint=True, retstep=False, dtype=float, axis=0
 ):
-  if dtype:
-    # In numpy 2.x, the result type of np.linspace is based off of `start` and
-    # `end`. We mimic the behavior.
-    if np.lib.NumpyVersion(np.__version__) >= '2.0.0.dev0':
-      dtype = np_utils.result_type([start * 1.0, stop * 1.0])
-    else:
-      dtype = np_utils.result_type(dtype)
-  start = np_array_ops.array(start, dtype=dtype)
-  stop = np_array_ops.array(stop, dtype=dtype)
+  # numpy computes the samples in a floating point type derived from `start`
+  # and `stop`, and only casts them to `dtype` as a final step. `dtype` must
+  # therefore not be used as the computation type, otherwise e.g. an integer
+  # `dtype` would truncate the samples before they are even computed.
+  # The default value of `dtype` plays the role of numpy's `dtype=None`, i.e.
+  # "infer the output type", so it is not treated as an explicit request.
+  if dtype is float or dtype is None:
+    dtype = None
+  else:
+    dtype = np_utils.result_type(dtype)
+  # In numpy 2.x, the result type of np.linspace is based off of `start` and
+  # `end`. We mimic the behavior.
+  if np.lib.NumpyVersion(np.__version__) >= '2.0.0.dev0':
+    computation_dtype = np_utils.result_type([start * 1.0, stop * 1.0])
+  else:
+    computation_dtype = np_utils.result_type(float)
+  start = np_array_ops.array(start, dtype=computation_dtype)
+  stop = np_array_ops.array(stop, dtype=computation_dtype)
   if num < 0:
     raise ValueError(
         'Argument `num` (number of samples) must be a non-negative integer. '
@@ -1272,7 +1281,7 @@ def linspace(  # pylint: disable=missing-docstring
       result = math_ops.linspace(start, new_stop, num, axis=axis)
     else:
       result = math_ops.linspace(start, stop, num, axis=axis)
-  if dtype:
+  if dtype is not None:
     if dtype.is_integer:
       # Since numpy 1.20, linspace's rounding is towards -inf instead of 0
       result = math_ops.floor(result)
@@ -1286,18 +1295,13 @@ def linspace(  # pylint: disable=missing-docstring
 @tf_export.tf_export('experimental.numpy.logspace', v1=[])
 @np_utils.np_doc('logspace')
 def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None, axis=0):
-  # In numpy 2.x, the result type of np.logspace is based off of `start` and
-  # `end`. We mimic the behavior.
-  if np.lib.NumpyVersion(np.__version__) >= '2.0.0.dev0':
-    dtype = np_utils.result_type([start * 1.0, stop * 1.0])
-  else:
-    dtype = np_utils.result_type(start, stop, dtype)
-  result = linspace(
-      start, stop, num=num, endpoint=endpoint, dtype=dtype, axis=axis
-  )
+  # Like numpy, the exponents are computed in the floating point type derived
+  # from `start` and `stop` (which `linspace` takes care of), and `dtype` only
+  # determines the type the final result is cast to.
+  result = linspace(start, stop, num=num, endpoint=endpoint, axis=axis)
   result = math_ops.pow(math_ops.cast(base, result.dtype), result)
-  if dtype:
-    result = math_ops.cast(result, dtype)
+  if dtype is not None:
+    result = math_ops.cast(result, np_utils.result_type(dtype))
   return result
 
 

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1255,7 +1255,9 @@ def linspace(  # pylint: disable=missing-docstring
   # In numpy 2.x, the result type of np.linspace is based off of `start` and
   # `end`. We mimic the behavior.
   if np.lib.NumpyVersion(np.__version__) >= '2.0.0.dev0':
-    computation_dtype = np_utils.result_type([start * 1.0, stop * 1.0])
+    computation_dtype = np_utils.result_type(start, stop)
+    if not (computation_dtype.is_floating or computation_dtype.is_complex):
+      computation_dtype = np_utils.result_type(float)
   else:
     computation_dtype = np_utils.result_type(float)
   start = np_array_ops.array(start, dtype=computation_dtype)

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -448,6 +448,54 @@ class MathTest(test.TestCase, parameterized.TestCase):
     run_test(0, -5, endpoint=False)
     run_test(0, -5, base=2.0)
 
+  def testLinSpaceDtype(self):
+    # An explicitly requested `dtype` must be honored, and must not be used as
+    # the type the samples are computed in: numpy computes the samples in a
+    # floating point type derived from `start` and `stop`, and only casts them
+    # to `dtype` as a final step.
+    dtypes = [
+        np.int32, np.int64, np.float16, np.float32, np.float64, np.complex64,
+        np.complex128
+    ]
+
+    def run_test(start, stop, **kwargs):
+      for dtype in dtypes:
+        self.match(
+            np_math_ops.linspace(start, stop, dtype=dtype, **kwargs),
+            np.linspace(start, stop, dtype=dtype, **kwargs),
+            msg='linspace({}, {}, dtype={})'.format(start, stop, dtype))
+
+    run_test(0, 10)
+    run_test(0, 10, num=0)
+    run_test(0, 10, num=1)
+    run_test(0, 10, num=5)
+    run_test(0, 10, num=5, endpoint=False)
+    run_test(0, -10, num=5)
+    run_test(0, -10, num=5, endpoint=False)
+    run_test(-5, 5, num=4)
+
+  def testLogSpaceDtype(self):
+    # As for `linspace`, `dtype` only determines the type of the result; the
+    # exponents are computed in a floating point type derived from `start` and
+    # `stop`.
+    dtypes = [
+        np.int32, np.int64, np.float16, np.float32, np.float64, np.complex64,
+        np.complex128
+    ]
+
+    def run_test(start, stop, **kwargs):
+      for dtype in dtypes:
+        self.match(
+            np_math_ops.logspace(start, stop, dtype=dtype, **kwargs),
+            np.logspace(start, stop, dtype=dtype, **kwargs),
+            msg='logspace({}, {}, dtype={})'.format(start, stop, dtype))
+
+    run_test(0, 3, num=4)
+    run_test(0, 3, num=4, endpoint=False)
+    run_test(0, 3, num=4, base=2.0)
+    run_test(0, -3, num=4)
+    run_test(1, 3, num=5)
+
   def testGeomSpace(self):
 
     def run_test(start, stop, **kwargs):


### PR DESCRIPTION
`tf.experimental.numpy.linspace` and `tf.experimental.numpy.logspace` silently discard an explicitly requested `dtype` and return the type inferred from `start` and `stop` instead.

```python
>>> import numpy as np, tensorflow.experimental.numpy as tnp

>>> tnp.linspace(0, 10, 5, dtype=np.int32)
<tf.Tensor: shape=(5,), dtype=float64, numpy=array([ 0. ,  2.5,  5. ,  7.5, 10. ])>
>>> np.linspace(0, 10, 5, dtype=np.int32)
array([ 0,  2,  5,  7, 10], dtype=int32)

>>> tnp.logspace(0, 3, 4, dtype=np.int32)
<tf.Tensor: shape=(4,), dtype=float64, numpy=array([   1.,   10.,  100., 1000.])>
>>> np.logspace(0, 3, 4, dtype=np.int32)
array([   1,   10,  100, 1000], dtype=int32)
```

The requested dtype is ignored for every dtype, not just integers — `dtype=np.float32` also returns `float64`.

### Cause

Both functions overwrite `dtype` with the inferred type before it is ever used:

```python
if dtype:
  # In numpy 2.x, the result type of np.linspace is based off of `start` and
  # `end`. We mimic the behavior.
  if np.lib.NumpyVersion(np.__version__) >= '2.0.0.dev0':
    dtype = np_utils.result_type([start * 1.0, stop * 1.0])   # <-- discards the argument
```

That inference is correct for the *default* case and was added in #74161 to match numpy 2.x, but it is applied unconditionally, so an explicit `dtype` never survives. The branch is the one that runs in CI, which pins `numpy==2.1.3`.

A second, related problem: `dtype` was also used as the type the samples are *computed* in (`np_array_ops.array(start, dtype=dtype)`). numpy computes the samples in a floating point type derived from `start`/`stop` and only casts to `dtype` as a final step, so an integer `dtype` would have truncated the samples before they were computed. This also left the existing integer-rounding branch in `linspace`

```python
if dtype.is_integer:
  # Since numpy 1.20, linspace's rounding is towards -inf instead of 0
  result = math_ops.floor(result)
```

unreachable, since `dtype` was always a float type by that point.

### Fix

Separate the computation type from the result type, mirroring numpy:

* the inferred type is used to compute the samples (unchanged for the default case, so the numpy 2.x behavior from #74161 is preserved);
* an explicitly requested `dtype` is honored by casting the result at the end, with the existing `floor` applied for integer dtypes.

`logspace` now simply defers the exponent computation to `linspace` and casts the final result, which is exactly what `numpy.logspace` does:

```python
y = linspace(start, stop, num=num, endpoint=endpoint, axis=axis)
if dtype is None:
    return _nx.power(base, y)
return _nx.power(base, y).astype(dtype, copy=False)
```

Note that `linspace`'s signature has `dtype=float` as its default rather than numpy's `dtype=None`. That default keeps its existing meaning of "infer the output type", so no public signature changes and no golden API updates are needed. `geomspace`, the only in-tree caller of `logspace`, is unaffected.

### Testing

Added `testLinSpaceDtype` and `testLogSpaceDtype` to `np_math_ops_test.py`, covering `int32/int64/float16/float32/float64/complex64/complex128` against numpy across `endpoint`, `base`, negative ranges and `num` in `{0, 1, 4, 5, 50}`. Both fail before this change and pass after.

The existing `testLinSpace`, `testLogSpace` and `testGeomSpace` continue to pass, so the default-dtype behavior is unchanged.

I also ran a differential sweep of `linspace`/`logspace`/`geomspace` against numpy over 61,480 combinations of the 8 input transforms used by `np_math_ops_test.py`, `num` in `{0, 1, 2, 5, 10}`, `endpoint`, `retstep`, `axis`, negative and equal endpoints, and all of the dtypes above (comparing dtype, shape and values). Failures drop from 46,100 to 16, with **no case that passed before now failing**.

The 16 remaining are pre-existing and unrelated to dtype handling: with `float32` inputs and an integer `dtype`, `10**7.5` computed in `float32` lands one ULP above numpy's value (`31622778` vs `31622776`) and truncation to an integer makes that visible. It reproduces identically before this change once the dtype is honored, and comes from `pow`, not from this code.

