### PR TITLE
Fix CHECK-fail crash in TensorScatterMin/Max with malformed indices

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
@@ -853,6 +853,22 @@ class ScatterNdTest(test.TestCase, parameterized.TestCase):
     shape = [3, 4, 5, 6, 7, 8, 9]
     self.evaluate(self.scatter_nd(indices, values, shape))
 
+  def testUpdatesRankTooSmallForTensorScatterMinMax(self):
+    """Regression test for #94132 and #94134."""
+    input_tensor = np.random.random((1, 10, 4)).astype(np.float64)
+    indices = np.array([[[0]]], dtype=np.int64)  # shape (1,1,1), outer_dims=2
+    updates = np.array([0.0], dtype=np.float64)  # rank 1, too small
+
+    with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+      self.evaluate(
+          array_ops.tensor_scatter_min(
+              tensor=input_tensor, indices=indices, updates=updates))
+
+    with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+      self.evaluate(
+          array_ops.tensor_scatter_max(
+              tensor=input_tensor, indices=indices, updates=updates))
+
 
 class ScatterNdNonAliasingAddTest(ScatterNdTest):
   non_aliasing_add_test = True

--- a/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
@@ -855,7 +855,7 @@ class ScatterNdTest(test.TestCase, parameterized.TestCase):
 
   def testUpdatesRankTooSmallForTensorScatterMinMax(self):
     """Regression test for #94132 and #94134."""
-    input_tensor = np.random.random((1, 10, 4)).astype(np.float64)
+    input_tensor = np.zeros((1, 10, 4), dtype=np.float64)
     indices = np.array([[[0]]], dtype=np.int64)  # shape (1,1,1), outer_dims=2
     updates = np.array([0.0], dtype=np.float64)  # rank 1, too small
 


### PR DESCRIPTION
## Problem
`tf.raw_ops.TensorScatterMin` and `TensorScatterMax` crash with a fatal `CHECK` failure (`d < dims()`) when provided with malformed indices where the rank of `updates` is smaller than the number of outer dimensions of `indices`.

## Root Cause
In `TensorScatterOp::Compute` (`tensorflow/core/kernels/scatter_nd_op.cc`), the outer-dimension matching loop attempts to access `updates.shape().dim_size(i)` without first validating that the `updates` tensor has a sufficient rank.

## Fix
Added a rank validation guard before the outer-dimension loop in `TensorScatterOp::Compute`. This ensures an `InvalidArgumentError` is raised gracefully instead of crashing the process. 

Added regression tests `testUpdatesRankTooSmallForTensorScatterMinMax` to `scatter_nd_ops_test.py`.

Fixes #94132
Fixes #94134
