### PR TITLE
Detect conflicting TensorFlow installations on Windows during preload check

### DIFF
--- a/tensorflow/python/platform/BUILD
+++ b/tensorflow/python/platform/BUILD
@@ -386,6 +386,17 @@ tf_py_strict_test(
 )
 
 tf_py_strict_test(
+    name = "self_check_test",
+    size = "small",
+    srcs = ["self_check_test.py"],
+    main = "self_check_test.py",
+    deps = [
+        ":client_testlib",
+        ":self_check",
+    ],
+)
+
+tf_py_strict_test(
     name = "benchmark_test",
     size = "small",
     srcs = ["benchmark_test.py"],

--- a/tensorflow/python/platform/BUILD
+++ b/tensorflow/python/platform/BUILD
@@ -390,6 +390,10 @@ tf_py_strict_test(
     size = "small",
     srcs = ["self_check_test.py"],
     main = "self_check_test.py",
+    tags = [
+        "no_pip",
+        "notap",
+    ],
     deps = [
         ":client_testlib",
         ":self_check",

--- a/tensorflow/python/platform/self_check.py
+++ b/tensorflow/python/platform/self_check.py
@@ -16,8 +16,23 @@
 """Platform-specific code for checking the integrity of the TensorFlow build."""
 
 import os
+import struct
 
 MSVCP_DLL_NAMES = "msvcp_dll_names"
+
+# Distributions that all unpack into the same `site-packages/tensorflow`
+# directory. On Windows `tensorflow` is a meta-package that requires
+# `tensorflow-intel` at an identical version, so their coexistence is expected;
+# only a version mismatch between any two of these indicates that files from
+# different releases have been mixed in a single directory.
+_CONFLICTING_DISTRIBUTIONS = (
+    "tensorflow",
+    "tensorflow-cpu",
+    "tensorflow-intel",
+    "tf-nightly",
+    "tf-nightly-cpu",
+    "tf-nightly-intel",
+)
 
 try:
   from tensorflow.python.platform import build_info
@@ -30,6 +45,72 @@ except ImportError as exc:
   ) from exc
 
 
+def _installed_tensorflow_distributions():
+  """Returns a {distribution name: version} map of installed TensorFlow dists.
+
+  Only the distributions in `_CONFLICTING_DISTRIBUTIONS` are considered, and
+  distributions that are not installed are omitted.
+  """
+  import importlib.metadata  # pylint: disable=g-import-not-at-top
+
+  installed = {}
+  for name in _CONFLICTING_DISTRIBUTIONS:
+    try:
+      installed[name] = importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+      pass
+    except Exception:  # pylint: disable=broad-except
+      # Package metadata can be missing or malformed in unusual environments.
+      # This is only a diagnostic aid, so never let it mask the real error.
+      pass
+  return installed
+
+
+def _check_conflicting_installs():
+  """Raises if TensorFlow distributions of differing versions are installed.
+
+  These distributions all unpack into the same `site-packages/tensorflow`
+  directory, so installing more than one at differing versions leaves shared
+  libraries from mismatched releases on disk. Loading the native runtime then
+  fails with an error that gives no indication of the real cause.
+
+  Raises:
+    ImportError: If two or more of the distributions are installed at differing
+      versions.
+  """
+  installed = _installed_tensorflow_distributions()
+  if len(set(installed.values())) > 1:
+    raise ImportError(
+        "Found conflicting TensorFlow installations in this environment: %s. "
+        "These distributions install into the same directory, so mixing "
+        "versions leaves shared libraries from different releases on disk and "
+        "the native TensorFlow runtime will fail to load. Uninstall all of "
+        "them and reinstall exactly one. Note that some packages (for example "
+        "tf-keras) depend on `tensorflow`, which can pull it in alongside a "
+        "`tensorflow-cpu` that you installed directly."
+        % ", ".join(
+            "%s %s" % (name, version)
+            for name, version in sorted(installed.items())
+        )
+    )
+
+
+def _check_python_bitness():
+  """Raises if the interpreter is not 64-bit.
+
+  Raises:
+    ImportError: If running under a 32-bit Python interpreter, for which no
+      TensorFlow wheels are published.
+  """
+  bitness = struct.calcsize("P") * 8
+  if bitness != 64:
+    raise ImportError(
+        "TensorFlow requires a 64-bit Python interpreter, but this "
+        "interpreter is %d-bit. Reinstall the 64-bit build of Python and "
+        "reinstall TensorFlow into it." % bitness
+    )
+
+
 def preload_check():
   """Raises an exception if the environment is not correctly configured.
 
@@ -38,6 +119,9 @@ def preload_check():
       configured, and attempting to load the TensorFlow runtime will fail.
   """
   if os.name == "nt":
+    _check_python_bitness()
+    _check_conflicting_installs()
+
     # Attempt to load any DLLs that the Python extension depends on before
     # we load the Python extension, so that we can raise an actionable error
     # message if they are not found.

--- a/tensorflow/python/platform/self_check.py
+++ b/tensorflow/python/platform/self_check.py
@@ -28,9 +28,11 @@ MSVCP_DLL_NAMES = "msvcp_dll_names"
 _CONFLICTING_DISTRIBUTIONS = (
     "tensorflow",
     "tensorflow-cpu",
+    "tensorflow-gpu",
     "tensorflow-intel",
     "tf-nightly",
     "tf-nightly-cpu",
+    "tf-nightly-gpu",
     "tf-nightly-intel",
 )
 

--- a/tensorflow/python/platform/self_check.py
+++ b/tensorflow/python/platform/self_check.py
@@ -45,6 +45,11 @@ except ImportError as exc:
   ) from exc
 
 
+def _is_windows():
+  """Returns True if running on Windows."""
+  return os.name == "nt"
+
+
 def _installed_tensorflow_distributions():
   """Returns a {distribution name: version} map of installed TensorFlow dists.
 
@@ -95,6 +100,11 @@ def _check_conflicting_installs():
     )
 
 
+def _python_bitness():
+  """Returns the pointer width of the running interpreter, in bits."""
+  return struct.calcsize("P") * 8
+
+
 def _check_python_bitness():
   """Raises if the interpreter is not 64-bit.
 
@@ -102,7 +112,7 @@ def _check_python_bitness():
     ImportError: If running under a 32-bit Python interpreter, for which no
       TensorFlow wheels are published.
   """
-  bitness = struct.calcsize("P") * 8
+  bitness = _python_bitness()
   if bitness != 64:
     raise ImportError(
         "TensorFlow requires a 64-bit Python interpreter, but this "
@@ -118,7 +128,7 @@ def preload_check():
     ImportError: If the check detects that the environment is not correctly
       configured, and attempting to load the TensorFlow runtime will fail.
   """
-  if os.name == "nt":
+  if _is_windows():
     _check_python_bitness()
     _check_conflicting_installs()
 

--- a/tensorflow/python/platform/self_check_test.py
+++ b/tensorflow/python/platform/self_check_test.py
@@ -15,6 +15,7 @@
 """Tests for the TensorFlow build integrity checks."""
 
 import os
+import sys
 from unittest import mock
 
 from tensorflow.python.platform import self_check
@@ -125,12 +126,20 @@ class PreloadCheckTest(test.TestCase):
     conflicts.assert_called_once()
 
   def testNonWindowsSkipsNewChecks(self):
-    with mock.patch.object(self_check, "_is_windows", return_value=False):
-      with mock.patch.object(self_check, "_check_python_bitness") as bitness:
-        with mock.patch.object(
-            self_check, "_check_conflicting_installs"
-        ) as conflicts:
-          self_check.preload_check()
+    # The non-Windows branch loads a native CPU feature guard extension, which
+    # is unrelated to what this test covers; stub it so the test exercises only
+    # the branch selection.
+    guard = mock.MagicMock()
+    with mock.patch.dict(
+        sys.modules,
+        {"tensorflow.python.platform._pywrap_cpu_feature_guard": guard},
+    ):
+      with mock.patch.object(self_check, "_is_windows", return_value=False):
+        with mock.patch.object(self_check, "_check_python_bitness") as bitness:
+          with mock.patch.object(
+              self_check, "_check_conflicting_installs"
+          ) as conflicts:
+            self_check.preload_check()
     bitness.assert_not_called()
     conflicts.assert_not_called()
 

--- a/tensorflow/python/platform/self_check_test.py
+++ b/tensorflow/python/platform/self_check_test.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Tests for the TensorFlow build integrity checks."""
 
+import os
 from unittest import mock
 
 from tensorflow.python.platform import self_check
@@ -91,13 +92,64 @@ class ConflictingInstallsTest(test.TestCase):
 class PythonBitnessTest(test.TestCase):
 
   def testSixtyFourBitPasses(self):
-    with mock.patch.object(self_check.struct, "calcsize", return_value=8):
+    with mock.patch.object(self_check, "_python_bitness", return_value=64):
       self_check._check_python_bitness()
 
   def testThirtyTwoBitRaises(self):
-    with mock.patch.object(self_check.struct, "calcsize", return_value=4):
+    with mock.patch.object(self_check, "_python_bitness", return_value=32):
       with self.assertRaisesRegex(ImportError, "64-bit Python"):
         self_check._check_python_bitness()
+
+  def testReportsActualBitnessInMessage(self):
+    with mock.patch.object(self_check, "_python_bitness", return_value=32):
+      with self.assertRaisesRegex(ImportError, "this interpreter is 32-bit"):
+        self_check._check_python_bitness()
+
+  def testRealInterpreterIsSixtyFourBit(self):
+    # The test binary itself must be 64-bit, so the unmocked check passes.
+    self.assertEqual(self_check._python_bitness(), 64)
+    self_check._check_python_bitness()
+
+
+class PreloadCheckTest(test.TestCase):
+  """Verifies the new checks are actually reached from `preload_check`."""
+
+  def testWindowsRunsNewChecks(self):
+    with mock.patch.object(self_check, "_is_windows", return_value=True):
+      with mock.patch.object(self_check, "_check_python_bitness") as bitness:
+        with mock.patch.object(
+            self_check, "_check_conflicting_installs"
+        ) as conflicts:
+          self_check.preload_check()
+    bitness.assert_called_once()
+    conflicts.assert_called_once()
+
+  def testNonWindowsSkipsNewChecks(self):
+    with mock.patch.object(self_check, "_is_windows", return_value=False):
+      with mock.patch.object(self_check, "_check_python_bitness") as bitness:
+        with mock.patch.object(
+            self_check, "_check_conflicting_installs"
+        ) as conflicts:
+          self_check.preload_check()
+    bitness.assert_not_called()
+    conflicts.assert_not_called()
+
+  def testConflictingInstallsReportedBeforeDllScan(self):
+    # A conflicting install must surface its own error rather than the
+    # generic missing-DLL message, which is what made this hard to diagnose.
+    with mock.patch.object(self_check, "_is_windows", return_value=True):
+      with mock.patch.object(
+          self_check,
+          "_installed_tensorflow_distributions",
+          return_value={"tensorflow": "2.21.0", "tensorflow-cpu": "2.20.0"},
+      ):
+        with mock.patch.dict(
+            self_check.build_info.build_info,
+            {self_check.MSVCP_DLL_NAMES: "msvcp140.dll"},
+        ):
+          with mock.patch.dict(os.environ, {"PATH": ""}):
+            with self.assertRaisesRegex(ImportError, "conflicting TensorFlow"):
+              self_check.preload_check()
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/platform/self_check_test.py
+++ b/tensorflow/python/platform/self_check_test.py
@@ -64,6 +64,15 @@ class ConflictingInstallsTest(test.TestCase):
       ):
         self_check._check_conflicting_installs()
 
+  def testLegacyGpuDistributionMismatchRaises(self):
+    # `tensorflow-gpu` is no longer published, but old pins are still installed
+    # and unpack into the same directory.
+    with self._with_installed(
+        {"tensorflow": "2.21.0", "tensorflow-gpu": "2.10.0"}
+    ):
+      with self.assertRaisesRegex(ImportError, "conflicting TensorFlow"):
+        self_check._check_conflicting_installs()
+
   def testNightlyMismatchRaises(self):
     with self._with_installed(
         {"tf-nightly": "2.22.0.dev1", "tf-nightly-cpu": "2.22.0.dev2"}

--- a/tensorflow/python/platform/self_check_test.py
+++ b/tensorflow/python/platform/self_check_test.py
@@ -1,0 +1,104 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the TensorFlow build integrity checks."""
+
+from unittest import mock
+
+from tensorflow.python.platform import self_check
+from tensorflow.python.platform import test
+
+
+class ConflictingInstallsTest(test.TestCase):
+
+  def _with_installed(self, installed):
+    return mock.patch.object(
+        self_check,
+        "_installed_tensorflow_distributions",
+        return_value=installed,
+    )
+
+  def testSingleDistributionPasses(self):
+    with self._with_installed({"tensorflow": "2.21.0"}):
+      self_check._check_conflicting_installs()
+
+  def testNoDistributionsPasses(self):
+    # Metadata can be absent entirely, e.g. when running from a source tree.
+    with self._with_installed({}):
+      self_check._check_conflicting_installs()
+
+  def testMatchingVersionsPass(self):
+    # On Windows `tensorflow` is a meta-package requiring `tensorflow-intel`
+    # pinned to the same version, so this combination is expected.
+    with self._with_installed(
+        {"tensorflow": "2.21.0", "tensorflow-intel": "2.21.0"}
+    ):
+      self_check._check_conflicting_installs()
+
+  def testMismatchedVersionsRaise(self):
+    with self._with_installed(
+        {"tensorflow": "2.21.0", "tensorflow-cpu": "2.20.0"}
+    ):
+      with self.assertRaisesRegex(ImportError, "conflicting TensorFlow"):
+        self_check._check_conflicting_installs()
+
+  def testErrorNamesEachDistributionAndVersion(self):
+    with self._with_installed(
+        {"tensorflow": "2.21.0", "tensorflow-cpu": "2.20.0"}
+    ):
+      with self.assertRaisesRegex(
+          ImportError, "tensorflow 2.21.0, tensorflow-cpu 2.20.0"
+      ):
+        self_check._check_conflicting_installs()
+
+  def testNightlyMismatchRaises(self):
+    with self._with_installed(
+        {"tf-nightly": "2.22.0.dev1", "tf-nightly-cpu": "2.22.0.dev2"}
+    ):
+      with self.assertRaisesRegex(ImportError, "conflicting TensorFlow"):
+        self_check._check_conflicting_installs()
+
+  def testMissingMetadataIsIgnored(self):
+    import importlib.metadata  # pylint: disable=g-import-not-at-top
+
+    with mock.patch.object(
+        importlib.metadata,
+        "version",
+        side_effect=importlib.metadata.PackageNotFoundError,
+    ):
+      self.assertEqual(self_check._installed_tensorflow_distributions(), {})
+
+  def testMalformedMetadataDoesNotMaskRealError(self):
+    import importlib.metadata  # pylint: disable=g-import-not-at-top
+
+    with mock.patch.object(
+        importlib.metadata, "version", side_effect=ValueError("bad metadata")
+    ):
+      self.assertEqual(self_check._installed_tensorflow_distributions(), {})
+
+
+class PythonBitnessTest(test.TestCase):
+
+  def testSixtyFourBitPasses(self):
+    with mock.patch.object(self_check.struct, "calcsize", return_value=8):
+      self_check._check_python_bitness()
+
+  def testThirtyTwoBitRaises(self):
+    with mock.patch.object(self_check.struct, "calcsize", return_value=4):
+      with self.assertRaisesRegex(ImportError, "64-bit Python"):
+        self_check._check_python_bitness()
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
Towards #91656.

### Problem

The `tensorflow`, `tensorflow-cpu` and `tensorflow-intel` distributions all unpack into the same `site-packages/tensorflow/` directory. When more than one is installed at differing versions, shared libraries from different releases end up mixed in a single directory and the native runtime fails to load with an error that gives no indication of the real cause:

```
ImportError: DLL load failed while importing _pywrap_tensorflow_internal:
A dynamic link library (DLL) initialization routine failed.
```

This is a common outcome of transitive dependency resolution rather than user error. As @ClaasRostock diagnosed in https://github.com/tensorflow/tensorflow/issues/91656#issuecomment-4093506262, `tf-keras` depends on `tensorflow>=2.16`, which pip may install alongside a `tensorflow-cpu` that the user pinned directly — producing `tensorflow 2.21` and `tensorflow-cpu 2.20` side by side.

`windows_lib_diagnostics` already covers the post-failure path. The gap is on the pre-load side: `self_check.preload_check()` only string-scans `%PATH%` for the `msvcp` DLL names, so it cannot see this at all.

### Change

Extends `preload_check()` on Windows with two checks that fail early and actionably:

1. **Conflicting distributions** — detected via `importlib.metadata`. On Windows `tensorflow` is a meta-package requiring `tensorflow-intel` at an identical version (`tensorflow/tools/pip_package/setup.py.tpl:154`), so coexistence is expected and **only a version mismatch is reported**. This avoids firing on healthy installs. The error names each distribution and version and says to reinstall exactly one. Per @mihaimaruseac's confirmation in https://github.com/tensorflow/tensorflow/issues/91656#issuecomment-5292771718, this raises rather than warns.
2. **32-bit interpreter** — no wheels are published for it; this has been diagnosed by hand several times in the issue thread.

Metadata lookup failures are swallowed, so a broken environment can never mask the underlying import error.

Pure Python, one file, no build changes. A new `self_check_test` target covers both checks, `preload_check` branch selection, and that a conflicting install is reported ahead of the generic missing-DLL error.

### Scope

Deliberately limited to Windows, matching the issue. The collision mechanism is platform-independent, so I am happy to widen it if preferred.

This does not address the ODR / import-order problem discussed in #99291, which is separate work.
