### PR TITLE
Add explicit `-lcrypto` link option to SYSTEM-BoringSSL

### DIFF
--- a/third_party/systemlibs/boringssl.BUILD
+++ b/third_party/systemlibs/boringssl.BUILD
@@ -28,7 +28,10 @@ cc_library(
 
 cc_library(
     name = "ssl",
-    linkopts = ["-lssl", "-lcrypto"],
+    linkopts = [
+        "-lssl",
+        "-lcrypto",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":crypto",

--- a/third_party/systemlibs/boringssl.BUILD
+++ b/third_party/systemlibs/boringssl.BUILD
@@ -28,7 +28,7 @@ cc_library(
 
 cc_library(
     name = "ssl",
-    linkopts = ["-lssl"],
+    linkopts = ["-lssl", "-lcrypto"],
     visibility = ["//visibility:public"],
     deps = [
         ":crypto",


### PR DESCRIPTION
When building with system OpenSSL (TF_SYSTEM_LIBS=boringssl) linking `libtensorflow_cc.so.2` fails with many undefined references originating in grpc, e.g.:

```
bazel-out/k8-opt/bin/external/com_github_grpc_grpc/libtsi_ssl_credentials.pic.a(ssl_transport_security.pic.o):ssl_transport_security.cc:function populate_ssl_context(ssl_ctx_st*, tsi_ssl_pem_key_cert_pair const*, char const*): error: undefined reference to 'PEM_read_bio_PrivateKey'
bazel-out/k8-opt/bin/external/com_github_grpc_grpc/libtsi_ssl_credentials.pic.a(ssl_transport_security.pic.o):ssl_transport_security.cc:function populate_ssl_context(ssl_ctx_st*, tsi_ssl_pem_key_cert_pair const*, char const*): error: undefined reference to 'EVP_PKEY_free'
```

Cause: When using the pywrap rules libcrypto gets no longer linked into `libtensorflow_cc` leading to those undefined symbols.
As the pywrap rules mechanism ignores the transitive dependency this PR makes it explicit via `linkopts`

I'm not familiar with those pywrap rules mechanism but AI suggested:
`pywrap_library` partitions all linker inputs between libtensorflow_framework and libtensorflow_cc with a first-claim-wins filter instead of following `deps`. The `@boringssl//:crypto` target is claimed by framework (via tsl's `oauth client`) while `@boringssl//:ssl` is claimed by _cc through gRPC so the ssl -> crypto edge is severed.

Interestingly libtensorflow_cc gets `-lssl` arguments, for some reason 14 times.


This seems to be a regression in 2.20 which made the pywrap bazel rules introduced in 2.19 (as opt-in) enabled by default