### PR TITLE
Fix `tnp.isinf`/`isneginf`/`isposinf` crashing on unconverted inputs and returning scalar `False`

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1065,25 +1065,28 @@ def isfinite(x):
 @tf_export.tf_export('experimental.numpy.isinf', v1=[])
 @np_utils.np_doc('isinf')
 def isinf(x):
+  x = np_array_ops.asarray(x)
   if x.dtype.is_floating:
     return _scalar(math_ops.is_inf, x, True)
-  return False
+  return np_array_ops.zeros_like(x, dtypes.bool)
 
 
 @tf_export.tf_export('experimental.numpy.isneginf', v1=[])
 @np_utils.np_doc('isneginf')
 def isneginf(x):
+  x = np_array_ops.asarray(x)
   if x.dtype.is_floating:
     return x == np_array_ops.full_like(x, -np.inf)
-  return False
+  return np_array_ops.zeros_like(x, dtypes.bool)
 
 
 @tf_export.tf_export('experimental.numpy.isposinf', v1=[])
 @np_utils.np_doc('isposinf')
 def isposinf(x):
+  x = np_array_ops.asarray(x)
   if x.dtype.is_floating:
     return x == np_array_ops.full_like(x, np.inf)
-  return False
+  return np_array_ops.zeros_like(x, dtypes.bool)
 
 
 @tf_export.tf_export('experimental.numpy.log2', v1=[])

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -645,6 +645,40 @@ class MathTest(test.TestCase, parameterized.TestCase):
     self.assertFalse(np_math_ops.isneginf(x1))
     self.assertFalse(np_math_ops.isneginf(x2))
 
+  def testIsInfFamilyNonFloatInputs(self):
+    # A non-floating input has no infinities, but the result must still be an
+    # elementwise boolean array shaped like the input, as numpy returns, and
+    # the argument must be converted before its dtype is inspected.
+    fns = [(np_math_ops.isinf, np.isinf), (np_math_ops.isposinf, np.isposinf),
+           (np_math_ops.isneginf, np.isneginf)]
+    args = [
+        [1, 2, 3],
+        np.array([1, 2, 3], dtype=np.int32),
+        np.array([1, 2, 3], dtype=np.int64),
+        np.array([[1, 2], [3, 4]], dtype=np.int32),
+        np.array([True, False]),
+        ops.convert_to_tensor([1, 2, 3]),
+    ]
+    for tf_fun, np_fun in fns:
+      for arg in args:
+        self.match(
+            tf_fun(arg),
+            np_fun(np.asarray(arg)),
+            msg='{}({})'.format(np_fun.__name__, arg))
+
+  def testIsInfFamilyFloatInputs(self):
+    fns = [(np_math_ops.isinf, np.isinf), (np_math_ops.isposinf, np.isposinf),
+           (np_math_ops.isneginf, np.isneginf)]
+    args = [
+        np.array([1.0, np.inf, -np.inf, np.nan], dtype=np.float64),
+        np.array([1.0, np.inf, -np.inf], dtype=np.float32),
+    ]
+    for tf_fun, np_fun in fns:
+      for arg in args:
+        self.match(
+            tf_fun(arg), np_fun(arg),
+            msg='{}({})'.format(np_fun.__name__, arg))
+
 if __name__ == '__main__':
   tensor.enable_tensor_equality()
   ops.enable_eager_execution()


### PR DESCRIPTION
`tf.experimental.numpy.isinf`, `isneginf` and `isposinf` inspect the dtype of the argument before converting it, so anything that isn't already a `Tensor` crashes:

```python
>>> import numpy as np, tensorflow as tf, tensorflow.experimental.numpy as tnp

>>> tnp.isinf(np.array([1, 2, 3]))
AttributeError: 'numpy.dtypes.Int64DType' object has no attribute 'is_floating'

>>> tnp.isinf(np.array([1.0, np.inf], dtype=np.float32))
AttributeError: 'numpy.dtypes.Float32DType' object has no attribute 'is_floating'

>>> tnp.isinf([1, 2, 3])
AttributeError: 'list' object has no attribute 'dtype'
```

A numpy array fails whether it's integer or float — `numpy.dtype` simply has no `is_floating` attribute, that's a `tf.DType` thing.

Pass a `Tensor` and it doesn't crash, but for any non-floating dtype it returns a bare Python `False` instead of an elementwise result:

```python
>>> tnp.isinf(tf.constant([1, 2, 3]))
False
>>> np.isinf(np.array([1, 2, 3]))
array([False, False, False])
```

So a caller doing `tnp.isinf(x).any()` gets an `AttributeError` on a bool, and one relying on the shape to broadcast silently gets a scalar.

### Fix

Convert the argument with `np_array_ops.asarray` before looking at its dtype, and return `zeros_like(x, bool)` rather than `False` so the result is an elementwise boolean array shaped like the input. The floating-point path is untouched.

### Tests

`testIsInfFamilyNonFloatInputs` covers lists, int32/int64/bool numpy arrays, a 2-D array and an int `Tensor` across all three functions; `testIsInfFamilyFloatInputs` covers float32 and float64 arrays containing `inf`, `-inf` and `nan`. Both fail on master with the errors above and pass with this change.

The existing `testIsInf` still passes unchanged. It only uses 0-d scalar tensors, where the result is a 0-d boolean tensor that `assertFalse` accepts, which is why the bug survived — nothing in the suite passed these functions an actual array of a non-floating dtype.

`np_math_ops_test.py`, `np_logic_test.py` and `np_array_ops_test.py` show no new failures.

### Not covered here

numpy's `isinf` also reports infinities in complex values (`np.isinf(np.array([np.inf+0j]))` is `[True]`), while these functions treat complex as non-floating and answer all-False. Deciding that also means deciding what `isneginf`/`isposinf` should do for complex, where numpy raises `TypeError` — a behaviour change worth its own discussion, so I've kept it out of this fix.
