### PR TITLE
Clamp dynamic strided_slice runtime size to zero to prevent XLA:CPU crash

### DIFF
--- a/tensorflow/compiler/tests/slice_ops_test.py
+++ b/tensorflow/compiler/tests/slice_ops_test.py
@@ -311,5 +311,21 @@ class StridedSliceTest(xla_test.XLATestCase):
 
         self.assertAllEqual([3, 4, 5], result)
 
+  # Regression for #124950. On a bounded-dynamic input (here tf.where's
+  # output), strided_slice with a negative begin used to compute a
+  # negative runtime dimension size and pass it to SetDimensionSize. The
+  # resulting fused XLA:CPU kernel then segfaulted on launch. The fix
+  # clamps the runtime size to zero (`strided_slice_op.cc`), matching
+  # the sibling dynamic-index branch's pattern.
+  def testStridedSliceOnDynamicInputWithDegenerateBoundsDoesNotCrash(self):
+    with self.session() as sess:
+      inp = array_ops.placeholder(dtypes.bool, shape=[3])
+      with self.test_scope():
+        result = array_ops.strided_slice(
+            array_ops.where(inp), [-1, 0], [0, 3])
+      out = sess.run(result, feed_dict={inp: [True, False, True]})
+      self.assertEqual(tensor_shape.TensorShape((0, 1)), out.shape)
+
+
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
@@ -394,10 +394,19 @@ class StridedSliceOp : public XlaOpKernel {
             }
             operand_size = xla::Min(operand_size, end_size);
           }
+          // Clamp the runtime size to zero, matching the dynamic-index
+          // branch above (line 219). Without the clamp, a bounded-dynamic
+          // input paired with static bounds that produce a degenerate
+          // interval (e.g. tf.strided_slice(dyn, [-1, 0], [0, 3])) emits
+          // set-dimension-size with a negative runtime value, which
+          // XLA:CPU codegens into a fused kernel that segfaults on launch
+          // (issue #124950).
           slice = xla::SetDimensionSize(
               slice,
-              xla::Sub(operand_size, xla::ConstantR0<int32_t>(
-                                         ctx->builder(), begin[input_index])),
+              xla::Max(xla::Sub(operand_size,
+                                xla::ConstantR0<int32_t>(
+                                    ctx->builder(), begin[input_index])),
+                       xla::ConstantR0<int32_t>(ctx->builder(), 0)),
               i);
         }
       }


### PR DESCRIPTION
`tf.strided_slice` on a bounded-dynamic input under `jit_compile=True` with certain canonicalized bounds (for example, `strided_slice(dyn, [-1, 0], [0, 3])` where the static end is smaller than the canonicalized begin) computed a negative runtime dimension size at the tf2xla lowering step. That negative value was then passed unchanged to `xla::SetDimensionSize`, propagated through a `SliceToDynamic` custom call, and used by an emitted XLA:CPU fused kernel whose resolved function pointer landed on invalid executable memory when the runtime dim was negative. Result: SIGSEGV on kernel launch, deterministic under the reporter's repro on Linux and confirmed here on Windows (exit 139).

The bug is a divergence between two sibling branches of the same op. The dynamic-INDEX branch at `tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc:219` already clamps: `xla::Max(xla::Sub(end_index, begin_index), zero)`. The dynamic-INPUT branch at `strided_slice_op.cc:397-402` was doing the same subtract without the clamp. This PR mirrors the clamp onto the second branch.

The regression test lives in `slice_ops_test.py::StridedSliceTest` alongside the existing `test2DDegenerate` (line 193), which uses the same `[-1, 0], [0, 3]` bounds on a STATIC-shape input and verifies the empty `shape=(0, 3)` return. The new test wraps the input in `array_ops.where` to force the bounded-dynamic path, then asserts the empty `shape=(0, 1)` return under `test_scope`. Without the fix, the assertion never runs. CI would surface the SIGSEGV as a job crash.

Fixes #124950