### PR TITLE
Guard TF_TensorToPyArray against tensors above NPY_MAXDIMS

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -2508,6 +2508,26 @@ class RepeatTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     self.assertAllEqual(v_tf, v_np)
     self.assertAllEqual(v_tf_fn, v_np)
 
+  def testHighRankStringTensorToNumpyDoesNotSegfault(self):
+    # Regression test for #124973. Converting a rank > NPY_MAXDIMS tensor
+    # to numpy hit the unguarded slow path in TF_TensorToPyArray and
+    # segfaulted. The reporter reached it via tf.repeat's error formatter
+    # interpolating a string tensor; here we hit the same guard directly
+    # by chaining expand_dims to build the high-rank tensor and calling
+    # .numpy() on it. String dtype forces the slow path -- numeric dtypes
+    # take the aliased fast path, which is already guarded upstream in
+    # ArrayFromMemory.
+    if not context.executing_eagerly():
+      self.skipTest("Bug is in the eager .numpy() conversion path.")
+    # Rank 100: above numpy's NPY_MAXDIMS ceiling (32 pre-2.0, 64 post-2.0)
+    # and below TF's own TensorShape cap of 254.
+    x = constant_op.constant("s")
+    for _ in range(100):
+      x = array_ops.expand_dims(x, 0)
+    with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                "NumPy arrays can have at most"):
+      x.numpy()
+
 
 class RepeatBenchmark(test_lib.Benchmark):
   """Benchmark the repeat implementation."""

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -2513,7 +2513,7 @@ class RepeatTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     # to numpy hit the unguarded slow path in TF_TensorToPyArray and
     # segfaulted. The reporter reached it via tf.repeat's error formatter
     # interpolating a string tensor; here we hit the same guard directly
-    # by chaining expand_dims to build the high-rank tensor and calling
+    # by reshaping a scalar string constant to rank 100 and calling
     # .numpy() on it. String dtype forces the slow path -- numeric dtypes
     # take the aliased fast path, which is already guarded upstream in
     # ArrayFromMemory.
@@ -2521,9 +2521,7 @@ class RepeatTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       self.skipTest("Bug is in the eager .numpy() conversion path.")
     # Rank 100: above numpy's NPY_MAXDIMS ceiling (32 pre-2.0, 64 post-2.0)
     # and below TF's own TensorShape cap of 254.
-    x = constant_op.constant("s")
-    for _ in range(100):
-      x = array_ops.expand_dims(x, 0)
+    x = array_ops.reshape(constant_op.constant("s"), [1] * 100)
     with self.assertRaisesRegex(errors.InvalidArgumentError,
                                 "NumPy arrays can have at most"):
       x.numpy()

--- a/tensorflow/python/lib/core/ndarray_tensor.cc
+++ b/tensorflow/python/lib/core/ndarray_tensor.cc
@@ -480,6 +480,17 @@ absl::Status TF_TensorToPyArray(Safe_TF_TensorPtr tensor,
   TF_RETURN_IF_ERROR(
       GetPyArrayDimensionsForTensor(tensor.get(), &dims, &nelems));
 
+  // NumPy's array-creation APIs (PyArray_Empty below and PyArray_SimpleNewFromData
+  // in the aliased fast path) segfault when dim_size exceeds NPY_MAXDIMS.
+  // The aliased path guards this in ArrayFromMemory; mirror the check here so the
+  // string/resource and copy paths reject high-rank tensors instead of crashing.
+  if (dims.size() > NPY_MAXDIMS) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Cannot convert tensor with ", dims.size(),
+        " dimensions to NumPy array. NumPy arrays can have at most ",
+        NPY_MAXDIMS, " dimensions"));
+  }
+
   // If the type is neither string nor resource we can reuse the Tensor memory.
   TF_Tensor* original = tensor.get();
   TF_Tensor* moved = TF_TensorMaybeMove(tensor.release());


### PR DESCRIPTION
`TF_TensorToPyArray` calls `PyArray_Empty` (slow/copy path) without checking that `dims.size() <= NPY_MAXDIMS`. NumPy segfaults on high-rank tensors that reach either that API or `PyArray_SimpleNewFromData` in the aliased fast path. `ArrayFromMemory` already guards the fast path at `ndarray_tensor_bridge.cc:247-252`, but `TF_TensorToPyArray` -- the always-slow route for `TF_STRING`/`TF_RESOURCE` tensors, and the fallback when `TF_TensorMaybeMove` fails -- is unguarded. Any caller that triggers `.numpy()` on a rank > `NPY_MAXDIMS` string tensor crashes the process. The reporter's `tf.repeat` repro is one accidental trigger via error-message formatting; the underlying gap affects every `.numpy()`/`repr()` call on such a tensor.

This mirrors the `NPY_MAXDIMS` check from `ArrayFromMemory` into `TF_TensorToPyArray`. Message text is byte-identical to the existing guard.

The regression test lives in `RepeatTest` since that class is where readers looking for #124973 regressions will land. To reach the new guard deterministically, the test reshapes a scalar string constant to a rank-100 `TF_STRING` tensor and calls `.numpy()` on it -- string dtype forces the slow path, whereas numeric dtypes reach the already-guarded `ArrayFromMemory`. Rank 100 was chosen deliberately: above numpy's `NPY_MAXDIMS` ceiling on all released versions (32 pre-2.0, 64 post-2.0) and well below TF's own `TensorShape::MaxDimensions()` cap of 254. The test skips in graph mode because `.numpy()` requires eager execution -- noted here explicitly since the enclosing `RepeatTest` class carries `@run_all_in_graph_and_eager_modes`.

Fixes #124973