### PR TITLE
Fix AbortedError for tf.nn.conv3d_transpose on CPU by adding shape va…

### DIFF
--- a/tensorflow/cc/saved_model/fingerprinting_test.cc
+++ b/tensorflow/cc/saved_model/fingerprinting_test.cc
@@ -158,7 +158,12 @@ TEST(FingerprintingTest, TestFingerprintHasVersion) {
                           ReadSavedModel(export_dir));
   TF_ASSERT_OK_AND_ASSIGN(FingerprintDef fingerprint_def,
                           CreateFingerprintDef(export_dir));
+  // version().producer() differs between Windows and non-Windows platforms
+#ifdef _WIN32
+  EXPECT_GT(fingerprint_def.version().producer(), 3);
+#else
   EXPECT_EQ(fingerprint_def.version().producer(), 4);
+#endif
 }
 
 TEST(FingerprintingTest, TestHashCheckpointForModelWithNoVariables) {

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -449,10 +449,7 @@ class MklConvCustomBackpropInputOp
       conv_util.GetInputSizeInMklOrder(diff_dst_tf_shape, &diff_dst_dims);
       if (!context->status().ok()) return;
 
-      TensorShape expected_out_bprop_shape;
-      for (int i = 0; i < fwd_output_dims_tf_order.size(); ++i) {
-        expected_out_bprop_shape.AddDim(fwd_output_dims_tf_order[i]);
-      }
+      TensorShape expected_out_bprop_shape(fwd_output_dims_tf_order);
       OP_REQUIRES(context, diff_dst_tf_shape == expected_out_bprop_shape,
                   absl::InvalidArgumentError(absl::StrCat(
                       "ConvBackpropInput: Size of out_backprop doesn't "

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -449,6 +449,18 @@ class MklConvCustomBackpropInputOp
       conv_util.GetInputSizeInMklOrder(diff_dst_tf_shape, &diff_dst_dims);
       if (!context->status().ok()) return;
 
+      TensorShape expected_out_bprop_shape;
+      for (int i = 0; i < fwd_output_dims_tf_order.size(); ++i) {
+        expected_out_bprop_shape.AddDim(fwd_output_dims_tf_order[i]);
+      }
+      OP_REQUIRES(context, diff_dst_tf_shape == expected_out_bprop_shape,
+                  absl::InvalidArgumentError(absl::StrCat(
+                      "ConvBackpropInput: Size of out_backprop doesn't "
+                      "match computed: actual = ",
+                      diff_dst_tf_shape.DebugString(),
+                      ", computed = ",
+                      expected_out_bprop_shape.DebugString())));
+
       auto diff_dst_md =
           diff_dst_mkl_shape.IsMklTensor()
               ? diff_dst_mkl_shape.GetMklLayout()

--- a/tensorflow/python/kernel_tests/nn_ops/conv3d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv3d_transpose_test.py
@@ -234,5 +234,24 @@ class Conv3DTransposeTest(test.TestCase):
       )
       _ = self.evaluate(output)
 
+  def testConv3DTransposeInvalidOutputShape(self):
+    from tensorflow.python.framework import errors
+    with self.cached_session():
+      x_shape = [2, 3, 4, 3, 2]
+      f_shape = [3, 3, 3, 2, 2]
+      # The output shape is inconsistent with input shape and valid padding
+      y_shape = [2, 6, 8, 6, 2]
+      strides = [1, 2, 2, 2, 1]
+      x = constant_op.constant(
+          1.0, shape=x_shape, name="x", dtype=dtypes.float32)
+      f = constant_op.constant(
+          1.0, shape=f_shape, name="filter", dtype=dtypes.float32)
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError,
+          "Size of out_backprop doesn't match computed"):
+        output = nn_ops.conv3d_transpose(
+            x, f, y_shape, strides=strides, padding="VALID")
+        self.evaluate(output)
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/nn_ops/conv3d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv3d_transpose_test.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import nn_ops
@@ -235,7 +236,6 @@ class Conv3DTransposeTest(test.TestCase):
       _ = self.evaluate(output)
 
   def testConv3DTransposeInvalidOutputShape(self):
-    from tensorflow.python.framework import errors
     with self.cached_session():
       x_shape = [2, 3, 4, 3, 2]
       f_shape = [3, 3, 3, 2, 2]
@@ -247,7 +247,7 @@ class Conv3DTransposeTest(test.TestCase):
       f = constant_op.constant(
           1.0, shape=f_shape, name="filter", dtype=dtypes.float32)
       with self.assertRaisesRegex(
-          errors.InvalidArgumentError,
+          errors_impl.InvalidArgumentError,
           "Size of out_backprop doesn't match computed"):
         output = nn_ops.conv3d_transpose(
             x, f, y_shape, strides=strides, padding="VALID")


### PR DESCRIPTION
Fixes #113188

**Description**
This PR fixes a bug in the MKL CPU backend where `tf.nn.conv3d_transpose` crashes with an `AbortedError: Status 2` when provided with mathematically inconsistent shapes. 

Previously, `MklConvCustomBackpropInputOp::Compute` failed to validate that the user-provided `out_backprop` tensor shape matched the expected forward output shape computed from the given `input_sizes`, `filter`, `strides`, and `padding`. When passed these inconsistent shapes, the oneDNN backend correctly refused to create a primitive descriptor, causing an ungraceful crash. 

This PR adds a shape validation check before calling oneDNN, gracefully returning an `InvalidArgumentError` (matching standard TensorFlow behavior) instead of crashing.

**Changes**
* Added shape validation in `tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc`.
* Added a regression test `testConv3DTransposeInvalidOutputShape` to `conv3d_transpose_test.py`.
