### PR TITLE
Fix SiLU gradient underflow for large negative inputs

### DIFF
--- a/tensorflow/python/ops/nn_grad_test.py
+++ b/tensorflow/python/ops/nn_grad_test.py
@@ -266,6 +266,40 @@ class SwishGradOpTest(test.TestCase):
       error = gradient_checker_v2.max_error(theoretical, numerical)
       self.assertLess(error, 1e-4)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testSwishPreservesSmallValuesAndGradients(self):
+    test_cases = (
+        (dtypes.float32, -90.0, 1e-5),
+        (dtypes.float64, -709.0, 1e-12),
+    )
+    for dtype, value, rtol in test_cases:
+      with self.subTest(dtype=dtype.name):
+        features = constant_op.constant(value, dtype=dtype)
+        beta = constant_op.constant(1.0, dtype=dtype)
+        with backprop.GradientTape() as tape:
+          tape.watch([features, beta])
+          swish = nn_impl.swish(features, beta)
+
+        features_grad, beta_grad = tape.gradient(
+            swish, [features, beta])
+        q = np.exp(np.float64(value))
+        sigmoid = q / (1.0 + q)
+        expected_value = value * sigmoid
+        expected_features_grad = sigmoid * (1.0 + value * (1.0 - sigmoid))
+        expected_beta_grad = value**2 * sigmoid * (1.0 - sigmoid)
+        self.assertAllClose(
+            expected_value, self.evaluate(swish), rtol=rtol, atol=0)
+        self.assertAllClose(
+            expected_features_grad,
+            self.evaluate(features_grad),
+            rtol=rtol,
+            atol=0)
+        self.assertAllClose(
+            expected_beta_grad,
+            self.evaluate(beta_grad),
+            rtol=rtol,
+            atol=0)
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -459,6 +459,23 @@ def swish(features, beta=1.0):
   beta = ops.convert_to_tensor(beta, name="beta")
   beta = math_ops.cast(beta, features.dtype)
 
+  def multiply_with_sigmoid(multiplier, logits, sigmoid_logits):
+    """Computes `multiplier * sigmoid(logits)` without early underflow."""
+    # sigmoid(logits) may underflow even when the scaled result is representable.
+    # In that range sigmoid(logits) and exp(logits) differ by less than the
+    # dtype's precision, so evaluate the product in the log domain.
+    sigmoid_underflow = math_ops.logical_and(
+        math_ops.equal(sigmoid_logits, 0.0), math_ops.is_finite(logits))
+    safe_multiplier = array_ops.where_v2(
+        sigmoid_underflow, multiplier, array_ops.ones_like(multiplier))
+    safe_logits = array_ops.where_v2(
+        sigmoid_underflow, logits, array_ops.zeros_like(logits))
+    underflow_result = math_ops.sign(safe_multiplier) * math_ops.exp(
+        safe_logits + math_ops.log(math_ops.abs(safe_multiplier)))
+    return array_ops.where_v2(
+        sigmoid_underflow, underflow_result,
+        multiplier * sigmoid_logits)
+
   @custom_gradient.custom_gradient
   def swish_impl(features, beta):
 
@@ -471,17 +488,22 @@ def swish(features, beta=1.0):
       # de-duped with the forward pass) and we can free the sigmoid(features)
       # expression immediately after use during the forward pass.
       with ops.control_dependencies([dy]):
-        sigmoid_features = math_ops.sigmoid(beta * features)
+        logits = beta * features
+        sigmoid_features = math_ops.sigmoid(logits)
 
-      activation_grad = (
-          sigmoid_features * (1.0 + (beta * features) *
-                              (1.0 - sigmoid_features)))
+      activation_multiplier = 1.0 + logits * (1.0 - sigmoid_features)
+      activation_grad = multiply_with_sigmoid(
+          activation_multiplier, logits, sigmoid_features)
       beta_grad = math_ops.reduce_sum(
-          dy * math_ops.square(features) * sigmoid_features *
-          (1.0 - sigmoid_features))
+          dy * multiply_with_sigmoid(
+              math_ops.square(features) * (1.0 - sigmoid_features), logits,
+              sigmoid_features))
       return (dy * activation_grad, beta_grad)
 
-    return features * math_ops.sigmoid(beta * features), grad
+    logits = beta * features
+    sigmoid_features = math_ops.sigmoid(logits)
+    return multiply_with_sigmoid(
+        features, logits, sigmoid_features), grad
 
   return swish_impl(features, beta)
 

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -467,9 +467,9 @@ def swish(features, beta=1.0):
     sigmoid_underflow = math_ops.logical_and(
         math_ops.equal(sigmoid_logits, 0.0), math_ops.is_finite(logits))
     safe_multiplier = array_ops.where_v2(
-        sigmoid_underflow, multiplier, array_ops.ones_like(multiplier))
+        sigmoid_underflow, multiplier, math_ops.cast(1.0, multiplier.dtype))
     safe_logits = array_ops.where_v2(
-        sigmoid_underflow, logits, array_ops.zeros_like(logits))
+        sigmoid_underflow, logits, math_ops.cast(0.0, logits.dtype))
     underflow_result = math_ops.sign(safe_multiplier) * math_ops.exp(
         safe_logits + math_ops.log(math_ops.abs(safe_multiplier)))
     return array_ops.where_v2(


### PR DESCRIPTION
Fixes #124835.

## What changed

- Keep the existing fast SiLU path when `sigmoid(beta * x)` is representable.
- When the sigmoid intermediate underflows but its scaled product is still representable, evaluate that product in the log domain.
- Apply the guarded fallback to the forward value, feature gradient, and beta gradient.
- Add float32 and float64 regression coverage in graph and eager modes.

## Validation

- Reproduced the reported TensorFlow 2.20.0 result at float64 `x = -709`: the feature gradient was `-0.0`.
- Verified the patched implementation returns a finite feature gradient of `-8.614807714413413e-306` (analytic reference: `-8.614807714413836e-306`).
- Verified float32 `x = -90`, the forward result, beta gradient, vector inputs, custom beta values, infinities, signed zero, and NaN behavior.
- Passed the new regression test in graph and eager modes.
- Passed the existing `SwishGradOpTest.testSwishGrad` and full `SwishTest` suite.
- `python3 -m py_compile tensorflow/python/ops/nn_impl.py tensorflow/python/ops/nn_grad_test.py`
- TensorFlow PyLint configuration: 10.00/10.
- `git diff --check`
