### PR TITLE
Fix heap buffer overflow in TFLite Reshape Prepare() when input and output bytes mismatch (#124982)

### DIFF
--- a/tensorflow/lite/kernels/reshape.cc
+++ b/tensorflow/lite/kernels/reshape.cc
@@ -138,8 +138,11 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
       if (IsConstantOrPersistentTensor(input)) {
         SetTensorToPersistentRo(output);
         TF_LITE_ENSURE_OK(context, ResizeOutput(context, node));
+        TF_LITE_ENSURE_EQ(context, output->bytes, input->bytes);
         op_data->output_ptr = output->data.data;
-        memcpy(output->data.data, input->data.data, input->bytes);
+        if (input->bytes > 0) {
+          memcpy(output->data.data, input->data.data, input->bytes);
+        }
       } else {
         TF_LITE_ENSURE_OK(context, ResizeOutput(context, node));
       }

--- a/tensorflow/lite/kernels/reshape_test.cc
+++ b/tensorflow/lite/kernels/reshape_test.cc
@@ -334,5 +334,19 @@ TEST(ReshapeShapeResolverTest, RejectsInferredDimensionOverflow) {
                                                  *output_shape),
             kTfLiteOk);
 }
+TEST(ReshapeOpTest, MismatchedConstantReshapeFails) {
+  // Input tensor with 5 float elements (20 bytes)
+  std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+  // Target shape requesting 6 elements (24 bytes) - mismatch!
+  std::vector<int> shape_data = {6};
+  
+  ReshapeOpModel m({TensorType_FLOAT32, {5}}, shape_data,
+                   {TensorType_INT32, {1}}, TensorType_FLOAT32,
+                   /*use_shape_parameter=*/false);
+  m.SetInput(input_data);
+  // Allocation/Preparation should fail due to size mismatch
+  EXPECT_NE(m.InvokeUnchecked(), kTfLiteOk);
+}
+
 }  // namespace
 }  // namespace tflite


### PR DESCRIPTION
### Summary of Changes

Fixes #124982.

#### Description
When handling constant or persistent input tensors in TFLite's `Reshape` kernel `Prepare()`, `ResizeOutput()` resizes the output tensor according to the target shape. If the total byte size of the target shape (`output->bytes`) does not match the input tensor's size (`input->bytes`), `memcpy(output->data.data, input->data.data, input->bytes)` attempted to copy `input->bytes` into a buffer sized for `output->bytes`, causing a heap-buffer-overflow (WRITE).

#### Fix Details
- Added `TF_LITE_ENSURE_EQ(context, output->bytes, input->bytes)` after `ResizeOutput()`.
- Ensures invalid shape specifications cleanly fail preparation with `kTfLiteError` rather than triggering out-of-bounds memory writes.