### PR TITLE
Fix stack buffer overflow in TFLite Select reference kernel for rank > 8 tensors

### DIFF
--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -1399,6 +1399,15 @@ cc_test(
 )
 
 cc_test(
+    name = "select_test",
+    srcs = ["select_test.cc"],
+    deps = [
+        ":reference_base",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "runtime_shape_test",
     srcs = ["runtime_shape_test.cc"],
     deps = [

--- a/tensorflow/lite/kernels/internal/reference/select.h
+++ b/tensorflow/lite/kernels/internal/reference/select.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cmath>
 #include <cstring>
 
+#include "absl/container/inlined_vector.h"
 #include "ruy/profiler/instrumentation.h"  // from @ruy
 #include "tensorflow/lite/kernels/internal/common.h"
 #include "tensorflow/lite/kernels/internal/reference/broadcast_loop.h"
@@ -150,7 +151,7 @@ inline void BroadcastSelectSimple(const RuntimeShape& cond_shape,
                                   const RuntimeShape& y_shape, const T* y_data,
                                   const RuntimeShape& output_shape,
                                   T* output_data) {
-  constexpr int kMaxRank = 8;
+  constexpr size_t kInlineRank = 8;
   const int dims_count = std::max(
       output_shape.DimensionsCount(),
       std::max(cond_shape.DimensionsCount(),
@@ -159,8 +160,6 @@ inline void BroadcastSelectSimple(const RuntimeShape& cond_shape,
     *output_data = *cond_data ? *x_data : *y_data;
     return;
   }
-
-  TFLITE_DCHECK_LE(dims_count, kMaxRank);
 
   const RuntimeShape extended_output_shape =
       RuntimeShape::ExtendedShape(dims_count, output_shape);
@@ -171,11 +170,12 @@ inline void BroadcastSelectSimple(const RuntimeShape& cond_shape,
   const RuntimeShape extended_y_shape =
       RuntimeShape::ExtendedShape(dims_count, y_shape);
 
-  size_t cond_strides[kMaxRank];
-  size_t x_strides[kMaxRank];
-  size_t y_strides[kMaxRank];
-  size_t o_strides[kMaxRank];
-  size_t o_shape[kMaxRank];
+  const size_t rank = static_cast<size_t>(dims_count);
+  absl::InlinedVector<size_t, kInlineRank> cond_strides(rank);
+  absl::InlinedVector<size_t, kInlineRank> x_strides(rank);
+  absl::InlinedVector<size_t, kInlineRank> y_strides(rank);
+  absl::InlinedVector<size_t, kInlineRank> o_strides(rank);
+  absl::InlinedVector<size_t, kInlineRank> o_shape(rank);
 
   size_t cond_accum_stride = 1;
   size_t x_accum_stride = 1;
@@ -224,8 +224,9 @@ inline void BroadcastSelectSimple(const RuntimeShape& cond_shape,
     o_accum_stride *= output_dim;
   }
 
-  RunSelectOp(cond_data, x_data, y_data, output_data, cond_strides, x_strides,
-              y_strides, o_strides, o_shape, next_dim_idx);
+  RunSelectOp(cond_data, x_data, y_data, output_data, cond_strides.data(),
+              x_strides.data(), y_strides.data(), o_strides.data(),
+              o_shape.data(), next_dim_idx);
 }
 
 template <typename D, typename T>
@@ -237,10 +238,6 @@ void BroadcastSelect5DSlow(const RuntimeShape& input_condition_shape,
                            const T* input_y_data,
                            const RuntimeShape& output_shape, T* output_data) {
   ruy::profiler::ScopeLabel label("Select/BroadcastSelectSlow");
-  TFLITE_DCHECK_LE(input_condition_shape.DimensionsCount(), 8);
-  TFLITE_DCHECK_LE(input_x_shape.DimensionsCount(), 8);
-  TFLITE_DCHECK_LE(input_y_shape.DimensionsCount(), 8);
-  TFLITE_DCHECK_LE(output_shape.DimensionsCount(), 8);
 
   BroadcastSelectSimple(input_condition_shape, input_condition_data,
                         input_x_shape, input_x_data, input_y_shape,

--- a/tensorflow/lite/kernels/internal/select_test.cc
+++ b/tensorflow/lite/kernels/internal/select_test.cc
@@ -1,0 +1,99 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/select.h"
+
+#include <cstddef>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace tflite {
+namespace reference_ops {
+namespace {
+
+// Regression test for a stack buffer overflow in BroadcastSelectSimple:
+// cond_strides/x_strides/y_strides/o_strides/o_shape were fixed-size
+// kMaxRank=8 C arrays, guarded only by a TFLITE_DCHECK_LE that compiles out
+// in release builds. A rank-9 input -- reachable from a .tflite model's own
+// declared tensor shapes for a Select/SelectV2 op -- wrote one element past
+// each array. Same bug class and same fix (absl::InlinedVector, sized to
+// the real rank) as broadcast_loop.h's rank-9 regression test.
+TEST(SelectTest, SupportsRankGreaterThanInlineRank) {
+  // x alternates 1/2 across all 9 dimensions; cond/y/output are constant 2.
+  // This broadcasting pattern prevents BroadcastSelectSimple's loop-fusion
+  // optimization from collapsing the dimensions, forcing next_dim_idx to
+  // increment on (almost) every one of the 9 dimensions -- walking one past
+  // the previously fixed-size 8-element arrays.
+  const RuntimeShape cond_shape({2, 2, 2, 2, 2, 2, 2, 2, 2});
+  const RuntimeShape x_shape({1, 2, 1, 2, 1, 2, 1, 2, 1});
+  const RuntimeShape y_shape({2, 2, 2, 2, 2, 2, 2, 2, 2});
+  const RuntimeShape output_shape({2, 2, 2, 2, 2, 2, 2, 2, 2});
+
+  const size_t cond_size = cond_shape.FlatSize();
+  const size_t x_size = x_shape.FlatSize();
+  const size_t y_size = y_shape.FlatSize();
+  const size_t output_size = output_shape.FlatSize();
+
+  std::vector<uint8_t> cond_data(cond_size, 1);
+  std::vector<float> x_data(x_size);
+  std::vector<float> y_data(y_size, 100.0f);
+  std::vector<float> output_data(output_size, 0.0f);
+  for (size_t i = 0; i < x_size; ++i) x_data[i] = static_cast<float>(i);
+
+  // Must not read or write outside the five metadata arrays regardless of
+  // rank; ASan/stack-protector builds catch a regression here.
+  BroadcastSelectSimple(cond_shape, cond_data.data(), x_shape, x_data.data(),
+                        y_shape, y_data.data(), output_shape,
+                        output_data.data());
+
+  // Independently recompute the expected value for each output element via
+  // a manual per-dimension index decomposition (not reusing any of
+  // BroadcastSelectSimple's own stride/fusion logic), the same style of
+  // correctness oracle broadcast_loop_test.cc uses.
+  const int rank = output_shape.DimensionsCount();
+  for (size_t output_index = 0; output_index < output_size; ++output_index) {
+    size_t remaining = output_index;
+    size_t cond_index = 0, x_index = 0, y_index = 0;
+    size_t cond_stride = 1, x_stride = 1, y_stride = 1;
+    // Decode output_index into per-dimension coordinates from the innermost
+    // dimension outward, accumulating each input's flat index only where
+    // that input's own dimension size is not 1 (i.e. not broadcasting).
+    std::vector<size_t> coord(rank);
+    for (int dim = rank - 1; dim >= 0; --dim) {
+      const size_t output_dim = static_cast<size_t>(output_shape.Dims(dim));
+      coord[dim] = remaining % output_dim;
+      remaining /= output_dim;
+    }
+    for (int dim = rank - 1; dim >= 0; --dim) {
+      const size_t cond_dim = static_cast<size_t>(cond_shape.Dims(dim));
+      const size_t x_dim = static_cast<size_t>(x_shape.Dims(dim));
+      const size_t y_dim = static_cast<size_t>(y_shape.Dims(dim));
+      if (cond_dim != 1) cond_index += coord[dim] * cond_stride;
+      if (x_dim != 1) x_index += coord[dim] * x_stride;
+      if (y_dim != 1) y_index += coord[dim] * y_stride;
+      cond_stride *= cond_dim;
+      x_stride *= x_dim;
+      y_stride *= y_dim;
+    }
+    const float expected = cond_data[cond_index] ? x_data[x_index] : y_data[y_index];
+    EXPECT_EQ(output_data[output_index], expected)
+        << "output index " << output_index;
+  }
+}
+
+}  // namespace
+}  // namespace reference_ops
+}  // namespace tflite


### PR DESCRIPTION
`BroadcastSelectSimple` in `tensorflow/lite/kernels/internal/reference/select.h` sized its `cond_strides`/`x_strides`/`y_strides`/`o_strides`/`o_shape` metadata arrays to a fixed `kMaxRank=8`, guarded only by a `TFLITE_DCHECK_LE` that compiles out entirely in release builds. `dims_count` is derived directly from the condition/x/y/output tensor shapes of a `Select`/`SelectV2` op -- which come from the `.tflite` model file itself. A model declaring any of these tensors with rank > 8 writes past the end of all five fixed-size stack arrays.

Confirmed with AddressSanitizer against a standalone, faithful extraction of the real, unmodified function: a rank-9 input using real broadcasting (alternating size-1 dimensions, so the loop-fusion optimization can't collapse the effective rank) reliably triggers a stack-buffer-overflow abort. The same harness, patched with this fix, runs clean.

This is the identical bug class as `broadcast_loop.h`'s `BroadcastBinaryOpSimple`, fixed earlier the same day. This PR applies the same fix (`absl::InlinedVector` sized to the real rank, instead of a fixed-size C array). No `BUILD` dependency changes needed -- `select.h` and `broadcast_loop.h` share both enclosing `cc_library` targets (`reference_base`, `legacy_reference_base`), which already picked up `absl/container:inlined_vector` from that fix. Also drops the now-redundant `DCHECK`s in `BroadcastSelect5DSlow`, which only forwards to the now-safe `BroadcastSelectSimple`.

Added a rank-9 alternating-broadcast regression test (`select_test.cc`) matching `broadcast_loop_test.cc`'s style, including full correctness verification via an independently-computed per-dimension index decomposition (not just an absence-of-crash check).