### PR TITLE
Use safe shape validation for TensorScatter ops

### DIFF
--- a/tensorflow/core/kernels/scatter_nd_op.cc
+++ b/tensorflow/core/kernels/scatter_nd_op.cc
@@ -222,41 +222,8 @@ class TensorScatterOp : public ScatterOpBase<Device> {
                 absl::InvalidArgumentError(
                     "Indices and updates specified for empty output shape"));
 
-    const int64_t outer_dims = indices.shape().dims() - 1;
-
-    OP_REQUIRES(c, updates.shape().dims() >= outer_dims,
-                absl::InvalidArgumentError(absl::StrCat(
-                    "Updates shape must have rank at least the number of "
-                    "outer dimensions of indices (",
-                    outer_dims,
-                    "). Found: updates shape=", updates.shape().DebugString(),
-                    ", indices shape=", indices.shape().DebugString())));
-
-    for (int i = 0; i < outer_dims; ++i) {
-      OP_REQUIRES(c, indices.shape().dim_size(i) == updates.shape().dim_size(i),
-                  absl::InvalidArgumentError(absl::StrCat(
-                      "Outer dimensions of indices and update must match. "
-                      "Indices shape: ",
-                      indices.shape().DebugString(),
-                      ", updates shape:", updates.shape().DebugString())));
-    }
-
-    const int64_t ix = indices.shape().dim_size(outer_dims);
-    OP_REQUIRES(
-        c, updates.shape().dims() - outer_dims == shape.dims() - ix,
-        absl::InvalidArgumentError(absl::StrCat(
-            "Inner dimensions of output shape must match "
-            "inner dimensions of updates shape. Output: ",
-            shape.DebugString(), " updates: ", updates.shape().DebugString())));
-    for (int i = 0; i + outer_dims < updates.shape().dims(); ++i) {
-      OP_REQUIRES(
-          c, updates.shape().dim_size(i + outer_dims) == shape.dim_size(ix + i),
-          absl::InvalidArgumentError(absl::StrCat(
-              "The inner ", shape.dims() - ix,
-              " dimensions of output.shape=", shape.DebugString(),
-              " must match the inner ", updates.shape().dims() - outer_dims,
-              " dimensions of updates.shape=", updates.shape().DebugString())));
-    }
+    OP_REQUIRES_OK(c, ValidateScatterNdUpdateShape(
+                          shape, indices.shape(), updates.shape()));
 
     AllocatorAttributes alloc_attr;
     MemoryType memory_type = DEVICE_MEMORY;

--- a/tensorflow/core/kernels/scatter_nd_op_test.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_test.cc
@@ -137,6 +137,21 @@ TEST_F(TensorScatterUpdateOpTest, HigherRank) {
   test::ExpectTensorEqual<float>(expected, *GetOutput(0));
 }
 
+TEST_F(TensorScatterUpdateOpTest, Error_MismatchedOuterDimensions) {
+  MakeOp(DT_FLOAT, DT_INT32);
+
+  AddInputFromArray<float>(TensorShape({5}), {0, 0, 0, 0, 0});
+  AddInputFromArray<int32_t>(TensorShape({5, 1, 1}), {0, 1, 2, 3, 4});
+  AddInputFromArray<float>(TensorShape({5}), {1, 2, 3, 4, 5});
+
+  absl::Status status = RunOpKernel();
+  EXPECT_TRUE(absl::StrContains(
+      status.ToString(),
+      "Dimensions [0,2) of indices[shape=[5,1,1]] must match dimensions "
+      "[0,2) of updates[shape=[5]]"))
+      << status;
+}
+
 TEST_F(TensorScatterUpdateOpTest, Error_IndexOutOfRange) {
   MakeOp(DT_FLOAT, DT_INT32);
 


### PR DESCRIPTION
`TensorScatter` duplicated the scatter-shape checks and accessed an `updates` dimension before confirming that `updates` had sufficient rank. A malformed input could therefore trigger a fatal `TensorShape` check instead of returning `InvalidArgument`.

This change uses the existing `ValidateScatterNdUpdateShape` helper, which orders the rank checks safely and is already used by the execution path. A focused regression test covers mismatched outer dimensions.

Fixes #104793

Testing in progress:

```
bazel test //tensorflow/core/kernels:scatter_nd_op_test
```