### PR TITLE
Validate reverse axes for scalar and empty inputs

### DIFF
--- a/tensorflow/core/kernels/reverse_op.cc
+++ b/tensorflow/core/kernels/reverse_op.cc
@@ -249,61 +249,68 @@ class ReverseV2Op : public OpKernel {
     const Tensor& input = context->input(0);
     const Tensor& sparse_dims = context->input(1);
 
+    const int input_dims = input.dims();
+    const TensorShape& sparse_dims_shape = sparse_dims.shape();
+    const auto& axes_sparse_flat = sparse_dims.flat<Tidx>();
+
+    // The axes are validated before the shortcut for scalar and empty inputs
+    // below. Those inputs have nothing to reverse, but their axes can still be
+    // out of range, and shape inference already rejects them in graph mode.
+    // Validating here keeps eager execution consistent with that. Note that a
+    // scalar has no valid axis at all, so any axis is rejected for it, while
+    // an empty axis list stays valid for every input.
+    OP_REQUIRES(context, TensorShapeUtils::IsVector(sparse_dims_shape),
+                absl::InvalidArgumentError(absl::StrCat(
+                    "'dims' must be 1-dimension, not ", sparse_dims.dims())));
+    absl::InlinedVector<bool, 8> axes_dense(input_dims, false);
+    for (int dummy = 0; dummy < axes_sparse_flat.size(); dummy++) {
+      Tidx axis = internal::SubtleMustCopy<Tidx>(axes_sparse_flat(dummy));
+      Tidx canonical_axis = axis < 0 ? input_dims + axis : axis;
+      OP_REQUIRES(context, canonical_axis >= 0 && canonical_axis < input_dims,
+                  errors::InvalidArgument("'axis'[", dummy, "] = ", axis,
+                                          " is out of valid range [", 0, ", ",
+                                          input_dims - 1));
+      OP_REQUIRES(context, !axes_dense[canonical_axis],
+                  errors::InvalidArgument("axis ", canonical_axis,
+                                          " specified more than once."));
+      axes_dense[canonical_axis] = true;
+    }
+
     if (TensorShapeUtils::IsScalar(input.shape()) || input.NumElements() == 0) {
       context->set_output(0, input);
-    } else {
-      const int input_dims = input.dims();
-      const TensorShape& sparse_dims_shape = sparse_dims.shape();
-      const auto& axes_sparse_flat = sparse_dims.flat<Tidx>();
+      return;
+    }
 
-      OP_REQUIRES(context, TensorShapeUtils::IsVector(sparse_dims_shape),
-                  absl::InvalidArgumentError(absl::StrCat(
-                      "'dims' must be 1-dimension, not ", sparse_dims.dims())));
-      absl::InlinedVector<bool, 8> axes_dense(input_dims, false);
-      for (int dummy = 0; dummy < axes_sparse_flat.size(); dummy++) {
-        Tidx axis = internal::SubtleMustCopy<Tidx>(axes_sparse_flat(dummy));
-        Tidx canonical_axis = axis < 0 ? input_dims + axis : axis;
-        OP_REQUIRES(context, canonical_axis >= 0 && canonical_axis < input_dims,
-                    errors::InvalidArgument("'axis'[", dummy, "] = ", axis,
-                                            " is out of valid range [", 0, ", ",
-                                            input_dims - 1));
-        OP_REQUIRES(context, !axes_dense[canonical_axis],
-                    errors::InvalidArgument("axis ", canonical_axis,
-                                            " specified more than once."));
-        axes_dense[canonical_axis] = true;
-      }
+    OP_REQUIRES(context, input_dims <= 8,
+                absl::UnimplementedError(
+                    "reverse is not implemented for tensors of rank > 8."));
 
-      OP_REQUIRES(context, input_dims <= 8,
-                  absl::UnimplementedError(
-                      "reverse is not implemented for tensors of rank > 8."));
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->allocate_output(0, input.shape(), &output));
 
-      Tensor* output = nullptr;
-      OP_REQUIRES_OK(context,
-                     context->allocate_output(0, input.shape(), &output));
-
-      // TODO(cwhipkey): we can do dimension folding to reduce, e.g., a reverse
-      // of a single dimension to the dims=3 or dims=2 case, regardless of the
-      // number of dimensions in the tensor. This would let some ops use faster
-      // lower-dimension code (and use optimized versions).
+    // TODO(cwhipkey): we can do dimension folding to reduce, e.g., a reverse
+    // of a single dimension to the dims=3 or dims=2 case, regardless of the
+    // number of dimensions in the tensor. This would let some ops use faster
+    // lower-dimension code (and use optimized versions).
 
 #define HANDLE_REVERSE(NDIMS)                                           \
   case NDIMS:                                                           \
     HandleReverseV2Case<Device, T, NDIMS>(context, axes_dense, output); \
     return;
 
-      switch (input_dims) {
-        HANDLE_REVERSE(0);
-        HANDLE_REVERSE(1);
-        HANDLE_REVERSE(2);
-        HANDLE_REVERSE(3);
-        HANDLE_REVERSE(4);
-        HANDLE_REVERSE(5);
-        HANDLE_REVERSE(6);
-        HANDLE_REVERSE(7);
-        HANDLE_REVERSE(8);
-      }
-#undef HANDLE_REVERSE
+    switch (input_dims) {
+      HANDLE_REVERSE(0);
+      HANDLE_REVERSE(1);
+      HANDLE_REVERSE(2);
+      HANDLE_REVERSE(3);
+      HANDLE_REVERSE(4);
+      HANDLE_REVERSE(5);
+      HANDLE_REVERSE(6);
+      HANDLE_REVERSE(7);
+      HANDLE_REVERSE(8);
     }
+#undef HANDLE_REVERSE
   }
 };
 

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -591,6 +591,41 @@ class ReverseV2Test(test_util.TensorFlowTestCase):
     v = array_ops.reverse_v2(x, axis=[1])
     self.assertAllEqual(self.evaluate(v), v)
 
+  def testReverseScalarOutOfRangeAxis(self):
+    # Regression test for GitHub issue 110038: a scalar has no valid axis, so
+    # any axis must be rejected. The kernel returned the input unchanged
+    # instead, which disagreed with the error shape inference raises for the
+    # same call in graph mode.
+    for axis in ([0], [1, 2, 3], [-1]):
+      with self.subTest(axis=axis):
+        with self.assertRaisesRegex(
+            (ValueError, errors.InvalidArgumentError), "out of valid range"):
+          self.evaluate(
+              array_ops.reverse_v2(constant_op.constant(4.0), axis=axis))
+
+  def testReverseScalarEmptyAxisIsValid(self):
+    # An empty axis list reverses nothing and stays valid for any input.
+    x = constant_op.constant(4.0)
+    self.assertAllEqual(4.0, self.evaluate(array_ops.reverse_v2(x, axis=[])))
+
+  def testReverseEmptyTensorOutOfRangeAxis(self):
+    # The same validation gap applied to empty tensors, whose axes can be out
+    # of range even though there is nothing to reverse.
+    for shape, axis in (([0], [5]), ([0, 3], [7]), ([0, 3], [-4])):
+      with self.subTest(shape=shape, axis=axis):
+        x = array_ops.zeros(shape, dtype=dtypes.float32)
+        with self.assertRaisesRegex(
+            (ValueError, errors.InvalidArgumentError), "out of valid range"):
+          self.evaluate(array_ops.reverse_v2(x, axis=axis))
+
+  def testReverseEmptyTensorValidAxis(self):
+    # In-range axes on empty tensors keep working.
+    for shape, axis in (([0], [0]), ([0, 3], [1]), ([0, 3], [-1])):
+      with self.subTest(shape=shape, axis=axis):
+        x = array_ops.zeros(shape, dtype=dtypes.float32)
+        self.assertAllEqual(
+            np.zeros(shape), self.evaluate(array_ops.reverse_v2(x, axis=axis)))
+
 
 class MeshgridTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
## Summary

Fixes #110038.

`tf.reverse` accepts out-of-range axes in eager execution for inputs that have nothing to reverse, while graph mode rejects the same call:

```python
x = tf.reduce_max(tf.constant([1., 2., 3., 4.]), axis=0)   # scalar
tf.reverse(x, axis=[1, 2, 3])          # eager: returns 4.0
tf.function(lambda t: tf.reverse(t, axis=[1, 2, 3]))(x)    # graph: ValueError
```

## Root cause

`ReverseV2Op::Compute` short-circuits before validating anything:

```c++
if (TensorShapeUtils::IsScalar(input.shape()) || input.NumElements() == 0) {
  context->set_output(0, input);
} else {
  ... // axis range and duplicate checks live here
}
```

Inputs with nothing to reverse skip the axis checks entirely. Everything else is validated correctly, so this is specific to that shortcut rather than a general weakness: rank-1 inputs already reject `axis=[5]`, `[-9]`, and duplicate `[0, 0]` in eager.

## Scope is wider than reported

The issue reports the scalar case. Comparing eager against graph across the shortcut's two branches on 2.21.0, empty tensors are affected too:

| input | axis | eager | graph |
| --- | --- | --- | --- |
| scalar | `[0]` | returns input | ValueError |
| scalar | `[1,2,3]` | returns input | ValueError |
| scalar | `[]` | ok | ok |
| empty `[0]` | `[0]` | ok | ok |
| empty `[0]` | `[5]` | returns input | ValueError |
| empty `[0,3]` | `[7]` | returns input | ValueError |

## Fix

Validate the axes before the shortcut, then return early only for the data movement. The checks and messages are unchanged; they simply are no longer skipped. Most of the diff is re-indentation from removing the enclosing `else` block.

Fixing the kernel rather than the Python wrapper means `tf.raw_ops.ReverseV2` is covered as well, so the eager and graph paths agree at the op level.

## Behavior change

This is intentional and worth calling out: code that passes an out-of-range axis to a scalar or empty tensor currently gets the input back silently and will now raise. Graph mode already raises for those calls, and the documented valid range is `[-rank(tensor), rank(tensor))`.

## Verification

Two existing tests constrain this and both still pass: `testReverse0DimAuto` (scalar with `axis=[]`) and `testReverseInvalidShape` (shape `[0,1,1]` with `axis=[1]`). Neither trips the validation, since an empty axis list never enters the loop and axis 1 is in range for rank 3.

Four regression tests are added covering scalar out-of-range, scalar with an empty axis list, empty-tensor out-of-range, and empty-tensor in-range. Against the unpatched 2.21.0 wheel all six out-of-range subcases fail and the valid-case tests pass, so the tests gate the change rather than passing vacuously.

The kernel itself is not compiled locally (no Bazel on this machine), so CI is the first build. To check the new control flow independently I simulated it against graph mode as the reference across 16 shape/axis combinations spanning scalars, empty tensors, negative axes, duplicates, and ordinary tensors, with no disagreements.

Credit to @bi6c for the report. @madhavmadupu's earlier PR #110060, closed by the stale bot rather than rejected, addressed this in `array_ops.py`; this takes the kernel-side approach so the raw op is fixed too.