### PR TITLE
Add mlir namespace to mlir casts/isa

### DIFF
--- a/tensorflow/dtensor/mlir/shape_utils.cc
+++ b/tensorflow/dtensor/mlir/shape_utils.cc
@@ -73,7 +73,7 @@ StatusOr<llvm::ArrayRef<int64_t>> ExtractGlobalInputShape(
         return absl::InternalError("global_shape does not have static rank");
       return *global_shape;
     }
-    return ExtractGlobalOutputShape(cast<mlir::OpResult>(input_value.get()));
+    return ExtractGlobalOutputShape(mlir::cast<mlir::OpResult>(input_value.get()));
   }
 
   // If we reach this point, we're working with a function argument.

--- a/tensorflow/dtensor/mlir/spmd_expansion.cc
+++ b/tensorflow/dtensor/mlir/spmd_expansion.cc
@@ -188,7 +188,7 @@ bool GetResourceArgIndexIfUsedInAssignmentOp(
           GetForwardedDTensorLayoutInput(assign_variable_op.getResource());
       if (llvm::isa<mlir::BlockArgument>(resource)) {
         *resource_argument_index_for_assign_variable =
-            cast<mlir::BlockArgument>(resource).getArgNumber();
+            mlir::cast<mlir::BlockArgument>(resource).getArgNumber();
         return true;
       }
     }
@@ -221,7 +221,7 @@ mlir::LogicalResult UpdateFunctionArgsUsingLayout(mlir::func::FuncOp function) {
 
     // If argument is a resource type update the subtype shape information
     // to reflect local shape of resources.
-    if (isa<mlir::TF::ResourceType>(arg_type)) {
+    if (mlir::isa<mlir::TF::ResourceType>(arg_type)) {
       if (mlir::failed(UpdateResourceArgumentType(argument_index, function)))
         return mlir::failure();
       continue;


### PR DESCRIPTION
To avoid errors like:
tensorflow/dtensor/mlir/shape_utils.cc:76:25: error: ‘cast’ was not declared in this scope

See also https://github.com/tensorflow/tensorflow/commit/8b74320137afdb1817ae666be75ef0b7a44f5dac