### PR TITLE
Fix out-of-bounds index check for SparseMatrixSparseCholesky permutation

### DIFF
--- a/tensorflow/core/kernels/sparse/sparse_cholesky_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_cholesky_op.cc
@@ -274,6 +274,16 @@ class CSRSparseCholeskyCPUOp : public OpKernel {
                          perm_shape.dim_size(0), " != ", *batch_size));
     }
 
+    auto permutation_vec = permutation_indices.flat<int32_t>();
+    for (int64_t i = 0; i < permutation_vec.size(); ++i) {
+      const int32_t p = permutation_vec(i);
+      if (p < 0 || p >= *num_rows) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Permutation index out of bounds: got ", p,
+            ", but expected index in range [0, ", *num_rows, ")"));
+      }
+    }
+
     return absl::OkStatus();
   }
 };

--- a/tensorflow/core/kernels/sparse/sparse_cholesky_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_cholesky_op.cc
@@ -274,9 +274,11 @@ class CSRSparseCholeskyCPUOp : public OpKernel {
                          perm_shape.dim_size(0), " != ", *batch_size));
     }
 
-    auto permutation_vec = permutation_indices.flat<int32_t>();
-    for (int64_t i = 0; i < permutation_vec.size(); ++i) {
-      const int32_t p = permutation_vec(i);
+    const auto permutation_vec = permutation_indices.flat<int32_t>();
+    const int32_t* perm_data = permutation_vec.data();
+    const int64_t size = permutation_vec.size();
+    for (int64_t i = 0; i < size; ++i) {
+      const int32_t p = perm_data[i];
       if (p < 0 || p >= *num_rows) {
         return absl::InvalidArgumentError(absl::StrCat(
             "Permutation index out of bounds: got ", p,


### PR DESCRIPTION
Validates permutation indices in SparseMatrixSparseCholesky to ensure all entries are non-negative and strictly less than num_rows prior to running Eigen operations, preventing out-of-bounds memory accesses and segfaults.