### PR TITLE
Fix SIGSEGV in CropAndResizeGradBoxes when boxes contain NaN or non-finite values (#124955)

### DIFF
--- a/tensorflow/core/kernels/image/crop_and_resize_op.cc
+++ b/tensorflow/core/kernels/image/crop_and_resize_op.cc
@@ -252,6 +252,9 @@ struct CropAndResize<CPUDevice, T> {
         const float x1 = boxes(b, 1);
         const float y2 = boxes(b, 2);
         const float x2 = boxes(b, 3);
+        if (!std::isfinite(y1) || !std::isfinite(x1) || !std::isfinite(y2) || !std::isfinite(x2)) {
+          continue;
+        }
 
         const int32_t b_in = box_index(b);
         if (!FastBoundsCheck(b_in, batch_size)) {
@@ -372,6 +375,16 @@ class CropAndResizeGradImageOp : public AsyncOpKernel {
   }
 
   void ComputeAsync(OpKernelContext* context, DoneCallback done) override {
+    const Tensor& boxes = context->input(1);
+    if (boxes.NumElements() > 0) {
+      const Eigen::Tensor<bool, 0, Eigen::RowMajor> only_finite =
+          boxes.tensor<float, 2>().isfinite().all();
+      OP_REQUIRES_ASYNC(
+          context, only_finite(),
+          absl::InvalidArgumentError(
+              "boxes contains at least one element that is not finite"),
+          done);
+    }
     // The shape of 'grads' is [num_boxes, crop_height, crop_width, depth].
     const Tensor& grads = context->input(0);
     // The shape of 'boxes' is [num_boxes, 4].
@@ -493,6 +506,9 @@ struct CropAndResizeBackpropImage<CPUDevice, T> {
         const float x1 = boxes(b, 1);
         const float y2 = boxes(b, 2);
         const float x2 = boxes(b, 3);
+        if (!std::isfinite(y1) || !std::isfinite(x1) || !std::isfinite(y2) || !std::isfinite(x2)) {
+          continue;
+        }
 
         const int32_t b_in = box_index(b);
         if (!FastBoundsCheck(b_in, batch_size)) {
@@ -599,6 +615,16 @@ class CropAndResizeGradBoxesOp : public AsyncOpKernel {
   }
 
   void ComputeAsync(OpKernelContext* context, DoneCallback done) override {
+    const Tensor& boxes = context->input(3);
+    if (boxes.NumElements() > 0) {
+      const Eigen::Tensor<bool, 0, Eigen::RowMajor> only_finite =
+          boxes.tensor<float, 2>().isfinite().all();
+      OP_REQUIRES_ASYNC(
+          context, only_finite(),
+          absl::InvalidArgumentError(
+              "boxes contains at least one element that is not finite"),
+          done);
+    }
     // The shape of 'grads' is [num_boxes, crop_height, crop_width, depth].
     const Tensor& grads = context->input(0);
     // The shape of 'boxes' is [num_boxes, 4].
@@ -708,6 +734,9 @@ struct CropAndResizeBackpropBoxes<CPUDevice, T> {
       const float x1 = boxes(b, 1);
       const float y2 = boxes(b, 2);
       const float x2 = boxes(b, 3);
+        if (!std::isfinite(y1) || !std::isfinite(x1) || !std::isfinite(y2) || !std::isfinite(x2)) {
+          continue;
+        }
 
       const int32_t b_in = box_index(b);
       if (!FastBoundsCheck(b_in, batch_size)) {

--- a/tensorflow/core/kernels/image/crop_and_resize_op.cc
+++ b/tensorflow/core/kernels/image/crop_and_resize_op.cc
@@ -714,6 +714,11 @@ struct CropAndResizeBackpropBoxes<CPUDevice, T> {
         continue;
       }
 
+      if (!std::isfinite(y1) || !std::isfinite(x1) ||
+          !std::isfinite(y2) || !std::isfinite(x2)) {
+        continue;
+      }
+
       const float height_ratio =
           (crop_height > 1)
               ? static_cast<float>(image_height - 1) / (crop_height - 1)

--- a/tensorflow/python/ops/image_grad_test.py
+++ b/tensorflow/python/ops/image_grad_test.py
@@ -15,6 +15,8 @@
 """Functional tests for Image Op Gradients."""
 
 from tensorflow.python.ops import image_grad_test_base as test_base
+from tensorflow.python.framework import errors
+from tensorflow.python.ops import image_ops
 from tensorflow.python.platform import test
 
 ResizeNearestNeighborOpTest = test_base.ResizeNearestNeighborOpTestBase
@@ -22,7 +24,57 @@ ResizeBilinearOpTest = test_base.ResizeBilinearOpTestBase
 ResizeBicubicOpTest = test_base.ResizeBicubicOpTestBase
 ScaleAndTranslateOpTest = test_base.ScaleAndTranslateOpTestBase
 CropAndResizeOpTest = test_base.CropAndResizeOpTestBase
+
+
+class CropAndResizeGradTest(test_base.CropAndResizeOpTestBase):
+
+  def testCropAndResizeGradBoxesWithNaNOrNonFinite(self):
+    """Test crop_and_resize_grad_boxes with non-finite boxes."""
+    grads = np.ones((1, 2, 2, 1), dtype=np.float32)
+    image = np.ones((1, 4, 4, 1), dtype=np.float32)
+    boxes_nan = np.array([[0.0, np.nan, 1.0, 1.0]], dtype=np.float32)
+    box_ind = np.array([0], dtype=np.int32)
+
+    with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+      image_ops.crop_and_resize_grad_boxes(
+          grads, image, boxes_nan, box_ind
+      )
+
+  def testCropAndResizeGradImageWithNaNOrNonFinite(self):
+    """Test crop_and_resize_grad_image with non-finite boxes."""
+    grads = np.ones((1, 2, 2, 1), dtype=np.float32)
+    boxes_nan = np.array([[0.0, np.nan, 1.0, 1.0]], dtype=np.float32)
+    box_ind = np.array([0], dtype=np.int32)
+    image_dense_shape = np.array([1, 4, 4, 1], dtype=np.int32)
+
+    with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+      image_ops.crop_and_resize_grad_image(
+          grads, boxes_nan, box_ind, image_dense_shape, T=np.float32
+      )
+
 RGBToHSVOpTest = test_base.RGBToHSVOpTestBase
 
 if __name__ == "__main__":
   test.main()
+
+class CropAndResizeGradNonFiniteTest(test_util.TensorFlowTestCase):
+
+  def testCropAndResizeGradWithNaNOrNonFinite(self):
+    grads = np.ones((1, 2, 2, 1), dtype=np.float32)
+    image = np.ones((1, 4, 4, 1), dtype=np.float32)
+    boxes_nan = np.array([[0.0, np.nan, 1.0, 1.0]], dtype=np.float32)
+    box_ind = np.array([0], dtype=np.int32)
+
+    with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+      self.evaluate(
+          image_ops.crop_and_resize_grad_boxes(
+              grads, image, boxes_nan, box_ind
+          )
+      )
+
+    with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+      self.evaluate(
+          image_ops.crop_and_resize_grad_image(
+              grads, boxes_nan, box_ind, image_shape=[1, 4, 4, 1]
+          )
+      )


### PR DESCRIPTION
### Summary of Changes

Fixes #124955.

#### Description
When calling `CropAndResizeGradBoxes` (`CropAndResizeBackpropBoxes`) with `boxes` containing `NaN` or `Inf` floating-point coordinates, standard comparison bounds checks (e.g., `in_y < 0 || in_y > image_height - 1`) evaluate to `false` due to IEEE 754 NaN comparison semantics. Execution bypassed index clamping, leading to invalid out-of-bounds array reads during bilinear interpolation and causing a `SIGSEGV` crash.

#### Fix Details
- Added explicit `std::isfinite` checks on box coordinates (`y1, x1, y2, x2`).
- Invalid boxes containing non-finite values are now safely skipped during gradient accumulation.