### PR TITLE
reject negative indices in TensorListScatterIntoExistingList

### DIFF
--- a/tensorflow/core/kernels/list_kernels.h
+++ b/tensorflow/core/kernels/list_kernels.h
@@ -889,17 +889,18 @@ class TensorListScatterIntoExistingList : public OpKernel {
             "Expected len(indices) == tensor.shape[0], but saw: ",
             indices.NumElements(), " vs. ", input_tensor.shape().dim_size(0))));
 
-    // Resize the list if needed to accommodate all indices.
-    TensorList* output_list = nullptr;
-    OP_REQUIRES_OK(c, ForwardInputOrCreateNewList(c, 0, 0, *l, &output_list));
     const auto indices_vec = indices.vec<int32_t>();
-    for (int index = 0; index < indices.NumElements(); ++index) {
+    for (int64_t index = 0; index < indices.NumElements(); ++index) {
       OP_REQUIRES(
           c, indices_vec(index) >= 0,
           absl::InvalidArgumentError(
               "Indices in TensorListScatterIntoExistingList must all be "
               "non-negative."));
     }
+
+    // Resize the list if needed to accommodate all indices.
+    TensorList* output_list = nullptr;
+    OP_REQUIRES_OK(c, ForwardInputOrCreateNewList(c, 0, 0, *l, &output_list));
     int32_t max_index =
         (indices.NumElements() == 0)
             ? -1

--- a/tensorflow/core/kernels/list_kernels.h
+++ b/tensorflow/core/kernels/list_kernels.h
@@ -893,6 +893,13 @@ class TensorListScatterIntoExistingList : public OpKernel {
     TensorList* output_list = nullptr;
     OP_REQUIRES_OK(c, ForwardInputOrCreateNewList(c, 0, 0, *l, &output_list));
     const auto indices_vec = indices.vec<int32_t>();
+    for (int index = 0; index < indices.NumElements(); ++index) {
+      OP_REQUIRES(
+          c, indices_vec(index) >= 0,
+          absl::InvalidArgumentError(
+              "Indices in TensorListScatterIntoExistingList must all be "
+              "non-negative."));
+    }
     int32_t max_index =
         (indices.NumElements() == 0)
             ? -1

--- a/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
@@ -593,6 +593,17 @@ class ListOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         list_ops.tensor_list_stack(l, element_dtype=dtypes.float32),
         [1., 2., 3.])
 
+  def testScatterIntoExistingListWithNegativeIndicesFails(self):
+    l = list_ops.tensor_list_reserve(
+        element_dtype=dtypes.float32, element_shape=[], num_elements=5)
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError,
+        "Indices in TensorListScatterIntoExistingList must all be "
+        "non-negative."):
+      l = list_ops.tensor_list_scatter(
+          tensor=[1.], indices=[-1], element_shape=[], input_handle=l)
+      self.evaluate(l)
+
   def testScatterGrad(self):
     with backprop.GradientTape() as tape:
       c0 = constant_op.constant([1.0, 2.0])


### PR DESCRIPTION
TensorListScatterIntoExistingList checks that the indices tensor is a vector and that its length matches the input tensor's first dimension, then sizes the list from max_index only, so a negative index is never rejected. The shared Scatter() helper, which is documented to assume valid indices, then runs std::swap(list->tensors()[i], aligned) with that index and writes a Tensor before the std::vector buffer; with an existing 5-element list and indices=[-1] no resize happens and it indexes tensors()[-1] directly. Add the non-negative check that TensorListScatter and TensorListSetItem already carry, since this op reaches the same helper from tf.raw_ops.TensorListScatterIntoExistingList.