### PR TITLE
fix(array_ops): align eager and compiled graph behavior for single tensor tf.stack

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
@@ -29,6 +29,7 @@ from tensorflow.python.ops import array_ops_stack
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
 
@@ -394,6 +395,27 @@ class AutomaticStackingTest(test.TestCase):
 
     t_2 = ops.convert_to_tensor([t_0, t_0, t_1], dtype=dtypes.float64)
     self.assertEqual(dtypes.float64, t_2.dtype)
+
+
+  def testSingleTensorInput(self):
+    t = constant_op.constant([1, 2, 3])
+    stacked_axis0 = array_ops_stack.stack(t, axis=0)
+    self.assertAllEqual(self.evaluate(stacked_axis0), [[1, 2, 3]])
+
+    stacked_axis1 = array_ops_stack.stack(t, axis=1)
+    self.assertAllEqual(self.evaluate(stacked_axis1), [[1], [2], [3]])
+
+    v = variables.Variable([1, 2, 3])
+    self.evaluate(variables.global_variables_initializer())
+    stacked_var = array_ops_stack.stack(v, axis=0)
+    self.assertAllEqual(self.evaluate(stacked_var), [[1, 2, 3]])
+
+    @def_function.function
+    def compiled_stack(x):
+      return array_ops_stack.stack(x, axis=0)
+
+    result = compiled_stack(t)
+    self.assertAllEqual(self.evaluate(result), [[1, 2, 3]])
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/array_ops_stack.py
+++ b/tensorflow/python/ops/array_ops_stack.py
@@ -15,6 +15,7 @@
 # Tests for this file live in python/kernel_tests/array_ops_test.py
 """Operations to stack and unstack tensors."""
 
+from tensorflow.python.framework import composite_tensor
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.util import dispatch
@@ -68,6 +69,9 @@ def stack(values, axis=0, name="stack"):
   Raises:
     ValueError: If `axis` is out of the range [-(R+1), R+1).
   """
+  if isinstance(values, (ops.Tensor, composite_tensor.CompositeTensor)):
+    values = [values]
+
   if axis == 0:
     try:
       # If the input is a constant list, it can be converted to a constant op

--- a/tensorflow/python/ops/array_ops_stack.py
+++ b/tensorflow/python/ops/array_ops_stack.py
@@ -15,8 +15,8 @@
 # Tests for this file live in python/kernel_tests/array_ops_test.py
 """Operations to stack and unstack tensors."""
 
-from tensorflow.python.framework import composite_tensor
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.util import dispatch
 from tensorflow.python.util.tf_export import tf_export
@@ -69,7 +69,7 @@ def stack(values, axis=0, name="stack"):
   Raises:
     ValueError: If `axis` is out of the range [-(R+1), R+1).
   """
-  if ops.is_tensor(values) or isinstance(values, composite_tensor.CompositeTensor):
+  if tensor_util.is_tensor(values):
     values = [values]
 
   if axis == 0:

--- a/tensorflow/python/ops/array_ops_stack.py
+++ b/tensorflow/python/ops/array_ops_stack.py
@@ -69,7 +69,7 @@ def stack(values, axis=0, name="stack"):
   Raises:
     ValueError: If `axis` is out of the range [-(R+1), R+1).
   """
-  if isinstance(values, (ops.Tensor, composite_tensor.CompositeTensor)):
+  if ops.is_tensor(values) or isinstance(values, composite_tensor.CompositeTensor):
     values = [values]
 
   if axis == 0:


### PR DESCRIPTION
Fixes #125374

### Description
Calling `tf.stack` with a single bare `Tensor` (rather than a list or tuple of tensors) currently behaves inconsistently across execution modes. Under eager execution, `tf.stack` silently returns the single `Tensor` unstacked, whereas under `jit_compile=True` or autoclustering, it raises a `TypeError` from the underlying `Pack` op.

### Fix
Updated `tf.stack` in `tensorflow/python/ops/array_ops_stack.py` to check if `values` is an instance of `Tensor` or `CompositeTensor` and normalize it into a list `[values]` prior to graph/op construction, ensuring consistent stacking behavior across both eager and compiled graph execution paths.