### PR TITLE
Fix negative shape dimension check in RaggedTensorToTensorOp

### DIFF
--- a/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc
+++ b/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc
@@ -405,6 +405,14 @@ class RaggedTensorToTensorBaseOp : public OpKernel {
                    TensorShapeUtils::MakeShape(output_size, &output_shape));
     Tensor* output_tensor = nullptr;
 
+        for (int i = 0; i < output_shape.dims(); ++i) {
+      OP_REQUIRES(
+          context, output_shape.dim_size(i) >= 0,
+          errors::InvalidArgument(
+              "Output shape dimensions must be non-negative, got ",
+              output_shape.dim_size(i), " for dimension ", i));
+    }
+
     OP_REQUIRES_OK(context,
                    context->allocate_output(0, output_shape, &output_tensor));
     const INDEX_TYPE full_size = multiplier[0] * output_size[0];


### PR DESCRIPTION
Validates output shape dimensions in RaggedTensorToTensorOp to ensure they are strictly non-negative prior to allocating output buffers, preventing potential out-of-bounds memory writes.