### PR TITLE
Reconcile bounded-dynamic dims in BCastGradArgsOp before shape check

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -410,11 +410,13 @@ tf_xla_py_strict_test(
     ],
     deps = [
         ":xla_test",
+        "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:array_ops",
         "//tensorflow/python/ops:array_ops_gen",
         "//tensorflow/python/ops:bitwise_ops",
+        "//tensorflow/python/ops:gradients_impl",
         "//tensorflow/python/ops:math_ops",
         "//tensorflow/python/ops:math_ops_gen",
         "//tensorflow/python/ops:nn_ops",

--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -421,7 +421,6 @@ tf_xla_py_strict_test(
         "//tensorflow/python/ops:math_ops_gen",
         "//tensorflow/python/ops:nn_ops",
         "//tensorflow/python/ops:nn_ops_gen",
-        "//tensorflow/python/platform:client_testlib",
         "//tensorflow/python/platform:test",
         "//third_party/py/numpy",
     ],

--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -19,6 +19,7 @@ import itertools
 import numpy as np
 
 from tensorflow.compiler.tests import xla_test
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -26,6 +27,7 @@ from tensorflow.python.ops import bitwise_ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import gen_math_ops
 from tensorflow.python.ops import gen_nn_ops
+from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import googletest
@@ -1686,6 +1688,31 @@ class BinaryOpsTest(xla_test.XLATestCase):
           x,
           np.array((3, 7, 8, 9), dtype=np.int32),
           expected=np.tile(x, (1, 7, 8, 9)))
+
+  def testMulGradientOnBoundedDynamicDimension(self):
+    # tf.slice(x, [0], [n]), where n is itself only known at runtime, has an
+    # output size that's bounded by x's static shape but not statically
+    # known. Multiplying that result against a differently-shaped static
+    # tensor and differentiating used to fail XLA compilation in
+    # BroadcastGradientArgs, which resolved the dynamic dimension to its
+    # upper bound and rejected it as incompatible with the static side even
+    # though the two are equal at runtime (see GitHub issue #119382).
+    with self.session() as sess:
+      with self.test_scope():
+        x = array_ops.placeholder(dtypes.float32, shape=[5])
+        mask = array_ops.placeholder(dtypes.bool, shape=[3])
+        weights = constant_op.constant([1.0, -2.0], dtype=dtypes.float32)
+        n = math_ops.reduce_sum(math_ops.cast(mask, dtypes.int32))
+        sliced = array_ops.slice(x, [0], [n])
+        out = math_ops.reduce_sum(sliced * weights)
+        grad = gradients_impl.gradients(out, x)[0]
+      result = sess.run(
+          grad,
+          feed_dict={
+              x: [-2.0, -1.0, 0.0, 1.0, 2.0],
+              mask: [True, False, True],
+          })
+    self.assertAllClose(result, [1.0, -2.0, 0.0, 0.0, 0.0])
 
 
 if __name__ == "__main__":

--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -31,7 +31,6 @@ from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import googletest
-from tensorflow.python.platform import test as test_lib
 
 
 class BinaryOpsTest(xla_test.XLATestCase):

--- a/tensorflow/compiler/tf2xla/kernels/bcast_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/bcast_ops.cc
@@ -104,6 +104,7 @@ class BCastGradArgsOp : public XlaOpKernel {
         absl::UnimplementedError("Broadcast for n-ary operations (n > 2)"));
 
     absl::InlinedVector<BCast::Vec, 4> shapes;
+    absl::InlinedVector<std::vector<bool>, 2> dynamic_dims;
     for (int i = 0; i < ctx->num_inputs(); ++i) {
       const TensorShape in_shape = ctx->InputShape(i);
       OP_REQUIRES(
@@ -116,9 +117,38 @@ class BCastGradArgsOp : public XlaOpKernel {
       // path to use the same shape to decide the reduction indices.
       OP_REQUIRES_OK(ctx, ctx->ConstantInputAsIntVector(
                               i, &vec, xla::ValueInferenceMode::kUpperBound));
+      std::vector<bool> dynamic;
+      OP_REQUIRES_OK(ctx,
+                      ctx->ResolveInputDynamismIntoPredVector(i, &dynamic));
 
       shapes.push_back(BCast::Vec(vec.begin(), vec.end()));
+      dynamic_dims.push_back(std::move(dynamic));
     }
+
+    // A dimension resolved from its upper bound (rather than a true
+    // compile-time constant) can numerically disagree with the other
+    // operand's static dimension even though the two are guaranteed equal at
+    // runtime. The forward broadcasting op already requires this, or it
+    // would have failed itself. Reconcile such axes, aligned from the
+    // trailing dimension per standard broadcasting rules, before the static
+    // compatibility check below, so a dynamic upper bound doesn't cause a
+    // false-positive shape-incompatibility failure.
+    const int64_t rank0 = shapes[0].size();
+    const int64_t rank1 = shapes[1].size();
+    const int64_t common_rank = rank0 < rank1 ? rank0 : rank1;
+    for (int64_t k = 0; k < common_rank; ++k) {
+      const int64_t i0 = rank0 - 1 - k;
+      const int64_t i1 = rank1 - 1 - k;
+      int64_t& d0 = shapes[0][i0];
+      int64_t& d1 = shapes[1][i1];
+      if (d0 == d1 || d0 == 1 || d1 == 1) continue;
+      if (dynamic_dims[0][i0]) {
+        d0 = d1;
+      } else if (dynamic_dims[1][i1]) {
+        d1 = d0;
+      }
+    }
+
     BCast bcast(shapes[0], shapes[1]);
     OP_REQUIRES(ctx, bcast.IsValid(),
                 absl::InvalidArgumentError(absl::StrCat(

--- a/tensorflow/compiler/tf2xla/kernels/bcast_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/bcast_ops.cc
@@ -120,6 +120,12 @@ class BCastGradArgsOp : public XlaOpKernel {
       std::vector<bool> dynamic;
       OP_REQUIRES_OK(ctx,
                       ctx->ResolveInputDynamismIntoPredVector(i, &dynamic));
+      OP_REQUIRES(
+          ctx, dynamic.size() == vec.size(),
+          absl::InternalError(absl::StrCat(
+              "Size mismatch between input shape vector size (", vec.size(),
+              ") and dynamism vector size (", dynamic.size(), ") for input ",
+              i)));
 
       shapes.push_back(BCast::Vec(vec.begin(), vec.end()));
       dynamic_dims.push_back(std::move(dynamic));


### PR DESCRIPTION
Addresses #119382

## Problem

Differentiating a bounded-dynamic tensor (e.g. from `tf.boolean_mask`) multiplied against a differently-sized static tensor fails XLA compilation under `jit_compile=True`:

```python
import tensorflow as tf

def f(x, gather_idx, mask, weights):
  with tf.GradientTape() as tape:
    tape.watch(x)
    picked = tf.gather(x, gather_idx)
    masked = tf.boolean_mask(picked, mask)
    out = tf.reduce_sum(masked * weights)
  return out, tape.gradient(out, x)

x = tf.linspace(-2.0, 2.0, 5)
gather_idx = tf.constant([4, 1, 3], tf.int32)
mask = tf.constant([True, False, True])
weights = tf.constant([1.0, -2.0], tf.float32)

tf.function(f, jit_compile=True)(x, gather_idx, mask, weights)
```

```
InvalidArgumentError: Incompatible shapes: [3] vs. [2]
```

`masked` has a bounded-dynamic size (upper bound 3, true runtime size 2), `weights` has a static size of 2. Eager and graph mode both succeed; only `jit_compile=True` fails.

## Root cause

`BCastGradArgsOp::Compile` (`tensorflow/compiler/tf2xla/kernels/bcast_ops.cc`) reads both operand shapes via `ConstantInputAsIntVector(..., kUpperBound)`. For a bounded-dynamic dimension, this returns the upper bound (3 here), not the true runtime value (2). The subsequent `BCast::IsValid()` check then compares that upper bound against the other operand's real static size and rejects it, even though the two are guaranteed equal at runtime.

## Fix

Resolve per-dimension dynamism via `ResolveInputDynamismIntoPredVector` (the same pattern already used in `reshape_op.cc`, `slice_op.cc`, and elsewhere in tf2xla) and reconcile a dynamic-vs-static dimension pair, aligned from the trailing dimension per standard broadcasting rules, before the compatibility check. Scope: only `BCastGradArgsOp::Compile`; `BCastArgsOp` (the forward `BroadcastArgs` op) is untouched, since the repro shows only the gradient path fails.

## Testing

Added `testMulGradientOnBoundedDynamicDimension` to `tensorflow/compiler/tests/binary_ops_test.py`. It uses `tf.slice(x, [0], [n])`, where `n` is a runtime-only-known count, as the bounded-dynamic source rather than `tf.boolean_mask`/`tf.gather` directly. See Known limitation below for why.

`bazel test //tensorflow/compiler/tests:binary_ops_test_cpu`: passes, including the new test.
`bazel test //tensorflow/compiler/tests:unary_ops_test_cpu`: passes (regression guard for the related bounded-dynamic-dimension fix in #123015, unaffected by this change).

## Known limitation

This fixes `BroadcastGradientArgs` specifically. It does not fully unblock the exact reproduction above: with this fix applied, `tf.boolean_mask`'s own gradient hits a second, separate bug in `UnsortedSegmentSum`'s tf2xla kernel (`SegmentReduce::Compile` in `tensorflow/compiler/tf2xla/kernels/segment_reduction_ops.cc`), which has the same class of issue (a bounded-dynamic dimension resolved to its upper bound) in a different kernel. That's broader in scope than this fix (it affects any `tf.gather` gradient under `jit_compile=True`, not just `boolean_mask`'s) and is filed separately as #124963.
