### PR TITLE
[XLA] Fix RandomShuffle comparison type for float vectors

### DIFF
--- a/tensorflow/compiler/mlir/tf2xla/tests/legalize-tf.mlir
+++ b/tensorflow/compiler/mlir/tf2xla/tests/legalize-tf.mlir
@@ -2708,6 +2708,17 @@ func.func @neg_dynamic(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 
 // -----
 
+// CHECK-LABEL: @random_shuffle_float_vector
+func.func @random_shuffle_float_vector(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+  // CHECK: "mhlo.sort"
+  // CHECK: ^bb0([[KEY_LHS:%.*]]: tensor<i32>, [[KEY_RHS:%.*]]: tensor<i32>, {{.*}}: tensor<f32>, {{.*}}: tensor<f32>):
+  // CHECK: mhlo.compare  LT, [[KEY_LHS]], [[KEY_RHS]] : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  %0 = "tf.RandomShuffle"(%arg0) {seed = 1 : i64, seed2 = 2 : i64} : (tensor<2xf32>) -> tensor<2xf32>
+  func.return %0 : tensor<2xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @sigmoid
 func.func @sigmoid(%arg0: tensor<2xf32>) -> tensor<2xf32> {
   // CHECK: mhlo.logistic
@@ -2798,4 +2809,3 @@ func.func @func_xla_sharding_consistent(%arg0: tensor<4x8xi32>) -> (tensor<4x8xi
   %1 = "tf.A"(%0) : (tensor<4x8xi32>) -> (tensor<4x8xi32>)
   func.return %1 : tensor<4x8xi32>
 }
-

--- a/tensorflow/compiler/mlir/tf2xla/tests/legalize-tf.mlir
+++ b/tensorflow/compiler/mlir/tf2xla/tests/legalize-tf.mlir
@@ -2712,7 +2712,7 @@ func.func @neg_dynamic(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 func.func @random_shuffle_float_vector(%arg0: tensor<2xf32>) -> tensor<2xf32> {
   // CHECK: "mhlo.sort"
   // CHECK: ^bb0([[KEY_LHS:%.*]]: tensor<i32>, [[KEY_RHS:%.*]]: tensor<i32>, {{.*}}: tensor<f32>, {{.*}}: tensor<f32>):
-  // CHECK: mhlo.compare  LT, [[KEY_LHS]], [[KEY_RHS]] : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  // CHECK: mhlo.compare  LT, [[KEY_LHS]], [[KEY_RHS]], TOTALORDER : (tensor<i32>, tensor<i32>) -> tensor<i1>
   %0 = "tf.RandomShuffle"(%arg0) {seed = 1 : i64, seed2 = 2 : i64} : (tensor<2xf32>) -> tensor<2xf32>
   func.return %0 : tensor<2xf32>
 }


### PR DESCRIPTION
## Summary

- Add MLIR regression coverage for `tf.RandomShuffle` on a floating-point vector with integer sort keys.
- Move the comparator fix to canonical StableHLO so TensorFlow's internal and downstream builds consume the same implementation.
- Rebase the branch onto current TensorFlow `master` and remove the local-only `temporary.patch` change.

## Upstream dependency

- openxla/stablehlo#2995 implements the comparator-key fix and adds direct helper-level tests for both integer and floating-point keys.
- This TensorFlow regression should land after that PR is merged and its StableHLO revision is synced/pinned here.

## Testing

- `bazel test //:stablehlo_ops_test --test_output=errors` (clean StableHLO build; passed)
- `bazel test --jobs=4 --repo_env=HERMETIC_PYTHON_VERSION=3.12 --disk_cache=/home/sa305415/tf-bazel-disk-cache --test_output=errors //tensorflow/compiler/mlir/tf2xla/tests:legalize-tf.mlir.test` (passed with the comparator fix applied)

Fixes #121232
