### PR TITLE
Resolve take_along_axis axis-swap branch at trace time

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1660,7 +1660,13 @@ def take_along_axis(arr, indices, axis):  # pylint: disable=missing-docstring
   if axis is None:
     return take_along_axis(arr.ravel(), indices, 0)
 
-  rank = array_ops.rank(arr)
+  # Prefer the static rank so that `axis` and the branch predicate below stay
+  # Python values. With a tensor predicate the conditional further down is
+  # emitted as a real op whose two branches have different shapes, which XLA
+  # rejects.
+  rank = arr.shape.rank
+  if rank is None:
+    rank = array_ops.rank(arr)
   axis = axis + rank if axis < 0 else axis
 
   # Broadcast shapes to match, ensure that the axis of interest is not
@@ -1691,7 +1697,11 @@ def take_along_axis(arr, indices, axis):  # pylint: disable=missing-docstring
 
   swapaxes_ = lambda t: swapaxes(t, axis, -1)
 
-  dont_move_axis_to_end = math_ops.equal(axis, np_utils.subtract(rank, 1))
+  if isinstance(rank, int):
+    # Resolved at trace time, so only the taken branch is built.
+    dont_move_axis_to_end = axis == rank - 1
+  else:
+    dont_move_axis_to_end = math_ops.equal(axis, np_utils.subtract(rank, 1))
   arr = np_utils.cond(
       dont_move_axis_to_end, lambda: arr, lambda: swapaxes_(arr)
   )

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -1171,6 +1171,40 @@ class ArrayMethodsTest(test.TestCase):
     out = np_array_ops.take_along_axis(x, ind, axis=1)
     self.assertAllEqual(out, out_expected)
 
+  def testTakeAlongAxisJitCompile(self):
+    # Regression test for GitHub issue 62391: the axis-swapping branch was
+    # emitted as a real conditional whose branches have different shapes, so
+    # the result shape XLA computed disagreed with the shape set on the
+    # result and a following op saw the wrong dimension.
+    x = constant_op.constant(
+        np.random.default_rng(1).standard_normal((5, 3, 2)), dtypes.float32)
+    ind = constant_op.constant([[[-1]]], dtype=dtypes.int32)
+
+    def f(x, ind):
+      taken = np_array_ops.take_along_axis(x, ind, axis=-2)
+      return array_ops.squeeze(taken, axis=-2)
+
+    expected = f(x, ind)
+    self.assertAllEqual((5, 2), expected.shape)
+    actual = def_function.function(f, jit_compile=True)(x, ind)
+    self.assertAllEqual((5, 2), actual.shape)
+    self.assertAllClose(expected, actual)
+
+  def testTakeAlongAxisUnknownRank(self):
+    # The tensor predicate is still used when the rank is not known
+    # statically.
+    @def_function.function(input_signature=[
+        tensor_spec.TensorSpec(None, dtypes.float32),
+        tensor_spec.TensorSpec(None, dtypes.int32),
+    ])
+    def f(x, ind):
+      return np_array_ops.take_along_axis(x, ind, axis=1)
+
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal((4, 6)).astype(np.float32)
+    ind = rng.integers(0, 6, (4, 3)).astype(np.int32)
+    self.assertAllClose(np.take_along_axis(x, ind, axis=1), f(x, ind))
+
   def testWhere(self):
     self.assertAllEqual([[1.0, 1.0], [1.0, 1.0]],
                         np_array_ops.where([True], [1.0, 1.0],


### PR DESCRIPTION
## Summary

Fixes #62391.

`tf.experimental.numpy.take_along_axis` fails under `jit_compile=True` when a following op depends on its shape. The issue's repro still reproduces on 2.21.0 with the originally reported error:

```
InvalidArgumentError: Tried to explicitly squeeze dimension 1 but dimension was not 1: 2
```

## Root cause

`take_along_axis` computes `rank = array_ops.rank(arr)`, a tensor, so the predicate deciding whether the gather axis must be moved to the end

```python
dont_move_axis_to_end = math_ops.equal(axis, np_utils.subtract(rank, 1))
```

is also a tensor. `np_utils.cond` only selects a branch at trace time when `get_static_value` resolves the predicate; here it does not, so a real conditional is emitted. Inspecting the traced graph for the repro shows three `StatelessIf` ops.

The two branches have different shapes: the gathered result before the axis is swapped back, `(5, 2, 1)`, and after, `(5, 1, 2)`. The function reconciles this with `result.set_shape(possible_result_shape)`, which is an unchecked assertion. The graph shows the conditional producing `(None, None, None)` followed by an `Identity` claiming `(5, 1, 2)`.

In graph mode only one branch executes, so the assertion holds. XLA compiles both branches and takes the conditional's shape from the branch that disagrees with the assertion, so the downstream `Squeeze` validates against dimension 1 of `(5, 2, 1)`, which is 2. That is exactly the reported error.

## Fix

Use the static rank when it is known, so `axis` and the predicate are Python values and `np_utils.cond` builds only the taken branch. The tensor predicate is kept as a fallback for dynamic rank. For statically shaped inputs the conditional disappears entirely: `StatelessIf` drops from 3 to 0 in the traced graph.

## Verification

Run locally against the 2.21.0 wheel with this change applied:

- The issue's repro passes under `jit_compile=True`, with values matching eager.
- 9 combinations of input shape, index shape, and axis, including negative axes and negative indices, match `numpy.take_along_axis` in both eager and jit.
- The dynamic-shape path still works through the tensor-predicate fallback.
- Full `np_array_ops_test.py` passes: 123 tests, no failures.

Two regression tests are added: one covering the jit path from the issue, and one pinning the unknown-rank fallback so the static path cannot be assumed unconditionally.

Credit to @jackd for the report and the minimal repro.