### PR TITLE
Validate seq_len_max against x's time dimension in BlockLSTM ops

### DIFF
--- a/tensorflow/core/kernels/rnn/lstm_ops.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops.cc
@@ -1058,6 +1058,13 @@ class BlockLSTMOp : public OpKernel {
     const Device& device = ctx->eigen_device<Device>();
 
     const int64_t seq_len_max = seq_len_max_tensor->scalar<int64_t>()();
+    OP_REQUIRES(ctx, seq_len_max >= 0,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "seq_len_max must be >= 0: ", seq_len_max)));
+    OP_REQUIRES(ctx, seq_len_max <= timelen,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "seq_len_max must be <= timelen (x.dim_size(0)): ",
+                    seq_len_max, " vs. ", timelen)));
     SliceHelper<Device, T> slicer(ctx);
     for (int64_t t = 0; t < seq_len_max; ++t) {
       const Tensor x_tensor = slicer.InputSlice(*x, t, "x");
@@ -1377,6 +1384,13 @@ class BlockLSTMGradOp : public OpKernel {
     functor::TensorZero<Device, T>()(device, b_grad_tensor->flat<T>());
 
     const int64_t seq_len_max = seq_len_max_tensor->scalar<int64_t>()();
+    OP_REQUIRES(ctx, seq_len_max >= 0,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "seq_len_max must be >= 0: ", seq_len_max)));
+    OP_REQUIRES(ctx, seq_len_max <= timelen,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "seq_len_max must be <= timelen (x.dim_size(0)): ",
+                    seq_len_max, " vs. ", timelen)));
     SliceHelper<Device, T> slicer(ctx);
     for (int64_t t = seq_len_max - 1; t >= 0; --t) {
       const Tensor& x_tensor = slicer.InputSlice(*x, t, "x");

--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -2811,6 +2811,7 @@ cuda_py_strict_test(
         ":rnn_grad",
         ":rnn_ops_gen",
         "//tensorflow/python/framework:dtypes",
+        "//tensorflow/python/framework:errors",
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/platform:client_testlib",

--- a/tensorflow/python/ops/rnn_grad_test.py
+++ b/tensorflow/python/ops/rnn_grad_test.py
@@ -19,6 +19,7 @@ import functools
 import numpy as np
 
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -115,6 +116,78 @@ class RNNGradTest(test.TestCase):
         grads.append(grad)
     self.assertAllClose(outputs[0], outputs[1])
     self.assertAllClose(grads[0], grads[1])
+
+  def testBlockLSTMSeqLenMaxTooLarge(self):
+    w, b, x, cs_prev, h_prev, w_peephole = self._block_lstm_inputs()
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "seq_len_max must be <= timelen"):
+      self._block_lstm(w, b, x, cs_prev, h_prev, w_peephole, seq_len_max=10)
+
+  def testBlockLSTMSeqLenMaxNegative(self):
+    w, b, x, cs_prev, h_prev, w_peephole = self._block_lstm_inputs()
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "seq_len_max must be >= 0"):
+      self._block_lstm(w, b, x, cs_prev, h_prev, w_peephole, seq_len_max=-1)
+
+  def testBlockLSTMGradSeqLenMaxTooLarge(self):
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "seq_len_max must be <= timelen"):
+      self._block_lstm_grad(seq_len_max=10)
+
+  def testBlockLSTMGradSeqLenMaxNegative(self):
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "seq_len_max must be >= 0"):
+      self._block_lstm_grad(seq_len_max=-1)
+
+  def _block_lstm_inputs(self, num_steps=2, batch_size=1, input_size=1,
+                         hidden_size=4):
+    """Returns a valid BlockLSTM input set whose x has num_steps timesteps."""
+    w = deterministic_random_uniform(
+        [input_size + hidden_size, 4 * hidden_size])
+    b = deterministic_random_uniform([4 * hidden_size])
+    x = deterministic_random_uniform([num_steps, batch_size, input_size])
+    cs_prev = h_prev = deterministic_random_uniform([batch_size, hidden_size])
+    w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)
+    return w, b, x, cs_prev, h_prev, w_peephole
+
+  def _block_lstm(self, w, b, x, cs_prev, h_prev, w_peephole, seq_len_max):
+    return gen_rnn_ops.BlockLSTM(
+        seq_len_max=math_ops.cast(seq_len_max, dtypes.int64),
+        x=x,
+        cs_prev=cs_prev,
+        h_prev=h_prev,
+        w=w,
+        wci=w_peephole,
+        wcf=w_peephole,
+        wco=w_peephole,
+        b=b,
+        use_peephole=False)
+
+  def _block_lstm_grad(self, seq_len_max):
+    """Runs a valid forward pass, then BlockLSTMGrad with seq_len_max."""
+    w, b, x, cs_prev, h_prev, w_peephole = self._block_lstm_inputs()
+    i, cs, f, o, ci, co, h = self._block_lstm(
+        w, b, x, cs_prev, h_prev, w_peephole, seq_len_max=x.shape[0])
+    return gen_rnn_ops.BlockLSTMGrad(
+        seq_len_max=math_ops.cast(seq_len_max, dtypes.int64),
+        x=x,
+        cs_prev=cs_prev,
+        h_prev=h_prev,
+        w=w,
+        wci=w_peephole,
+        wcf=w_peephole,
+        wco=w_peephole,
+        b=b,
+        i=i,
+        cs=cs,
+        f=f,
+        o=o,
+        ci=ci,
+        co=co,
+        h=h,
+        cs_grad=deterministic_random_uniform(cs.shape.as_list()),
+        h_grad=deterministic_random_uniform(h.shape.as_list()),
+        use_peephole=False)
 
   def _lstm_block(self, op, w, b, x, cs_prev, h_prev):
     w_peephole = array_ops.zeros(cs_prev.shape[1:], dtype=w.dtype)

--- a/tensorflow/python/ops/rnn_grad_test.py
+++ b/tensorflow/python/ops/rnn_grad_test.py
@@ -121,23 +121,27 @@ class RNNGradTest(test.TestCase):
     w, b, x, cs_prev, h_prev, w_peephole = self._block_lstm_inputs()
     with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
                                 "seq_len_max must be <= timelen"):
-      self._block_lstm(w, b, x, cs_prev, h_prev, w_peephole, seq_len_max=10)
+      self.evaluate(
+          self._block_lstm(w, b, x, cs_prev, h_prev, w_peephole, seq_len_max=10)
+      )
 
   def testBlockLSTMSeqLenMaxNegative(self):
     w, b, x, cs_prev, h_prev, w_peephole = self._block_lstm_inputs()
     with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
                                 "seq_len_max must be >= 0"):
-      self._block_lstm(w, b, x, cs_prev, h_prev, w_peephole, seq_len_max=-1)
+      self.evaluate(
+          self._block_lstm(w, b, x, cs_prev, h_prev, w_peephole, seq_len_max=-1)
+      )
 
   def testBlockLSTMGradSeqLenMaxTooLarge(self):
     with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
                                 "seq_len_max must be <= timelen"):
-      self._block_lstm_grad(seq_len_max=10)
+      self.evaluate(self._block_lstm_grad(seq_len_max=10))
 
   def testBlockLSTMGradSeqLenMaxNegative(self):
     with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
                                 "seq_len_max must be >= 0"):
-      self._block_lstm_grad(seq_len_max=-1)
+      self.evaluate(self._block_lstm_grad(seq_len_max=-1))
 
   def _block_lstm_inputs(self, num_steps=2, batch_size=1, input_size=1,
                          hidden_size=4):


### PR DESCRIPTION
`seq_len_max` was checked for rank only, never against `x`'s time dimension, so `tf.raw_ops.BlockLSTMGrad` aborted the process instead of returning an error:

```
Check failed: limit <= dim0_size (10 vs. 2)
```

Both bounds are needed. `Tensor::Slice` checks `0 <= start` before `limit <= dim0_size`, so a negative `seq_len_max` still crashes through the trailing `x_grad->Slice(seq_len_max, timelen)` even though the timestep loop never runs.

The forward `BlockLSTM` op has the same unguarded pattern, so this guards both. Fixing only the op named in the issue would leave the sibling one call away.

Both ops register GPU kernels. The checks run on the host inside `Compute()`, so the error is the same under either placement and the tests need no device pin.

Fixes #124974
