### PR TITLE
Reconcile bounded-dynamic prefix dims in SegmentReduce before the shape check

### DIFF
--- a/tensorflow/compiler/tests/segment_reduction_ops_test.py
+++ b/tensorflow/compiler/tests/segment_reduction_ops_test.py
@@ -277,6 +277,50 @@ class SegmentReductionOpsTest(xla_test.XLATestCase):
                             math_ops.unsorted_segment_sum, data, indices,
                             num_segments))
 
+  def testUnsortedSegmentSumBoundedDynamicPrefixDimension(self):
+    # Slicing by a run-time size gives a bounded-dynamic leading dimension.
+    # The kernel read that dimension as its upper bound and rejected it
+    # against the other operand's smaller size, even though the two are equal
+    # at run time.
+    for dtype in self.numeric_types:
+      with self.session() as sess, self.test_scope():
+        mask = array_ops.placeholder(np.bool_, shape=[3])
+        count = math_ops.reduce_sum(math_ops.cast(mask, dtypes.int32))
+
+        # Dynamic indices (bound 3, run-time 2) against static data (2).
+        data = array_ops.placeholder(dtype, shape=[2])
+        all_indices = array_ops.placeholder(np.int32, shape=[3])
+        y0 = math_ops.unsorted_segment_sum(
+            data, array_ops.slice(all_indices, [0], [count]), 3)
+
+        # Dynamic data (bound 3, run-time 2) against static indices (2).
+        all_data = array_ops.placeholder(dtype, shape=[3])
+        indices = array_ops.placeholder(np.int32, shape=[2])
+        y1 = math_ops.unsorted_segment_sum(
+            array_ops.slice(all_data, [0], [count]), indices, 3)
+
+        # Both sides dynamic, with different bounds. This is where the kernel
+        # slices the larger side while cwise_ops.cc pads instead.
+        pair_data = array_ops.placeholder(dtype, shape=[5])
+        pair_indices = array_ops.placeholder(np.int32, shape=[2])
+        y2 = math_ops.unsorted_segment_sum(
+            array_ops.slice(pair_data, [0], [count]),
+            array_ops.slice(pair_indices, [0], [count]), 3)
+
+        r0, r1, r2 = sess.run([y0, y1, y2], {
+            mask: np.array([True, False, True]),
+            data: np.array([1, 2], dtype=dtype),
+            all_indices: np.array([0, 2, 1], dtype=np.int32),
+            all_data: np.array([1, 2, 9], dtype=dtype),
+            indices: np.array([0, 2], dtype=np.int32),
+            pair_data: np.array([1, 2, 7, 8, 9], dtype=dtype),
+            pair_indices: np.array([0, 2], dtype=np.int32),
+        })
+
+      self.assertAllClose(np.array([1, 0, 2], dtype=dtype), r0)
+      self.assertAllClose(np.array([1, 0, 2], dtype=dtype), r1)
+      self.assertAllClose(np.array([1, 0, 2], dtype=dtype), r2)
+
   def testUnsortedSegmentOps1DIndices1DDataNegativeIndices(self):
     """Tests for min, max, and prod ops.
 

--- a/tensorflow/compiler/tf2xla/kernels/segment_reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/segment_reduction_ops.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "xla/hlo/builder/value_inference.h"
 #include "xla/hlo/builder/xla_builder.h"
 #include "xla/primitive_util.h"
+#include "xla/shape.h"
 #include "xla/xla_data.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/op_requires.h"
@@ -81,6 +82,54 @@ class SegmentReduce : public XlaOpKernel {
                 errors::InvalidArgument(type_string(),
                                         " requires that indices' rank be"
                                         " less than or equal to data's rank."));
+
+    // InputShape() reports a bounded-dynamic dimension as its upper bound, so
+    // two prefix dimensions that are equal at run time can still disagree
+    // here. Reconcile the operands first: their run-time sizes are equal, so
+    // both fit within the smaller of the two bounds. Slice the larger side
+    // down to that bound and re-apply its run-time size. Only a dimension
+    // that is actually dynamic is sliced, so a genuine static mismatch still
+    // fails the check below. This has to reach the operands rather than just
+    // the check, because xla::Scatter compares the same bounds again during
+    // shape inference and tolerates only unbounded dynamic sizes. Where
+    // cwise_ops.cc pads the smaller side up when both sides are dynamic,
+    // slicing is safe here: segment reduction does not broadcast, so there is
+    // no size-1 dimension to preserve. If the run-time sizes are not in fact
+    // equal the program was already invalid; XLA cannot detect that at compile
+    // time here, same as cwise_ops.cc.
+    OP_REQUIRES_VALUE(xla::Shape data_xla_shape, ctx, ctx->InputXlaShape(0));
+    OP_REQUIRES_VALUE(xla::Shape indices_xla_shape, ctx, ctx->InputXlaShape(1));
+    OP_REQUIRES(
+        ctx,
+        data_xla_shape.dimensions().size() == data_shape.dims() &&
+            indices_xla_shape.dimensions().size() == indices_shape.dims(),
+        errors::Internal(type_string(), " got mismatched ranks for data (",
+                         data_xla_shape.dimensions().size(), " vs. ",
+                         data_shape.dims(), ") or indices (",
+                         indices_xla_shape.dimensions().size(), " vs. ",
+                         indices_shape.dims(), ")"));
+    for (int d = 0; d < indices_shape.dims(); ++d) {
+      const int64_t data_bound = data_shape.dim_size(d);
+      const int64_t indices_bound = indices_shape.dim_size(d);
+      if (data_bound > indices_bound &&
+          data_xla_shape.is_dynamic_dimension(d)) {
+        xla::XlaOp size = xla::GetDimensionSize(data, d);
+        data = xla::SliceInDim(data, /*start_index=*/0,
+                               /*limit_index=*/indices_bound, /*stride=*/1,
+                               /*dimno=*/d);
+        data = xla::SetDimensionSize(data, size, d);
+        data_shape.set_dim(d, indices_bound);
+      } else if (indices_bound > data_bound &&
+                 indices_xla_shape.is_dynamic_dimension(d)) {
+        xla::XlaOp size = xla::GetDimensionSize(indices, d);
+        indices = xla::SliceInDim(indices, /*start_index=*/0,
+                                  /*limit_index=*/data_bound, /*stride=*/1,
+                                  /*dimno=*/d);
+        indices = xla::SetDimensionSize(indices, size, d);
+        indices_shape.set_dim(d, data_bound);
+      }
+    }
+
     // Validate that indices.shape is a prefix of data.shape.
     for (int d = 0; d < indices_shape.dims(); ++d) {
       OP_REQUIRES(

--- a/tensorflow/compiler/tf2xla/kernels/segment_reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/segment_reduction_ops.cc
@@ -94,9 +94,10 @@ class SegmentReduce : public XlaOpKernel {
     // shape inference and tolerates only unbounded dynamic sizes. Where
     // cwise_ops.cc pads the smaller side up when both sides are dynamic,
     // slicing is safe here: segment reduction does not broadcast, so there is
-    // no size-1 dimension to preserve. If the run-time sizes are not in fact
-    // equal the program was already invalid; XLA cannot detect that at compile
-    // time here, same as cwise_ops.cc.
+    // no size-1 dimension to preserve. The run-time size is clamped to the
+    // reduced bound, which XLA requires of a dynamic dimension; an input that
+    // trips the clamp had unequal prefix dimensions at run time and was
+    // already invalid for this op.
     OP_REQUIRES_VALUE(xla::Shape data_xla_shape, ctx, ctx->InputXlaShape(0));
     OP_REQUIRES_VALUE(xla::Shape indices_xla_shape, ctx, ctx->InputXlaShape(1));
     OP_REQUIRES(
@@ -113,7 +114,10 @@ class SegmentReduce : public XlaOpKernel {
       const int64_t indices_bound = indices_shape.dim_size(d);
       if (data_bound > indices_bound &&
           data_xla_shape.is_dynamic_dimension(d)) {
-        xla::XlaOp size = xla::GetDimensionSize(data, d);
+        xla::XlaOp size = xla::Min(
+            xla::GetDimensionSize(data, d),
+            xla::ConstantR0<int32_t>(ctx->builder(),
+                                     static_cast<int32_t>(indices_bound)));
         data = xla::SliceInDim(data, /*start_index=*/0,
                                /*limit_index=*/indices_bound, /*stride=*/1,
                                /*dimno=*/d);
@@ -121,7 +125,10 @@ class SegmentReduce : public XlaOpKernel {
         data_shape.set_dim(d, indices_bound);
       } else if (indices_bound > data_bound &&
                  indices_xla_shape.is_dynamic_dimension(d)) {
-        xla::XlaOp size = xla::GetDimensionSize(indices, d);
+        xla::XlaOp size = xla::Min(
+            xla::GetDimensionSize(indices, d),
+            xla::ConstantR0<int32_t>(ctx->builder(),
+                                     static_cast<int32_t>(data_bound)));
         indices = xla::SliceInDim(indices, /*start_index=*/0,
                                   /*limit_index=*/data_bound, /*stride=*/1,
                                   /*dimno=*/d);


### PR DESCRIPTION
`SegmentReduce::Compile` reads both operand shapes with `ctx->InputShape()`, which reports a bounded-dynamic dimension as its upper bound. The prefix check then compares that bound against the other operand's real, smaller size and rejects a call that is valid at run time:

```
UnsortedSegmentSum requires indices shape to be prefix of data_shape, but dimension 0 differs 2 vs. 3
```

Relaxing the check alone is not enough. `xla::Scatter` applies the same equality to the same bounds during shape inference, and `CompatibleDimensionSizes` accepts only unbounded dynamic sizes, so the compile fails again a layer down. This reconciles the operands instead: where the two bounds differ and the larger side is dynamic, slice it to the smaller bound and re-apply its run-time size. `cwise_ops.cc` already does this for binary ops, though it pads rather than slices when both sides are dynamic, to protect a size-1 broadcast dimension that segment reduction does not have.

The prefix check and its message are unchanged. Neither branch can fire when both dimensions are static, so genuinely incompatible shapes still fail exactly as before, for every op sharing this path. The rank check guarding the loop is what keeps `is_dynamic_dimension(d)` in bounds, since `InputShape()` and `InputXlaShape()` read from two independent sources.

One narrowing worth naming: re-applying the run-time size to a dimension whose bound was just reduced truncates an input whose true run-time size exceeded the smaller bound. That input was already invalid for this op, but it now truncates where it previously errored. `cwise_ops.cc` carries the same contract.

The test covers three configurations: dynamic against static on either side, and both sides dynamic with different bounds.

Fixes #124963
