### PR TITLE
Fix tf.reshape() to reject multiple -1 dims consistently

### DIFF
--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
@@ -1483,14 +1483,9 @@ TEST_F(ArithmeticOptimizerTest,
 
   GrapplerItem item;
   item.fetch = {"outputs"};
-  TF_CHECK_OK(s.ToGraphDef(&item.graph));
-
-  GraphDef output;
-  ArithmeticOptimizer optimizer;
-  EnableOnlyRemoveRedundantReshape(&optimizer);
-  OptimizeTwiceAndPrune(&optimizer, &item, &output);
-
-  EXPECT_EQ(CountOpNodes(output, "Reshape"), 1);
+  Status s2 = s.ToGraphDef(&item.graph);
+  EXPECT_FALSE(s2.ok());
+  EXPECT_EQ(s2.code(), absl::StatusCode::kInvalidArgument);
 }
 
 TEST_F(ArithmeticOptimizerTest, RemoveRedundantReshapeCombineReshapes) {

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -199,29 +199,49 @@ absl::Status SetOutputShapeForReshape(InferenceContext* c) {
     c->set_output(0, out);
     return absl::OkStatus();
   }
-  if (c->RankKnown(in)) {
-    // We don't know the number of output elements, but we can try to infer
-    // the missing dimension.
-    bool too_many_unknown = false;
-    int32_t out_unknown_idx = -1;
 
-    DimensionHandle known_out_elems = c->NumElements(out);
-    if (!c->ValueKnown(known_out_elems)) {
-      known_out_elems = c->MakeDim(1);
-      for (int32_t i = 0; i < c->Rank(out); ++i) {
-        DimensionHandle dim = c->Dim(out, i);
-        if (!c->ValueKnown(dim)) {
-          if (out_unknown_idx >= 0) {
-            too_many_unknown = true;
-            break;
-          }
-          out_unknown_idx = i;
-        } else {
-          TF_RETURN_IF_ERROR(
-              c->Multiply(known_out_elems, dim, &known_out_elems));
-        }
+  const Tensor* new_shape_tensor = c->input_tensor(1);
+  int32_t literal_neg_one_count = 0;
+  if (new_shape_tensor != nullptr) {
+    const int64_t num_elements = new_shape_tensor->NumElements();
+    if (new_shape_tensor->dtype() == DT_INT32) {
+      auto vec = new_shape_tensor->vec<int32_t>();
+      for (int64_t i = 0; i < num_elements; ++i) {
+        if (vec(i) == -1) ++literal_neg_one_count;
+      }
+    } else if (new_shape_tensor->dtype() == DT_INT64) {
+      auto vec = new_shape_tensor->vec<int64_t>();
+      for (int64_t i = 0; i < num_elements; ++i) {
+        if (vec(i) == -1) ++literal_neg_one_count;
       }
     }
+  }
+
+  int32_t out_unknown_idx = -1;
+  bool out_too_many_unknown = false;
+  DimensionHandle known_out_elems = c->NumElements(out);
+  if (!c->ValueKnown(known_out_elems)) {
+    known_out_elems = c->MakeDim(1);
+    for (int32_t i = 0; i < c->Rank(out); ++i) {
+      DimensionHandle dim = c->Dim(out, i);
+      if (!c->ValueKnown(dim)) {
+        if (out_unknown_idx >= 0) {
+          if (literal_neg_one_count >= 2) {
+            return absl::InvalidArgumentError(
+                absl::StrCat("Only one input size may be -1, not both ",
+                             out_unknown_idx, " and ", i));
+          }
+          out_too_many_unknown = true;
+        }
+        out_unknown_idx = i;
+      } else {
+        TF_RETURN_IF_ERROR(c->Multiply(known_out_elems, dim, &known_out_elems));
+      }
+    }
+  }
+
+  if (c->RankKnown(in)) {
+    bool too_many_unknown = false;
     int32_t in_unknown_idx = -1;
     DimensionHandle known_in_elems = c->NumElements(in);
     if (!c->ValueKnown(known_in_elems)) {
@@ -250,7 +270,7 @@ absl::Status SetOutputShapeForReshape(InferenceContext* c) {
               c->DebugString(known_out_elems), " elements)"));
         }
       } else if (in_unknown_idx < 0 && out_unknown_idx >= 0 &&
-                 c->Value(known_out_elems) > 0) {
+                 !out_too_many_unknown && c->Value(known_out_elems) > 0) {
         // Input fully known, infer the one missing output dim
         DimensionHandle inferred_dim;
         TF_RETURN_IF_ERROR(c->Divide(known_in_elems, c->Value(known_out_elems),
@@ -269,7 +289,8 @@ absl::Status SetOutputShapeForReshape(InferenceContext* c) {
         DimensionHandle unknown_in_dim = c->Dim(in, in_unknown_idx);
         TF_RETURN_IF_ERROR(
             c->Merge(unknown_in_dim, inferred_dim, &unknown_in_dim));
-      } else if (in_unknown_idx >= 0 && out_unknown_idx >= 0) {
+      } else if (in_unknown_idx >= 0 && out_unknown_idx >= 0 &&
+                 !out_too_many_unknown) {
         // Exactly one unknown dimension in both input and output. These 2 are
         // equal iff the known elements are equal.
         if (c->Value(known_in_elems) == c->Value(known_out_elems)) {

--- a/tensorflow/core/ops/array_ops_test.cc
+++ b/tensorflow/core/ops/array_ops_test.cc
@@ -989,10 +989,32 @@ TEST(ArrayOpsTest, Reshape_ShapeFn) {
   // dimensions.
   INFER_ERROR("Dimension size must be evenly divisible by 2 but is 7", op,
               "[7];[2]");
-  // Multiple missing dimensions cannot be inferred.
   new_shape = test::AsTensor<int32_t>({-1, -1, 2});
-  INFER_OK(op, "[8];[3]", "[?,?,2]");
-  INFER_OK(op, "?;[3]", "[?,?,2]");
+  INFER_ERROR("Only one input size may be -1, not both 0 and 1", op, "[8];[3]");
+  INFER_ERROR("Only one input size may be -1, not both 0 and 1", op, "?;[3]");
+
+  new_shape = test::AsTensor<int32_t>({2, -1, -1});
+  INFER_ERROR("Only one input size may be -1, not both 1 and 2", op,
+              "[12];[3]");
+
+  new_shape = test::AsTensor<int32_t>({-1, -1});
+  INFER_ERROR("Only one input size may be -1, not both 0 and 1", op,
+              "[4,12];[2]");
+
+  new_shape = test::AsTensor<int32_t>({4, 3, -1});
+  INFER_OK(op, "[48];[3]", "[4,3,4]");
+
+  new_shape = test::AsTensor<int32_t>({-1, 4, -1});
+  INFER_ERROR("Only one input size may be -1, not both 0 and 2", op,
+              "[48];[3]");
+
+  new_shape = test::AsTensor<int32_t>({-1, 2, 3});
+  INFER_OK(op, "?;[3]", "[?,2,3]");
+
+  op.input_tensors[1] = nullptr;
+  INFER_OK(op, "[8];[3]", "[?,?,?]");
+  INFER_OK(op, "[?];[3]", "[?,?,?]");
+  op.input_tensors[1] = &new_shape;
 
   // Symbolic shape propagation
   new_shape = test::AsTensor<int32_t>({-1, 2, 3});


### PR DESCRIPTION
Fixes #124877

tf.reshape() only allows one component of shape to be -1 (per its
docstring), but the multi-unknown-dim check in shape inference was
nested inside a rank-known branch for the input tensor, so it was
skipped whenever the input's rank wasn't statically known at trace
time. Eager mode and jit_compile=True both correctly reject reshapes
with two -1 dims, but XLA autoclustering hit this skipped path and
silently returned a result instead of raising.

The check for multiple unknown dims in the target shape now runs
unconditionally in SetOutputShapeForReshape, before the input-rank
branch, so all three paths raise the same
"Only one input size may be -1, not both X and Y" error.

Added regression tests in array_ops_test.cc covering: unknown input
rank with two -1s, two -1s at non-adjacent positions, and the exact
shapes from #124877.