### PR TITLE
Fix AttributeError in `tf.experimental.numpy` unary ops given integer inputs

### DIFF
--- a/tensorflow/python/ops/numpy_ops/BUILD
+++ b/tensorflow/python/ops/numpy_ops/BUILD
@@ -267,6 +267,17 @@ cuda_py_strict_test(
 )
 
 cuda_py_strict_test(
+    name = "np_math_ops_no_numpy_methods_test",
+    srcs = ["np_math_ops_no_numpy_methods_test.py"],
+    deps = [
+        ":np_math_ops",
+        "//tensorflow/python/framework:ops",
+        "//tensorflow/python/platform:client_testlib",
+        "//third_party/py/numpy",
+    ],
+)
+
+cuda_py_strict_test(
     name = "np_random_test",
     srcs = ["np_random_test.py"],
     deps = [

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -744,7 +744,10 @@ def _scalar(tf_fn, x, promote_to_float=False):
   """
   x = np_array_ops.asarray(x)
   if promote_to_float and not np.issubdtype(x.dtype.as_numpy_dtype, np.inexact):
-    x = x.astype(np_utils.result_type(float))
+    # `Tensor.astype` only exists once `enable_numpy_methods_on_tensor()` has
+    # been called, and is an alias of `math_ops.cast`; calling `cast` directly
+    # keeps these functions working without that opt-in.
+    x = math_ops.cast(x, np_utils.result_type(float))
   return tf_fn(x)
 
 

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_no_numpy_methods_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_no_numpy_methods_test.py
@@ -1,0 +1,110 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tf numpy math methods that must not depend on Tensor methods.
+
+`np_math_ops.enable_numpy_methods_on_tensor()` adds numpy methods such as
+`astype` to `Tensor`. The other numpy_ops test modules call it from their
+`__main__`, so a code path that only works once those methods are installed
+still passes there. This module deliberately does not call it, which is the
+configuration a user gets from a plain `import tensorflow`.
+"""
+
+import numpy as np
+
+from tensorflow.python.framework import ops
+from tensorflow.python.ops.numpy_ops import np_math_ops
+from tensorflow.python.platform import test
+
+
+# Unary ops that promote an integer argument to a floating point dtype.
+_PROMOTING_UNARY_OPS = [
+    ('log', np_math_ops.log, np.log),
+    ('exp', np_math_ops.exp, np.exp),
+    ('sqrt', np_math_ops.sqrt, np.sqrt),
+    ('ceil', np_math_ops.ceil, np.ceil),
+    ('floor', np_math_ops.floor, np.floor),
+    ('sin', np_math_ops.sin, np.sin),
+    ('cos', np_math_ops.cos, np.cos),
+    ('tan', np_math_ops.tan, np.tan),
+    ('sinh', np_math_ops.sinh, np.sinh),
+    ('cosh', np_math_ops.cosh, np.cosh),
+    ('tanh', np_math_ops.tanh, np.tanh),
+    ('arcsin', np_math_ops.arcsin, np.arcsin),
+    ('arccos', np_math_ops.arccos, np.arccos),
+    ('arctan', np_math_ops.arctan, np.arctan),
+    ('arcsinh', np_math_ops.arcsinh, np.arcsinh),
+    ('arccosh', np_math_ops.arccosh, np.arccosh),
+    ('arctanh', np_math_ops.arctanh, np.arctanh),
+    ('expm1', np_math_ops.expm1, np.expm1),
+    ('log1p', np_math_ops.log1p, np.log1p),
+    ('log2', np_math_ops.log2, np.log2),
+    ('log10', np_math_ops.log10, np.log10),
+    ('cbrt', np_math_ops.cbrt, np.cbrt),
+    ('sinc', np_math_ops.sinc, np.sinc),
+    ('exp2', np_math_ops.exp2, np.exp2),
+    ('deg2rad', np_math_ops.deg2rad, np.deg2rad),
+    ('fix', np_math_ops.fix, np.fix),
+    ('isnan', np_math_ops.isnan, np.isnan),
+    ('isfinite', np_math_ops.isfinite, np.isfinite),
+]
+
+
+class MathWithoutNumpyMethodsOnTensorTest(test.TestCase):
+
+  def testUnaryOpsAcceptIntegerInputs(self):
+    # Integer inputs are promoted to a float dtype internally. That promotion
+    # must not go through a `Tensor` method that only exists after
+    # `enable_numpy_methods_on_tensor()`.
+    expected_input = np.array([1, 2, 3], dtype=np.float64)
+    for name, tf_fun, np_fun in _PROMOTING_UNARY_OPS:
+      for arg in ([1, 2, 3],
+                  np.array([1, 2, 3], dtype=np.int32),
+                  np.array([1, 2, 3], dtype=np.int64)):
+        actual = tf_fun(arg)
+        expected = np_fun(expected_input)
+        np.testing.assert_allclose(
+            np.asarray(actual),
+            expected,
+            rtol=1e-6,
+            atol=1e-6,
+            err_msg='{}({})'.format(name, arg))
+
+  def testUnaryOpsAcceptIntegerScalars(self):
+    for name, tf_fun, np_fun in _PROMOTING_UNARY_OPS:
+      actual = tf_fun(2)
+      expected = np_fun(np.float64(2))
+      np.testing.assert_allclose(
+          np.asarray(actual),
+          expected,
+          rtol=1e-6,
+          atol=1e-6,
+          err_msg='{}(2)'.format(name))
+
+  def testFloatInputsAreUnchanged(self):
+    arg = np.array([1.5, 2.5, 3.5], dtype=np.float32)
+    for name, tf_fun, np_fun in _PROMOTING_UNARY_OPS:
+      actual = tf_fun(arg)
+      np.testing.assert_allclose(
+          np.asarray(actual),
+          np_fun(arg),
+          rtol=1e-6,
+          atol=1e-6,
+          err_msg='{}({})'.format(name, arg))
+
+
+if __name__ == '__main__':
+  ops.enable_eager_execution()
+  # Intentionally not calling `np_math_ops.enable_numpy_methods_on_tensor()`.
+  test.main()


### PR DESCRIPTION
Most of the unary math functions in `tf.experimental.numpy` raise `AttributeError` when you pass them an integer, unless you happen to have called `experimental_enable_numpy_behavior()` first.

```python
>>> import numpy as np, tensorflow.experimental.numpy as tnp

>>> tnp.sqrt([1, 2, 3])
AttributeError: EagerTensor object has no attribute 'astype'.
        If you are looking for numpy-related methods, please run the following:
        tf.experimental.numpy.experimental_enable_numpy_behavior()

>>> tnp.exp(np.array([1, 2, 3], dtype=np.int32))
AttributeError: EagerTensor object has no attribute 'astype'.
```

A plain Python int fails the same way. 29 exported functions are affected: `log`, `exp`, `sqrt`, `ceil`, `floor`, `sin`, `cos`, `tan`, `sinh`, `cosh`, `tanh`, `arcsin`, `arccos`, `arctan`, `arcsinh`, `arccosh`, `arctanh`, `expm1`, `log1p`, `log2`, `log10`, `cbrt`, `sinc`, `deg2rad`, `exp2`, `angle`, `fix`, `isnan` and `isfinite`.

### Cause

They all go through `_scalar`, which promotes integer inputs using a `Tensor` method:

```python
x = np_array_ops.asarray(x)
if promote_to_float and not np.issubdtype(x.dtype.as_numpy_dtype, np.inexact):
  x = x.astype(np_utils.result_type(float))
```

`asarray` returns a `Tensor`, and `Tensor` has no `astype` by default. That method is installed only by `enable_numpy_methods_on_tensor()`, where it is bound straight to `math_ops.cast`:

```python
setattr(tensor_class, 'astype', math_ops.cast)
```

So the promotion silently depends on an opt-in that most callers of these functions never make.

### Fix

Call `math_ops.cast` directly. Because `astype` is nothing more than an alias for it, this is the identical operation for anyone who has enabled numpy behaviour, and it makes the functions work for everyone who hasn't.

### Why the tests didn't catch it

Every module under `numpy_ops` that tests these functions calls `enable_numpy_methods_on_tensor()` from its `__main__`. That patches `Tensor` for the whole process, so `astype` exists and the bug is invisible — the promotion path is never exercised the way a normal user hits it.

Rather than work around that in the existing file, I added `np_math_ops_no_numpy_methods_test.py`, which deliberately does not make that call and so runs in the same configuration a plain `import tensorflow` gives you. On an unpatched tree two of its tests fail with the `AttributeError` above; with the fix the module passes. `np_math_ops_test.py` and `np_logic_test.py` are unchanged by the fix.

### One thing this doesn't fix

`isinf`, `isneginf` and `isposinf` also crash on integer input, but for an unrelated reason — they read `x.dtype.is_floating` off the raw argument before it has been converted, so a numpy array or a Python list blows up there instead, and integer inputs get a bare `False` rather than an array. That deserves its own change, so I've left it out of this one.
