### PR TITLE
Fix negative inter-op count in compute pool

### DIFF
--- a/tensorflow/core/common_runtime/process_util.cc
+++ b/tensorflow/core/common_runtime/process_util.cc
@@ -74,7 +74,7 @@ int32_t DefaultNumInterOpThreads() {
 static thread::ThreadPool* InitComputePool(const SessionOptions& options) {
   int32_t inter_op_parallelism_threads =
       options.config.inter_op_parallelism_threads();
-  if (inter_op_parallelism_threads == 0) {
+  if (inter_op_parallelism_threads <= 0) {
     inter_op_parallelism_threads = DefaultNumInterOpThreads();
   }
   return new thread::ThreadPool(

--- a/tensorflow/core/common_runtime/process_util_test.cc
+++ b/tensorflow/core/common_runtime/process_util_test.cc
@@ -34,5 +34,13 @@ TEST(ProcessUtilTest, ThreadPool) {
   delete pool;
 }
 
+TEST(ProcessUtilTest, ComputePoolNegativeInterOpThreadsUsesDefault) {
+  SessionOptions opts;
+  opts.config.set_inter_op_parallelism_threads(-1);
+
+  thread::ThreadPool* pool = ComputePool(opts);
+  EXPECT_GT(pool->NumThreads(), 0);
+}
+
 }  // anonymous namespace
 }  // namespace tensorflow


### PR DESCRIPTION
## Summary

- Treat negative `inter_op_parallelism_threads` values passed to the process-wide compute pool as unspecified, using the existing default path.
- Add regression coverage that `ComputePool` creates a valid pool for `-1`.

Addresses #124954.

## Validation

- `git diff --check`
- CI: `bazel test --config=linux -k //tensorflow/core/common_runtime:process_util_test`