### PR TITLE
Fix typo in CODEOWNERS path (tenosrflow -> tensorflow)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 
 /tensorflow/c/eager @qqfish
 /tensorflow/core/common_runtime/eager @qqfish
-/tenosrflow/core/debug @caisq
+/tensorflow/core/debug @caisq
 /tensorflow/core/kernels/mkl/ @penpornk
 /tensorflow/core/kernels/sparse/ @penpornk
 /tensorflow/core/nccl/ @azaks2 @chsigg


### PR DESCRIPTION
## Summary
Resolves the stale reference in CODEOWNERS.

Update CODEOWNERS line 5 to: `/tensorflow/core/debug`

## Test

```
# the stale line
sed -n '5p' CODEOWNERS

# tracked files under the referenced path, 0 before this PR
git ls-files -- 'tenosrflow/' | wc -l
```

## Additional information
Since 2018, 191 commits changed the directory over 2908 days without a matching CODEOWNERS rule.

I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.