### PR TITLE
fix(gpu): add input size validation to prevent illegal memory access in Where op

### DIFF
--- a/tensorflow/core/kernels/where_op_gpu.cu.h
+++ b/tensorflow/core/kernels/where_op_gpu.cu.h
@@ -270,6 +270,18 @@ struct Where<GPUDevice, NDIM, T, TIndex> {
       return absl::OkStatus();
     }
 
+    // Validate input size to prevent GPU memory exhaustion and out-of-bounds access.
+    // Limit to 1B elements (~8GB for int64 indices) to avoid allocation failures
+    // and illegal memory access in PropagateWhereIndicesKernel.
+    constexpr int64_t kMaxSafeElements = 1000000000LL;  // 1 billion elements
+    if (input.size() > kMaxSafeElements) {
+      return errors::InvalidArgument(
+          "WhereOp: Input tensor size (", input.size(), ") exceeds maximum safe size (",
+          kMaxSafeElements, ") for GPU processing. ",
+          "This prevents potential GPU memory exhaustion and out-of-bounds memory access. ",
+          "Consider using smaller tensors or processing on CPU.");
+    }
+
     const auto& cu_stream = GetGpuStream(ctx);
 
     std::size_t temp_storage_bytes = 0;


### PR DESCRIPTION
## Summary

This PR fixes a critical GPU bug where `tf.raw_ops.Where` with extremely large input tensors causes illegal memory access instead of raising a proper Python exception.

## Fixes

Closes #104365

## Problem

When calling `tf.raw_ops.Where` with extremely large input tensors (2 billion+ elements) on GPU:
- Process crashes with illegal memory read in `PropagateWhereIndicesKernel`
- No recoverable Python exception (InvalidArgumentError/ResourceExhaustedError)
- Compute-Sanitizer reports out-of-bounds read
- Potential denial-of-service condition

**Example crash:**
```python
with tf.device("/GPU:0"):
    condition = tf.constant(True, shape=[2147483647], dtype=tf.bool)
    tf.raw_ops.Where(condition=condition)  # Crashes instead of raising exception
```

**Error:**
```
Invalid __global__ read of size 8 bytes
at PropagateWhereIndicesKernel<1, long>+0xb0
Address 0x7fd16001ee00 is out of bounds
```

## Root Cause

No validation on input tensor size before GPU kernel launch. Large tensors cause:
1. GPU memory exhaustion during allocation
2. Out-of-bounds memory access in PropagateWhereIndicesKernel
3. Process abort instead of recoverable exception

## Solution

Added input size validation (max 1 billion elements) in Where<GPUDevice> before GPU processing to prevent crashes and return proper InvalidArgumentError.

## Changes

- Modified: tensorflow/core/kernels/where_op_gpu.cu.h
- Added: Input size validation before GPU processing
- Lines: +12 insertions

## Impact

- Prevents crashes with large tensors
- Returns proper InvalidArgumentError instead of crashing
- Provides clear error message with suggested workaround
- No impact on normal-sized tensors (< 1B elements)
- GPU-specific fix (CPU path unchanged)

## Type of Change

- Bug fix (fixes issue #104365)
- Non-breaking change
- GPU-specific fix
- Security improvement (prevents DoS)

## Checklist

- [x] Code follows TensorFlow style guidelines
- [x] Added input validation for safety
- [x] No breaking changes
- [x] GPU-specific fix, CPU unchanged
- [x] Clear error messages
- [x] Fixes reported issue #104365
