### PR TITLE
Fix confusion of `clang-format`/`clang-tidy` in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,10 +172,10 @@ Bazel BUILD files also need to include a license section, e.g.,
 Changes to TensorFlow C++ code should conform to
 [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
 
-Use `clang-tidy` to check your C/C++ changes. To install `clang-tidy` on ubuntu:16.04, do:
+Use `clang-format` to check your C/C++ changes. To install `clang-format` on Ubuntu, do:
 
 ```bash
-apt-get install -y clang-tidy
+sudo apt-get install -y clang-format
 ```
 
 You can check a C/C++ file by doing:


### PR DESCRIPTION
The example shows using `clang-format` but the sentences before talk about `clang-tidy`. From the related Python paragraph it can be inferred that clang-format is intended.

Also remove the docker-like reference to an outdated Ubuntu and add `sudo` to `apt-get` for clarity