### PR TITLE
Fix integer truncation and SIGSEGV in BlockLSTMGrad kernel (#104830)

### DIFF
--- a/tensorflow/core/kernels/rnn/lstm_ops.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops.cc
@@ -1200,6 +1200,11 @@ class BlockLSTMGradOp : public OpKernel {
     OP_REQUIRES(ctx, w_tensor->dims() == 2,
                 absl::InvalidArgumentError(absl::StrCat(
                     "w must be rank 2 but is rank ", w_tensor->dims())));
+    OP_REQUIRES(
+        ctx, w_tensor->dim_size(1) % 4 == 0 && w_tensor->dim_size(1) > 0,
+        absl::InvalidArgumentError(absl::StrCat(
+            "w matrix columns must be a positive multiple of 4, but got ",
+            w_tensor->dim_size(1))));
     const int64_t cell_size = w_tensor->dim_size(1) / 4;
     OP_REQUIRES(ctx, input_size + cell_size == w_tensor->dim_size(0),
                 absl::InvalidArgumentError(absl::StrCat(

--- a/tensorflow/core/kernels/rnn/lstm_ops.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops.cc
@@ -1201,7 +1201,7 @@ class BlockLSTMGradOp : public OpKernel {
                 absl::InvalidArgumentError(absl::StrCat(
                     "w must be rank 2 but is rank ", w_tensor->dims())));
     OP_REQUIRES(
-        ctx, w_tensor->dim_size(1) % 4 == 0 && w_tensor->dim_size(1) > 0,
+        ctx, w_tensor->dim_size(1) > 0 && w_tensor->dim_size(1) % 4 == 0,
         absl::InvalidArgumentError(absl::StrCat(
             "w matrix columns must be a positive multiple of 4, but got ",
             w_tensor->dim_size(1))));


### PR DESCRIPTION
### Summary of Changes

Fixes #104830.

#### Description
When calling `BlockLSTMGrad` or `BlockLSTMGradV2` with weight matrices `w` whose second dimension is not a positive multiple of 4 (e.g., shape `[1, 1]`), C++ integer division `cell_size = w_tensor->dim_size(1) / 4` evaluated to `0`. Consequently, `input_size + cell_size` matched `w_tensor->dim_size(0)` unexpectedly (`1 + 0 == 1`), bypassing existing shape checks and leading to out-of-bounds memory access / `SIGSEGV` during Eigen operations.

#### Fix Details
- Added explicit validation requiring `w_tensor->dim_size(1) % 4 == 0` and `w_tensor->dim_size(1) > 0`.
- Invalid weight matrix shapes now cleanly raise `absl::InvalidArgumentError` instead of crashing.