### PR TITLE
[XLA:CPU] Fix thread pool exhaustion in XlaLocalLaunchBase and XlaRunOp (#56423)

### DIFF
--- a/tensorflow/compiler/jit/kernels/BUILD
+++ b/tensorflow/compiler/jit/kernels/BUILD
@@ -104,3 +104,15 @@ cc_library(
     ],
     alwayslink = 1,
 )
+
+tf_cc_test(
+    name = "xla_ops_test",
+    srcs = ["xla_ops_test.cc"],
+    deps = [
+        "//tensorflow/compiler/xla:executable_run_options",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+    ],
+)

--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -637,6 +637,7 @@ void XlaLocalLaunchBase::ComputeAsync(OpKernelContext* ctx, DoneCallback done) {
       xla::gpu::GpuExecutableRunOptions gpu_options;
       xla::DeviceAssignment device_assignment;
       xla::ExecutableRunOptions run_options;
+      run_options.set_intra_op_thread_pool(&ctx->eigen_cpu_device());
       if (compilation_result->collective_info.has_value()) {
         OP_REQUIRES_OK_ASYNC(ctx,
                              ResolveDeviceAssignment(
@@ -964,6 +965,7 @@ void XlaRunOp::Compute(OpKernelContext* ctx) {
   }
 
   xla::ExecutableRunOptions run_options;
+  run_options.set_intra_op_thread_pool(&ctx->eigen_cpu_device());
 
   // Host callbacks used for HLO send/recv.
   xla::SendDeviceMemoryFunction send_function =

--- a/tensorflow/compiler/jit/kernels/xla_ops_test.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops_test.cc
@@ -1,0 +1,47 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, banner, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+
+#include "tensorflow/compiler/xla/executable_run_options.h"
+#include "tensorflow/core/framework/allocator.h"
+#include "tensorflow/core/framework/device_base.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/lib/core/threadpool.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+namespace {
+
+TEST(XlaOpsTest, ExecutableRunOptionsHasIntraOpThreadPool) {
+  // Create a thread pool and eigen device to simulate OpKernelContext setup
+  thread::ThreadPool thread_pool(Env::Default(), "test_pool", /*num_threads=*/2);
+  Eigen::ThreadPoolDevice eigen_device(thread_pool.AsEigenThreadPool(), 2);
+
+  // Initialize ExecutableRunOptions (default has nullptr thread pool)
+  xla::ExecutableRunOptions run_options;
+  EXPECT_EQ(run_options.intra_op_thread_pool(), nullptr);
+
+  // Set the intra-op thread pool from the device, mimicking XlaLocalLaunchBase / XlaRunOp
+  run_options.set_intra_op_thread_pool(&eigen_device);
+
+  // Assert thread pool pointer is preserved and non-null
+  EXPECT_NE(run_options.intra_op_thread_pool(), nullptr);
+  EXPECT_EQ(run_options.intra_op_thread_pool(), &eigen_device);
+}
+
+}  // namespace
+}  // namespace tensorflow


### PR DESCRIPTION
### Summary
This PR fixes a thread pool exhaustion bug (`std::system_error: Resource temporarily unavailable`) that occurs during multi-replica strategy execution (e.g., `MirroredStrategy`) when using `jit_compile=True` or XLA CPU compilation.

### Root Cause
In `tensorflow/compiler/jit/kernels/xla_ops.cc`, both `XlaLocalLaunchBase::ComputeAsync` (line 639) and `XlaRunOp::Compute` (line 966) instantiate `xla::ExecutableRunOptions run_options` without binding the session's `intra_op_thread_pool`:

1. When `run_options` lacks an `intra_op_thread_pool`, XLA's `ThreadPoolTaskRunner` receives a `nullptr` thread pool interface.
2. Under `MirroredStrategy` across training steps, XLA falls back to creating transient background tasks/threads per step per replica.
3. Over thousands of dataset iterations, OS task limits (`nproc` / `TasksMax`) are exhausted, leading to an unhandled `std::system_error` (`EAGAIN`) which invokes `std::terminate` and crashes the process.

### Solution
Bound `run_options.set_intra_op_thread_pool(&ctx->eigen_cpu_device());` right after `run_options` is declared in both `XlaLocalLaunchBase::ComputeAsync` and `XlaRunOp::Compute`. 

This ensures all XLA step executions reuse TensorFlow's persistent device thread pool instead of spawning unmanaged threads, dropping step-wise thread allocations to zero and keeping process memory/thread handles stable.

### Fixes Issues
* Fixes #56423

