### PR TITLE
Fix SELU gradient precision for negative inputs

### DIFF
--- a/tensorflow/python/eager/pywrap_gradient_exclusions.cc
+++ b/tensorflow/python/eager/pywrap_gradient_exclusions.cc
@@ -50,7 +50,7 @@ auto OpGradientInfoInit(const T &a) {
 
 absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
     const tensorflow::string &op_name) {
-  static std::array<OpIndexInfo, 366> a = {{
+  static std::array<OpIndexInfo, 365> a = {{
       {"Acosh"},
       {"AllToAll", 1, {0}},
       {"ApproximateEqual"},
@@ -292,7 +292,6 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
       {"SdcaFprint"},
       {"SegmentSum", 1, {0}},
       {"Select", 1, {2}},
-      {"Selu"},
       {"SerializeTensor"},
       {"SetSize"},
       {"Shape"},
@@ -429,7 +428,7 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
 
 absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedOutputIndices(
     const tensorflow::string &op_name) {
-  static std::array<OpIndexInfo, 489> a = {{
+  static std::array<OpIndexInfo, 490> a = {{
       {"Abs"},
       {"AccumulateNV2"},
       {"Acos"},
@@ -760,6 +759,7 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedOutputIndices(
       {"SegmentMean"},
       {"SegmentSum"},
       {"Select"},
+      {"Selu"},
       {"SeluGrad"},
       {"SerializeTensor"},
       {"SetSize"},

--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -2208,6 +2208,7 @@ py_library(
         ":array_ops_stack",
         ":math_ops",
         ":nn_ops_gen",
+        "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:ops",
     ],

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -18,6 +18,7 @@ import functools
 import itertools
 import operator
 
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
@@ -466,7 +467,19 @@ def _EluGrad(op: ops.Operation, grad):
 
 @ops.RegisterGradient("Selu")
 def _SeluGrad(op: ops.Operation, grad):
-  return gen_nn_ops.selu_grad(grad, op.outputs[0])
+  x = op.inputs[0]
+  scale = constant_op.constant(
+      1.0507009873554804934193349852946, dtype=x.dtype)
+  scale_alpha = constant_op.constant(
+      1.7580993408473768599402175208123, dtype=x.dtype)
+  # Reconstructing the negative-branch derivative from the SELU output loses
+  # precision when the output rounds to -scale_alpha. Compute it from x.
+  derivative = array_ops.where_v2(
+      x < 0.0,
+      scale_alpha * math_ops.exp(math_ops.minimum(x, 0.0)),
+      scale)
+  derivative = array_ops.where_v2(math_ops.is_nan(x), x, derivative)
+  return grad * derivative
 
 
 @ops.RegisterGradient("Softplus")

--- a/tensorflow/python/ops/nn_grad_test.py
+++ b/tensorflow/python/ops/nn_grad_test.py
@@ -237,6 +237,26 @@ class EluGradOpTest(test.TestCase):
 
 class SeluGradOpTest(test.TestCase):
 
+  @test_util.run_in_graph_and_eager_modes
+  def testSeluGradPreservesSmallNegativeGradients(self):
+    scale_alpha = 1.7580993408473768599402175208123
+    test_cases = (
+        (dtypes.float32, -20.0, 1e-6),
+        (dtypes.float64, -700.0, 1e-14),
+    )
+    for dtype, value, rtol in test_cases:
+      with self.subTest(dtype=dtype.name):
+        inputs = constant_op.constant(value, dtype=dtype)
+        with backprop.GradientTape() as tape:
+          tape.watch(inputs)
+          selu = gen_nn_ops.selu(inputs)
+
+        selu_grad = tape.gradient(selu, inputs)
+        np_dtype = dtype.as_numpy_dtype
+        expected = np_dtype(scale_alpha) * np.exp(np_dtype(value))
+        self.assertAllClose(
+            expected, self.evaluate(selu_grad), rtol=rtol, atol=0)
+
   @test_util.run_deprecated_v1
   def testSeluGradGradWRTgrad_ys(self):
     inputs = constant_op.constant(

--- a/tensorflow/python/ops/nn_grad_test.py
+++ b/tensorflow/python/ops/nn_grad_test.py
@@ -257,6 +257,33 @@ class SeluGradOpTest(test.TestCase):
         self.assertAllClose(
             expected, self.evaluate(selu_grad), rtol=rtol, atol=0)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testSeluGradEdgeCases(self):
+    scale = 1.0507009873554804934193349852946
+    scale_alpha = 1.7580993408473768599402175208123
+    for dtype in (dtypes.float32, dtypes.float64):
+      with self.subTest(dtype=dtype.name):
+        np_dtype = dtype.as_numpy_dtype
+        values = np.array(
+            [-np.inf, -2.0, -0.0, 0.0, 2.0, np.inf, np.nan],
+            dtype=np_dtype)
+        inputs = constant_op.constant(values, dtype=dtype)
+        with backprop.GradientTape() as tape:
+          tape.watch(inputs)
+          selu = gen_nn_ops.selu(inputs)
+
+        selu_grad = self.evaluate(tape.gradient(selu, inputs))
+        expected = np.array([
+            0.0,
+            np_dtype(scale_alpha) * np.exp(np_dtype(-2.0)),
+            scale,
+            scale,
+            scale,
+            scale,
+            np.nan,
+        ], dtype=np_dtype)
+        self.assertAllClose(expected, selu_grad)
+
   @test_util.run_deprecated_v1
   def testSeluGradGradWRTgrad_ys(self):
     inputs = constant_op.constant(


### PR DESCRIPTION
Fixes #124834.

## What changed

- Compute the SELU derivative from the original input instead of reconstructing it from the rounded activation output.
- Preserve the existing positive, signed-zero, infinity, and NaN behavior while using the stable `scale_alpha * exp(x)` negative branch.
- Update generated GradientTape exclusion metadata so eager execution retains the input and releases the now-unused output.
- Add float32 and float64 regression coverage in both graph and eager modes.

## Validation

- Reproduced the bug on TensorFlow 2.20.0: both float32 at `-20` and float64 at `-700` return a zero gradient.
- Verified the patched registered gradient returns `3.6237128853144895e-09` and `1.7334290832552396e-304`, respectively, in graph mode and direct eager execution.
- Verified vector inputs, infinities, signed zero, positive inputs, and NaN semantics against the analytic SELU derivative.
- Verified TensorFlow's gradient metadata analysis reports live inputs `{0}` and no live outputs for `_SeluGrad`.
- `python3 -m py_compile tensorflow/python/ops/nn_grad.py tensorflow/python/ops/nn_grad_test.py`
- TensorFlow PyLint configuration: 10.00/10 (excluding two unrelated existing inference false positives and an obsolete-option warning in the repository config under the current PyLint release).
- `git diff --check`
