### PR TITLE
[XLA] Enable complex cumsum and cumprod

### DIFF
--- a/tensorflow/compiler/tests/scan_ops_test.py
+++ b/tensorflow/compiler/tests/scan_ops_test.py
@@ -124,6 +124,12 @@ class CumsumTest(xla_test.XLATestCase):
       for axis in range(-6, 6, 3):
         self._compareAll(x, axis)
 
+  def testComplex(self):
+    x = np.array([1 + 2j, 3 + 4j, 5 + 6j])
+    for dtype in self.complex_types:
+      for axis in (-1, 0):
+        self._compareAll(x.astype(dtype), axis)
+
   def testMixedPrecision(self):
     with self.session(), self.test_scope():
       y = math_ops.cumsum(
@@ -295,6 +301,12 @@ class CumprodTest(xla_test.XLATestCase):
       x = np.arange(1, 145).reshape([2, 2, 3, 3, 2, 2]).astype(dtype)
       for axis in range(-6, 6, 3):
         self._compareAll(x, axis)
+
+  def testComplex(self):
+    x = np.array([1 + 2j, 3 + 4j, 5 + 6j])
+    for dtype in self.complex_types:
+      for axis in (-1, 0):
+        self._compareAll(x.astype(dtype), axis)
 
   @test_util.disable_mlir_bridge("Error handling")
   def testInvalidAxis(self):

--- a/tensorflow/compiler/tests/scan_ops_test.py
+++ b/tensorflow/compiler/tests/scan_ops_test.py
@@ -125,9 +125,9 @@ class CumsumTest(xla_test.XLATestCase):
         self._compareAll(x, axis)
 
   def testComplex(self):
-    x = np.array([1 + 2j, 3 + 4j, 5 + 6j])
+    x = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
     for dtype in self.complex_types:
-      for axis in (-1, 0):
+      for axis in (-2, -1, 0, 1):
         self._compareAll(x.astype(dtype), axis)
 
   def testMixedPrecision(self):
@@ -303,9 +303,9 @@ class CumprodTest(xla_test.XLATestCase):
         self._compareAll(x, axis)
 
   def testComplex(self):
-    x = np.array([1 + 2j, 3 + 4j, 5 + 6j])
+    x = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
     for dtype in self.complex_types:
-      for axis in (-1, 0):
+      for axis in (-2, -1, 0, 1):
         self._compareAll(x.astype(dtype), axis)
 
   @test_util.disable_mlir_bridge("Error handling")

--- a/tensorflow/compiler/tf2xla/kernels/scan_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/scan_ops.cc
@@ -34,8 +34,12 @@ limitations under the License.
 namespace tensorflow {
 namespace {
 
-constexpr std::array<DataType, 6> kScanOpTypes = {
-    {DT_HALF, DT_BFLOAT16, DT_FLOAT, DT_DOUBLE, DT_INT32, DT_INT64}};
+constexpr std::array<DataType, 8> kSumAndProductTypes = {
+    {DT_HALF, DT_BFLOAT16, DT_FLOAT, DT_DOUBLE, DT_INT32, DT_INT64,
+     DT_COMPLEX64, DT_COMPLEX128}};
+
+constexpr std::array<DataType, 4> kLogSumExpTypes = {
+    {DT_HALF, DT_BFLOAT16, DT_FLOAT, DT_DOUBLE}};
 
 enum class Reducer { kProduct, kSum, kLogSumExp };
 
@@ -140,7 +144,7 @@ class CumsumOp : public ScanOp {
   explicit CumsumOp(OpKernelConstruction* ctx) : ScanOp(ctx, Reducer::kSum) {}
 };
 REGISTER_XLA_OP(Name("Cumsum")
-                    .TypeConstraint("T", kScanOpTypes)
+                    .TypeConstraint("T", kSumAndProductTypes)
                     .CompileTimeConstantInput("axis"),
                 CumsumOp);
 
@@ -150,7 +154,7 @@ class CumprodOp : public ScanOp {
       : ScanOp(ctx, Reducer::kProduct) {}
 };
 REGISTER_XLA_OP(Name("Cumprod")
-                    .TypeConstraint("T", kScanOpTypes)
+                    .TypeConstraint("T", kSumAndProductTypes)
                     .CompileTimeConstantInput("axis"),
                 CumprodOp);
 
@@ -160,7 +164,7 @@ class CumulativeLogsumexpOp : public ScanOp {
       : ScanOp(ctx, Reducer::kLogSumExp) {}
 };
 REGISTER_XLA_OP(Name("CumulativeLogsumexp")
-                    .TypeConstraint("T", kScanOpTypes)
+                    .TypeConstraint("T", kLogSumExpTypes)
                     .CompileTimeConstantInput("axis"),
                 CumulativeLogsumexpOp);
 


### PR DESCRIPTION
## Summary

- Register `complex64` and `complex128` for the XLA `Cumsum` and `Cumprod` kernels.
- Keep `CumulativeLogsumexp` restricted to its real floating-point contract by giving it a separate type set.
- Cover both complex widths across inclusive, exclusive, forward, and reverse scans.

## Root cause

The TensorFlow ops accept complex tensors and XLA supports complex add and multiply reductions, but the tf2xla scan kernel registration omitted both complex dtypes. The compiler therefore rejected these ops before reaching the existing lowering.

## Testing

- `bazel test --jobs=16 --repo_env=HERMETIC_PYTHON_VERSION=3.12 --disk_cache=/home/sa305415/tf-bazel-disk-cache --test_output=errors //tensorflow/compiler/tests:scan_ops_test_cpu`
- All six shards passed, including `CumsumTest.testComplex` and `CumprodTest.testComplex`.

Fixes #117546
