### PR TITLE
Demote GPU CheckNumerics anomaly log from LOG(ERROR) to VLOG(1)

### DIFF
--- a/tensorflow/core/kernels/check_numerics_op.cc
+++ b/tensorflow/core/kernels/check_numerics_op.cc
@@ -289,8 +289,14 @@ class CheckNumericsOp<GPUDevice, T> : public AsyncOpKernel {
     const int is_nan = abnormality_indicators(0);
     const int is_inf = abnormality_indicators(1);
     if (is_nan || is_inf) {
-      LOG(ERROR) << "abnormal_detected_host @" << abnormality_indicators.data()
-                 << " = {" << is_nan << ", " << is_inf << "} " << message_;
+      // Logged at VLOG level rather than LOG(ERROR): the InvalidArgumentError
+      // set below already reports the anomaly to the caller in readable form,
+      // so emitting an error line per detection only duplicates it, and the
+      // host buffer address is useful for debugging this kernel alone. The
+      // CPU kernel and CheckNumericsV2 report the same condition without any
+      // logging.
+      VLOG(1) << "abnormal_detected_host @" << abnormality_indicators.data()
+              << " = {" << is_nan << ", " << is_inf << "} " << message_;
 
       std::string anomalies;
       if (is_nan && is_inf) {

--- a/tensorflow/core/kernels/check_numerics_op.cc
+++ b/tensorflow/core/kernels/check_numerics_op.cc
@@ -289,12 +289,8 @@ class CheckNumericsOp<GPUDevice, T> : public AsyncOpKernel {
     const int is_nan = abnormality_indicators(0);
     const int is_inf = abnormality_indicators(1);
     if (is_nan || is_inf) {
-      // Logged at VLOG level rather than LOG(ERROR): the InvalidArgumentError
-      // set below already reports the anomaly to the caller in readable form,
-      // so emitting an error line per detection only duplicates it, and the
-      // host buffer address is useful for debugging this kernel alone. The
-      // CPU kernel and CheckNumericsV2 report the same condition without any
-      // logging.
+      // Not LOG(ERROR): the InvalidArgumentError set below already reports
+      // this to the caller, so logging per detection would duplicate it.
       VLOG(1) << "abnormal_detected_host @" << abnormality_indicators.data()
               << " = {" << is_nan << ", " << is_inf << "} " << message_;
 


### PR DESCRIPTION
## Summary

Fixes #96524.

The GPU `CheckNumerics` kernel emits a `LOG(ERROR)` line on every NaN/Inf detection:

```
E0000 00:00:1751960796.835796  260759 check_numerics_op.cc:295] abnormal_detected_host @0x7fd6e3c05600 = {1, 0} Check if pdf output contains any NaNs of Infs
```

which floods stderr, as reported. The line prints a host buffer address and the raw indicator flags.

## Why this is redundant

In `CheckNumericsOp<GPUDevice, T>::checkForAnomalies`, the log is emitted immediately before:

```c++
context->SetStatus(absl::InvalidArgumentError(
    absl::StrCat(message_, " : Tensor had ", anomalies, " values")));
```

so the same condition is already reported to the caller in readable form. The logged address is of no use outside debugging this kernel.

The two sibling implementations in the same file already report this condition with no logging at all:

- `CheckNumericsOp<CPUDevice, T>` sets the status only.
- `CheckNumericsV2Op<GPUDevice, T>` overrides `checkForAnomalies` and sets the status only, which is why the workaround suggested in the issue (switching to `CheckNumericsV2`) avoids the noise.

The V1 GPU kernel is the only one of the three that logs.

## Change

Demote the line to `VLOG(1)`: silent by default, still available via `TF_CPP_VMODULE=check_numerics_op=1` for anyone debugging the kernel. No include or BUILD change is needed, since `VLOG` comes from the same header as the `LOG` already in use.

Given that both siblings log nothing at all, removing the line outright would also be consistent; happy to do that instead if reviewers prefer strict parity.

## Testing

No regression test: this asserts the absence of a log line from a GPU-only kernel, which is not practical to test in CI. The change is confined to logging severity and does not affect the op's status, outputs, or control flow.

Note that I do not have a GPU available, so this specific kernel path was not exercised locally; CI covers compilation of the GPU kernels.

Credit to @acampove for the report.