### PR TITLE
Reject unrepresentable TensorList scatter index

### DIFF
--- a/tensorflow/core/kernels/list_kernels.h
+++ b/tensorflow/core/kernels/list_kernels.h
@@ -15,6 +15,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_LIST_KERNELS_H_
 #define TENSORFLOW_CORE_KERNELS_LIST_KERNELS_H_
 
+#include <limits>
+
 #define EIGEN_USE_THREADS
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
@@ -908,6 +910,14 @@ class TensorListScatterIntoExistingList : public OpKernel {
               "non-negative; got ",
               *minmax.first)));
       max_index = *minmax.second;
+      // TensorListLength returns int32, so max_index + 1 must be representable
+      // as int32 before the list is resized.
+      OP_REQUIRES(
+          c, max_index < std::numeric_limits<int32_t>::max(),
+          absl::InvalidArgumentError(absl::StrCat(
+              "TensorListScatterIntoExistingList: index ", max_index,
+              " would produce a list length that is not representable as "
+              "int32")));
       // Also honor the list's declared capacity. TensorListPushBack already
       // enforces `size() < max_num_elements`; mirror it here so a scatter
       // cannot silently grow the list past its cap. This also bounds the

--- a/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
@@ -590,6 +590,25 @@ class ListOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
           )
       )
 
+  def testScatterIntoExistingListRejectsUnrepresentableLength(self):
+    l = list_ops.empty_tensor_list(
+        element_dtype=dtypes.float32, element_shape=[]
+    )
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError,
+        "list length that is not representable as int32",
+    ):
+      self.evaluate(
+          list_ops.tensor_list_scatter(
+              tensor=[1.0],
+              indices=constant_op.constant(
+                  [np.iinfo(np.int32).max], dtype=dtypes.int32
+              ),
+              element_shape=[],
+              input_handle=l,
+          )
+      )
+
   def testScatterFailsWithInvalidNumElements(self):
     c0 = constant_op.constant([1.0, 2.0])
     with self.assertRaisesRegex(


### PR DESCRIPTION
`master` now includes the negative-index validation from #121412 and the `max_num_elements` / overflow-safe resize hardening from #125802. This rebases the PR on those changes and retains only the remaining boundary case.

`TensorListLength` returns `int32`, so an index of `INT32_MAX` cannot be valid: accommodating it would require `INT32_MAX + 1` elements. The kernel now rejects that index before resizing, with a focused regression test covering graph and eager execution through the test class configuration.

Testing:

```text
bazel test //tensorflow/python/kernel_tests/data_structures:list_ops_test
```
