### PR TITLE
Fix int32 index overflow in MirrorPad for outputs above 2^31 elements

### DIFF
--- a/tensorflow/core/kernels/image/mirror_pad_op.cc
+++ b/tensorflow/core/kernels/image/mirror_pad_op.cc
@@ -120,12 +120,12 @@ class MirrorPadOp : public OpKernel {
     Tensor* output = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
 
-#define MIRROR_PAD_CASE(i)                                                \
-  case i: {                                                               \
-    functor::MirrorPad<Device, T, Tpaddings, i>()(                        \
-        context->eigen_device<Device>(), To32Bit(output->tensor<T, i>()), \
-        To32Bit(in0.tensor<T, i>()), paddings, offset_);                  \
-    break;                                                                \
+#define MIRROR_PAD_CASE(i)                                       \
+  case i: {                                                      \
+    functor::MirrorPad<Device, T, Tpaddings, i>()(               \
+        context->eigen_device<Device>(), output->tensor<T, i>(), \
+        in0.tensor<T, i>(), paddings, offset_);                  \
+    break;                                                       \
   }
 
     // Invoke the dims-specific implementation.
@@ -153,12 +153,12 @@ using GpuDevice = Eigen::GpuDevice;
 namespace functor {
 // Forward declarations of the functor specializations defined in the sharded
 // files.
-#define DECLARE_CPU_SPEC(T, Tpaddings, i)                     \
-  template <>                                                 \
-  void MirrorPad<CpuDevice, T, Tpaddings, i>::operator()(     \
-      const CpuDevice&, typename TTypes<T, i, int32>::Tensor, \
-      typename TTypes<T, i, int32>::ConstTensor,              \
-      TTypes<Tpaddings>::ConstMatrix, int);                   \
+#define DECLARE_CPU_SPEC(T, Tpaddings, i)                                 \
+  template <>                                                             \
+  void MirrorPad<CpuDevice, T, Tpaddings, i>::operator()(                 \
+      const CpuDevice&, typename TTypes<T, i>::Tensor,                    \
+      typename TTypes<T, i>::ConstTensor, TTypes<Tpaddings>::ConstMatrix, \
+      int);                                                               \
   extern template struct MirrorPad<CpuDevice, T, Tpaddings, i>;
 
 #define DECLARE_CPU_SPECS(T)       \
@@ -204,12 +204,12 @@ TF_CALL_tstring(REGISTER_KERNEL);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 // Forward declarations of the functor specializations for GPU.
-#define DECLARE_GPU_SPEC(T, Tpaddings, i)                     \
-  template <>                                                 \
-  void MirrorPad<GpuDevice, T, Tpaddings, i>::operator()(     \
-      const GpuDevice&, typename TTypes<T, i, int32>::Tensor, \
-      typename TTypes<T, i, int32>::ConstTensor,              \
-      TTypes<Tpaddings>::ConstMatrix, int);                   \
+#define DECLARE_GPU_SPEC(T, Tpaddings, i)                                 \
+  template <>                                                             \
+  void MirrorPad<GpuDevice, T, Tpaddings, i>::operator()(                 \
+      const GpuDevice&, typename TTypes<T, i>::Tensor,                    \
+      typename TTypes<T, i>::ConstTensor, TTypes<Tpaddings>::ConstMatrix, \
+      int);                                                               \
   extern template struct MirrorPad<GpuDevice, T, Tpaddings, i>;
 
 #define DECLARE_GPU_SPECS(T)       \
@@ -342,13 +342,12 @@ class MirrorPadGradOp : public OpKernel {
     Tensor* output = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
 
-#define MIRROR_PAD_GRAD_CASE(k)                                           \
-  case k: {                                                               \
-    functor::MirrorPadGrad<Device, T, Tpaddings, k>()(                    \
-        context->eigen_device<Device>(), To32Bit(output->tensor<T, k>()), \
-        To32Bit(in0.tensor<T, k>()), paddings, offset_,                   \
-        To32Bit(scratch.tensor<T, k>()));                                 \
-    break;                                                                \
+#define MIRROR_PAD_GRAD_CASE(k)                                         \
+  case k: {                                                             \
+    functor::MirrorPadGrad<Device, T, Tpaddings, k>()(                  \
+        context->eigen_device<Device>(), output->tensor<T, k>(),        \
+        in0.tensor<T, k>(), paddings, offset_, scratch.tensor<T, k>()); \
+    break;                                                              \
   }
 
     // Invoke the dims-specific implementation.
@@ -373,13 +372,12 @@ class MirrorPadGradOp : public OpKernel {
 namespace functor {
 // Forward declarations of the functor specializations defined in the sharded
 // files.
-#define DECLARE_CPU_SPEC(T, Tpaddings, k)                     \
-  template <>                                                 \
-  void MirrorPadGrad<CpuDevice, T, Tpaddings, k>::operator()( \
-      const CpuDevice&, typename TTypes<T, k, int32>::Tensor, \
-      typename TTypes<T, k, int32>::ConstTensor,              \
-      TTypes<Tpaddings>::ConstMatrix, int,                    \
-      typename TTypes<T, k, int32>::Tensor);                  \
+#define DECLARE_CPU_SPEC(T, Tpaddings, k)                                      \
+  template <>                                                                  \
+  void MirrorPadGrad<CpuDevice, T, Tpaddings, k>::operator()(                  \
+      const CpuDevice&, typename TTypes<T, k>::Tensor,                         \
+      typename TTypes<T, k>::ConstTensor, TTypes<Tpaddings>::ConstMatrix, int, \
+      typename TTypes<T, k>::Tensor);                                          \
   extern template struct MirrorPadGrad<CpuDevice, T, Tpaddings, k>;
 
 #define DECLARE_CPU_SPECS(T)       \
@@ -419,13 +417,12 @@ TF_CALL_NUMBER_TYPES(REGISTER_KERNEL);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 // Forward declarations of the functor specializations for GPU.
-#define DECLARE_GPU_SPEC(T, Tpaddings, k)                     \
-  template <>                                                 \
-  void MirrorPadGrad<GpuDevice, T, Tpaddings, k>::operator()( \
-      const GpuDevice&, typename TTypes<T, k, int32>::Tensor, \
-      typename TTypes<T, k, int32>::ConstTensor,              \
-      TTypes<Tpaddings>::ConstMatrix, int,                    \
-      typename TTypes<T, k, int32>::Tensor);                  \
+#define DECLARE_GPU_SPEC(T, Tpaddings, k)                                      \
+  template <>                                                                  \
+  void MirrorPadGrad<GpuDevice, T, Tpaddings, k>::operator()(                  \
+      const GpuDevice&, typename TTypes<T, k>::Tensor,                         \
+      typename TTypes<T, k>::ConstTensor, TTypes<Tpaddings>::ConstMatrix, int, \
+      typename TTypes<T, k>::Tensor);                                          \
   extern template struct MirrorPadGrad<GpuDevice, T, Tpaddings, k>;
 
 #define DECLARE_GPU_SPECS(T)       \

--- a/tensorflow/core/kernels/image/mirror_pad_op.h
+++ b/tensorflow/core/kernels/image/mirror_pad_op.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_IMAGE_MIRROR_PAD_OP_H_
 #define TENSORFLOW_CORE_KERNELS_IMAGE_MIRROR_PAD_OP_H_
 
+#include <type_traits>
+
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/platform/types.h"
@@ -337,17 +339,25 @@ namespace functor {
 // values are replicated (offset == 0) or not replicated (offset == 1).
 template <typename Device, typename T, typename Tpaddings, int Dims>
 struct MirrorPad {
-  void operator()(const Device& device,
-                  typename TTypes<T, Dims, int32_t>::Tensor output,
-                  typename TTypes<T, Dims, int32_t>::ConstTensor input,
+  void operator()(const Device& device, typename TTypes<T, Dims>::Tensor output,
+                  typename TTypes<T, Dims>::ConstTensor input,
                   typename TTypes<Tpaddings>::ConstMatrix padding, int offset) {
-    Eigen::array<Eigen::IndexPair<int32_t>, Dims> padding_dims;
+    MaybeWith32BitIndexing<Device>(
+        [&](auto output32, auto input32) {
+          // The padding_dims array must use the same index type as the
+          // tensor it applies to, or it silently narrows the very
+          // dimensions this indexing is widened to represent.
+          using Index = typename std::decay_t<decltype(output32)>::Index;
 
-    for (int i = 0; i < Dims; ++i) {
-      padding_dims[i] = Eigen::IndexPair<int32_t>(padding(i, 0), padding(i, 1));
-    }
+          Eigen::array<Eigen::IndexPair<Index>, Dims> padding_dims;
+          for (int i = 0; i < Dims; ++i) {
+            padding_dims[i] =
+                Eigen::IndexPair<Index>(padding(i, 0), padding(i, 1));
+          }
 
-    output.device(device) = MirrorPadOp(input, padding_dims, offset);
+          output32.device(device) = MirrorPadOp(input32, padding_dims, offset);
+        },
+        output, input);
   }
 
   template <typename PaddingDimensions, typename Derived>
@@ -364,74 +374,82 @@ struct MirrorPad {
 // values are replicated (offset == 0) or not replicated (offset == 1).
 template <typename Device, typename T, typename Tpaddings, int Dims>
 struct MirrorPadGrad {
-  void operator()(const Device& device,
-                  typename TTypes<T, Dims, int32_t>::Tensor output,
-                  typename TTypes<T, Dims, int32_t>::ConstTensor input,
+  void operator()(const Device& device, typename TTypes<T, Dims>::Tensor output,
+                  typename TTypes<T, Dims>::ConstTensor input,
                   typename TTypes<Tpaddings>::ConstMatrix paddings, int offset,
-                  typename TTypes<T, Dims, int32_t>::Tensor scratch) {
-    // Copy the gradient input into the scratch buffer.
-    scratch.device(device) = input;
+                  typename TTypes<T, Dims>::Tensor scratch) {
+    MaybeWith32BitIndexing<Device>(
+        [&](auto output32, auto input32, auto scratch32) {
+          // The offset and extent arrays must use the same index type as the
+          // tensors they slice, or they silently narrow the very dimensions
+          // this indexing is widened to represent.
+          using Index = typename std::decay_t<decltype(scratch32)>::Index;
 
-    Eigen::array<int32_t, Dims> lhs_offsets;
-    Eigen::array<int32_t, Dims> rhs_offsets;
-    Eigen::array<int32_t, Dims> extents;
-    Eigen::array<bool, Dims> reverses;
+          // Copy the gradient input into the scratch buffer.
+          scratch32.device(device) = input32;
 
-    for (int i = 0; i < Dims; ++i) {
-      lhs_offsets[i] = 0;
-      rhs_offsets[i] = 0;
-      extents[i] = scratch.dimension(i);
-      reverses[i] = false;
-    }
+          Eigen::array<Index, Dims> lhs_offsets;
+          Eigen::array<Index, Dims> rhs_offsets;
+          Eigen::array<Index, Dims> extents;
+          Eigen::array<bool, Dims> reverses;
 
-    // At this point, the central part (non-padded area) does not include the
-    // gradients back-propagated through padded areas. Those gradient components
-    // need be added to the central part.
-    //
-    // Note that a gradient input element falls into a padded area iff in at
-    // least one dimension i, the coordinate x(i) is in the range (python-style)
-    // [:paddings(i,0)] or [-paddings(i,1):].
+          for (int i = 0; i < Dims; ++i) {
+            lhs_offsets[i] = 0;
+            rhs_offsets[i] = 0;
+            extents[i] = scratch32.dimension(i);
+            reverses[i] = false;
+          }
 
-    for (int i = 0; i < Dims; ++i) {
-      reverses[i] = true;
+          // At this point, the central part (non-padded area) does not include
+          // the gradients back-propagated through padded areas. Those gradient
+          // components need be added to the central part.
+          //
+          // Note that a gradient input element falls into a padded area iff in
+          // at least one dimension i, the coordinate x(i) is in the range
+          // (python-style) [:paddings(i,0)] or [-paddings(i,1):].
 
-      // This handles the case when coordinate in dimension i is in the range
-      // [:paddings(i,0)]. This portion is added to the range
-      // [paddings(i,0) + offset:2 * paddings(i,0) + offset].
-      if (paddings(i, 0) > 0) {
-        rhs_offsets[i] = 0;
-        lhs_offsets[i] = paddings(i, 0) + offset;
-        extents[i] = paddings(i, 0);
+          for (int i = 0; i < Dims; ++i) {
+            reverses[i] = true;
 
-        scratch.slice(lhs_offsets, extents).device(device) +=
-            scratch.slice(rhs_offsets, extents).reverse(reverses);
-      }
+            // This handles the case when coordinate in dimension i is in the
+            // range [:paddings(i,0)]. This portion is added to the range
+            // [paddings(i,0) + offset:2 * paddings(i,0) + offset].
+            if (paddings(i, 0) > 0) {
+              rhs_offsets[i] = 0;
+              lhs_offsets[i] = paddings(i, 0) + offset;
+              extents[i] = paddings(i, 0);
 
-      // This handles the case when coordinate in dimension i is in the range
-      // [-paddings(i,1):]. This portion is added to the range
-      // [-2 * paddings(i,1) - offset:-paddings(i,1) - offset].
-      if (paddings(i, 1) > 0) {
-        rhs_offsets[i] = scratch.dimension(i) - paddings(i, 1);
-        lhs_offsets[i] = rhs_offsets[i] - paddings(i, 1) - offset;
-        extents[i] = paddings(i, 1);
+              scratch32.slice(lhs_offsets, extents).device(device) +=
+                  scratch32.slice(rhs_offsets, extents).reverse(reverses);
+            }
 
-        scratch.slice(lhs_offsets, extents).device(device) +=
-            scratch.slice(rhs_offsets, extents).reverse(reverses);
-      }
+            // This handles the case when coordinate in dimension i is in the
+            // range [-paddings(i,1):]. This portion is added to the range
+            // [-2 * paddings(i,1) - offset:-paddings(i,1) - offset].
+            if (paddings(i, 1) > 0) {
+              rhs_offsets[i] = scratch32.dimension(i) - paddings(i, 1);
+              lhs_offsets[i] = rhs_offsets[i] - paddings(i, 1) - offset;
+              extents[i] = paddings(i, 1);
 
-      reverses[i] = false;
-      lhs_offsets[i] = paddings(i, 0);
-      rhs_offsets[i] = paddings(i, 0);
-      extents[i] = output.dimension(i);
+              scratch32.slice(lhs_offsets, extents).device(device) +=
+                  scratch32.slice(rhs_offsets, extents).reverse(reverses);
+            }
 
-      // At this point, scratch buffer contains gradient input as if paddings
-      // for dimension k = 0,...,i are zeros. Therefore after the loop
-      // termination, the central part of the scratch buffer contains the folded
-      // gradients.
-    }
+            reverses[i] = false;
+            lhs_offsets[i] = paddings(i, 0);
+            rhs_offsets[i] = paddings(i, 0);
+            extents[i] = output32.dimension(i);
 
-    // Copy the central part of the scratch buffer to the output.
-    output.device(device) = scratch.slice(rhs_offsets, extents);
+            // At this point, scratch buffer contains gradient input as if
+            // paddings for dimension k = 0,...,i are zeros. Therefore after the
+            // loop termination, the central part of the scratch buffer contains
+            // the folded gradients.
+          }
+
+          // Copy the central part of the scratch buffer to the output.
+          output32.device(device) = scratch32.slice(rhs_offsets, extents);
+        },
+        output, input, scratch);
   }
 };
 }  // namespace functor

--- a/tensorflow/python/kernel_tests/array_ops/BUILD
+++ b/tensorflow/python/kernel_tests/array_ops/BUILD
@@ -481,6 +481,18 @@ cuda_py_strict_test(
     ],
 )
 
+tf_py_strict_test(
+    name = "large_mirror_pad_op_test",
+    size = "medium",
+    srcs = ["large_mirror_pad_op_test.py"],
+    deps = [
+        "//tensorflow/python/framework:for_generated_wrappers",
+        "//tensorflow/python/ops:array_ops",
+        "//tensorflow/python/ops:math_ops",
+        "//tensorflow/python/platform:client_testlib",
+    ],
+)
+
 cuda_py_strict_test(
     name = "manip_ops_test",
     size = "medium",

--- a/tensorflow/python/kernel_tests/array_ops/large_mirror_pad_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/large_mirror_pad_op_test.py
@@ -1,0 +1,53 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Functional tests for MirrorPad Op."""
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test
+
+
+class LargeMirrorPadOpTest(test.TestCase):
+  """Tests that belong in pad_op_test.py, but run over large tensors."""
+
+  def testMirrorPadLargeTensor(self):
+    # Regression test for a silent wrong result when the padded output has
+    # more than 2**31 elements. MirrorPad used to hand its tensors to Eigen
+    # through To32Bit() unconditionally, so the output element count was
+    # truncated to int32 and the assignment loop ran the wrong number of
+    # iterations, leaving part or all of the output unwritten.
+    #
+    # Rank 5 keeps the input small: REFLECT requires each padding to be less
+    # than its dimension, so 24 on both sides of a dimension of 25 gives 73,
+    # and 25 on both sides of a dimension of 26 gives 76. That is
+    # 73**4 * 76 = 2,158,266,316 output elements, over 2**31 by 10,782,668,
+    # from a 10 MB input.
+    #
+    # CPU-only test, because the output alone needs 2.2 GB.
+    with ops.device("/cpu:0"):
+      x = array_ops.ones([25, 25, 25, 25, 26], dtype=dtypes.uint8)
+      padded = array_ops.pad(
+          x, [[24, 24]] * 4 + [[25, 25]], mode="REFLECT")
+    with self.session(use_gpu=False):
+      self.assertEqual([73] * 4 + [76], padded.shape.as_list())
+      # Reflecting only ever copies existing elements, so every element of
+      # the result must be the 1 it was built from.
+      self.assertEqual(1, self.evaluate(math_ops.reduce_min(padded)))
+      self.assertEqual(1, self.evaluate(math_ops.reduce_max(padded)))
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
`tf.pad(..., mode='REFLECT')` returns a silently wrong result when the padded output has more than 2^31 elements. The shape is right and no error is raised, so the failure is invisible at the call site.

On TF 2.21.0, CPU, with a uint8 input of all ones (reflect only copies existing elements, so every output element must also be 1):

| input | output elements | vs INT32_MAX | reduce_min / reduce_max |
|---|---|---|---|
| [1000, 1000, 2000] | 2,100,000,000 | under | 1 / 1 |
| [1000, 1000, 2100] | 2,205,000,000 | over | 0 / 0 |

The only difference is the last axis, which moves the output element count across the boundary. Repeated 5 times, identical each run.

### Cause

`MirrorPadOp::Compute` passed its tensors to the functor through `To32Bit()` with no size check, and the functors declared their operands as `TTypes<T, Dims, int32_t>`. `To32Bit` states this precondition itself at `tensor_types.h:158`, `DCHECK(SafeFor32BitIndexing(in))`, but a DCHECK is compiled out of release builds, so the narrowing happened silently. Eigen's assignment then ran `total mod 2^32` iterations.

That last detail is testable, so I tested it. With an output of 4,299,161,600 elements, which is `2^32 + 4,194,304`, the truncated count is positive rather than negative, and exactly the first 4,194,304 elements come back written while the remainder stays zero. The all-zero result in the table above is the negative-truncation case of the same mechanism. Between 2^32 and 2^33 a caller gets a partially correct answer instead.

### Fix

`functor::MirrorPad` and `functor::MirrorPadGrad` now take `TTypes<T, Dims>` operands and wrap their bodies in `MaybeWith32BitIndexing<Device>`, matching `pad_op.h`. The five `To32Bit()` calls and the `, int32` in the four `DECLARE_*_SPEC` macros are gone. On CPU the generic template passes tensors through at their native index type; the `GpuDevice` specialization keeps the 32-bit fast path and checks `SafeFor32BitIndexing` on every operand before using it. The explicit instantiation lists, the five CPU shards and the `.cu.cc` are untouched, because the narrowing now happens inside the already instantiated functor.

`MirrorPadGrad` needed one thing beyond the signature change: its `lhs_offsets`, `rhs_offsets` and `extents` arrays were declared `Eigen::array<int32_t, Dims>` and assigned from tensor dimensions, which is a second narrowing on the same path. They now use the operands' own index type.

I included `MirrorPadGrad` because it carries the identical unguarded conversion in the same file. Say the word if you would rather it went separately.

### Test

`large_mirror_pad_op_test.py`, alongside the existing `large_concat_op_test.py` and following its structure. Rank 5 keeps the input at 10 MB: REFLECT requires each padding to be smaller than its dimension, so padding 24 on both sides of 25 gives 73 for four axes and padding 25 on both sides of 26 gives 76 for one, and 73^4 * 76 is 2,158,266,316 output elements. On the unpatched build the test's own assertions fail, `reduce_min` and `reduce_max` both returning 0 instead of 1.

### What I have not verified

I did not build TensorFlow for this, so CI is the first thing to compile the change and the first to run the new test against it. I also have no before-and-after measurement of CPU throughput at 64-bit index on a single build; the argument that it is acceptable rests on `pad_op.h`, `slice_op.h` and `strided_slice_op.h` already making the same trade.

Fixes #91027

