### PR TITLE
Validate RandomIndexShuffle round count

### DIFF
--- a/tensorflow/core/kernels/random_index_shuffle_ops.cc
+++ b/tensorflow/core/kernels/random_index_shuffle_ops.cc
@@ -36,6 +36,7 @@ namespace tensorflow {
 namespace {
 
 constexpr absl::string_view kRounds = "rounds";
+constexpr int32_t kMaxRounds = 1000;
 
 template <typename DType>
 std::array<uint32_t, 3> CastSeedFrom(const Tensor& seed_t, const int row) {
@@ -69,10 +70,10 @@ class RandomIndexShuffleOp : public OpKernel {
       : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr(kRounds, &rounds_));
     OP_REQUIRES(
-        context, rounds_ >= 4 && rounds_ % 2 == 0,
+        context, rounds_ >= 4 && rounds_ <= kMaxRounds && rounds_ % 2 == 0,
         absl::InvalidArgumentError(absl::StrCat(
-            "rounds must be an even integer greater than or equal to 4, but "
-            "got ",
+            "rounds must be an even integer between 4 and ", kMaxRounds,
+            ", but got ",
             rounds_)));
   }
 

--- a/tensorflow/core/kernels/random_index_shuffle_ops.cc
+++ b/tensorflow/core/kernels/random_index_shuffle_ops.cc
@@ -68,6 +68,12 @@ class RandomIndexShuffleOp : public OpKernel {
   explicit RandomIndexShuffleOp(OpKernelConstruction* context)
       : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr(kRounds, &rounds_));
+    OP_REQUIRES(
+        context, rounds_ >= 4 && rounds_ % 2 == 0,
+        absl::InvalidArgumentError(absl::StrFormat(
+            "rounds must be an even integer greater than or equal to 4, but "
+            "got %d",
+            rounds_)));
   }
 
   void Compute(OpKernelContext* context) override {

--- a/tensorflow/core/kernels/random_index_shuffle_ops.cc
+++ b/tensorflow/core/kernels/random_index_shuffle_ops.cc
@@ -70,9 +70,9 @@ class RandomIndexShuffleOp : public OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr(kRounds, &rounds_));
     OP_REQUIRES(
         context, rounds_ >= 4 && rounds_ % 2 == 0,
-        absl::InvalidArgumentError(absl::StrFormat(
+        absl::InvalidArgumentError(absl::StrCat(
             "rounds must be an even integer greater than or equal to 4, but "
-            "got %d",
+            "got ",
             rounds_)));
   }
 

--- a/tensorflow/core/kernels/random_index_shuffle_ops.cc
+++ b/tensorflow/core/kernels/random_index_shuffle_ops.cc
@@ -36,7 +36,6 @@ namespace tensorflow {
 namespace {
 
 constexpr absl::string_view kRounds = "rounds";
-constexpr int32_t kMaxRounds = 1000;
 
 template <typename DType>
 std::array<uint32_t, 3> CastSeedFrom(const Tensor& seed_t, const int row) {
@@ -70,11 +69,10 @@ class RandomIndexShuffleOp : public OpKernel {
       : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr(kRounds, &rounds_));
     OP_REQUIRES(
-        context, rounds_ >= 4 && rounds_ <= kMaxRounds && rounds_ % 2 == 0,
+        context, rounds_ >= 4 && rounds_ % 2 == 0,
         absl::InvalidArgumentError(absl::StrCat(
-            "rounds must be an even integer between 4 and ", kMaxRounds,
-            ", but got ",
-            rounds_)));
+            "rounds must be an even integer greater than or equal to 4, but ",
+            "got ", rounds_)));
   }
 
   void Compute(OpKernelContext* context) override {

--- a/tensorflow/core/kernels/random_index_shuffle_ops.cc
+++ b/tensorflow/core/kernels/random_index_shuffle_ops.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cstdint>
 
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "tensorflow/core/framework/bounds_check.h"

--- a/tensorflow/python/kernel_tests/random/random_index_shuffle_test.py
+++ b/tensorflow/python/kernel_tests/random/random_index_shuffle_test.py
@@ -118,11 +118,11 @@ class StatelessOpsTest(test.TestCase, parameterized.TestCase):
     ):
       self.evaluate(stateless.index_shuffle(5, seed=(1, 2), max_index=4))
 
-  @parameterized.parameters(-1, 0, 2, 3, 5)
+  @parameterized.parameters(-1, 0, 2, 3, 5, 1002)
   def test_invalid_rounds(self, rounds):
     with self.assertRaisesRegex(
         errors.InvalidArgumentError,
-        'rounds must be an even integer greater than or equal to 4',
+        'rounds must be an even integer between 4 and 1000',
     ):
       self.evaluate(
           gen_random_index_shuffle_ops.random_index_shuffle(

--- a/tensorflow/python/kernel_tests/random/random_index_shuffle_test.py
+++ b/tensorflow/python/kernel_tests/random/random_index_shuffle_test.py
@@ -118,6 +118,18 @@ class StatelessOpsTest(test.TestCase, parameterized.TestCase):
     ):
       self.evaluate(stateless.index_shuffle(5, seed=(1, 2), max_index=4))
 
+  @parameterized.parameters(-1, 0, 2, 3, 5)
+  def test_invalid_rounds(self, rounds):
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError,
+        'rounds must be an even integer greater than or equal to 4',
+    ):
+      self.evaluate(
+          gen_random_index_shuffle_ops.random_index_shuffle(
+              index=0, seed=[1, 2, 3], max_index=10, rounds=rounds
+          )
+      )
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/kernel_tests/random/random_index_shuffle_test.py
+++ b/tensorflow/python/kernel_tests/random/random_index_shuffle_test.py
@@ -118,11 +118,11 @@ class StatelessOpsTest(test.TestCase, parameterized.TestCase):
     ):
       self.evaluate(stateless.index_shuffle(5, seed=(1, 2), max_index=4))
 
-  @parameterized.parameters(-1, 0, 2, 3, 5, 1002)
+  @parameterized.parameters(-1, 0, 2, 3, 5)
   def test_invalid_rounds(self, rounds):
     with self.assertRaisesRegex(
         errors.InvalidArgumentError,
-        'rounds must be an even integer between 4 and 1000',
+        'rounds must be an even integer',
     ):
       self.evaluate(
           gen_random_index_shuffle_ops.random_index_shuffle(


### PR DESCRIPTION
The index-shuffle cipher assumes that `rounds` is even and at least 4, but the raw op previously accepted any integer. Negative values could be converted into a huge allocation size, while small or odd values violated the paired-round algorithm preconditions.

This change rejects invalid configurations during kernel construction. The parameterized regression test covers negative, zero, too-small even, and odd round counts.

Fixes #112753

Testing in progress:

```
bazel test //tensorflow/python/kernel_tests/random:random_index_shuffle_test
```