### PR TITLE
array_ops: validate out_type in shape()'s constant-folding path

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/shape_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/shape_ops_test.py
@@ -147,6 +147,15 @@ class ShapeOpsTest(test.TestCase):
     self._testAll(np.random.randn(2, 3, 5, 7, 11))
     self._testAll(np.random.randn(2, 3, 5, 7, 11, 13))
 
+  @test_util.run_deprecated_v1
+  def testOutTypeMustBeIntegral(self):
+    # Regression test: when the input's shape is fully known at graph
+    # construction time, shape() takes a constant-folding shortcut that
+    # used to skip the out_type validation the Shape op itself enforces.
+    x = constant_op.constant([1.0, 2.0, 3.0, 4.0])
+    with self.assertRaisesRegex(ValueError, "out_type"):
+      array_ops.shape(x, out_type=dtypes.float32)
+
   def testBool(self):
     self._testAll(np.random.choice((False, True), size=(2,)))
     self._testAll(np.random.choice((False, True), size=(2, 3)))

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -737,7 +737,7 @@ def shape_internal(input, name=None, optimize=True, out_type=None):
             return constant_op._tensor_shape_tensor_conversion_function(  # pylint: disable=protected-access
                 input_shape)
           if out_type not in (dtypes.int32, dtypes.int64):
-            raise ValueError("Argument `out_type` must be int32 or int64; got"
+            raise ValueError("Argument `out_type` must be int32 or int64; got "
                               f"{out_type!r}")
           return constant(input_shape.as_list(), out_type, name=name)
       if not out_type:

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -736,6 +736,9 @@ def shape_internal(input, name=None, optimize=True, out_type=None):
           if not out_type:
             return constant_op._tensor_shape_tensor_conversion_function(  # pylint: disable=protected-access
                 input_shape)
+          if out_type not in (dtypes.int32, dtypes.int64):
+            raise ValueError("Argument `out_type` must be int32 or int64; got"
+                              f"{out_type!r}")
           return constant(input_shape.as_list(), out_type, name=name)
       if not out_type:
         out_type = dtypes.int32


### PR DESCRIPTION
`tf.shape(x, out_type=...)` is supposed to reject anything other than
int32/int64 (the op's `out_type` attr is registered as `{int32, int64}`),
and eager execution does reject it. But `shape()` has a shortcut for
inputs whose static shape is already fully known: instead of building a
real `Shape` op it just returns `tf.constant(shape, dtype=out_type)`. That
path never checked `out_type` against the op's own allowed values, so
e.g. `out_type=tf.float32` would silently succeed and return a float
result whenever this shortcut is taken (any graph/tracing context with a
statically-shaped input — not XLA-specific, just easiest to notice there
since jit_compile=True/autoclustering hit it consistently while eager
didn't).

Added the same validation the underlying op would have applied, and a
regression test that exercises this exact path (`run_deprecated_v1` so it
actually traces a graph and takes the shortcut, rather than running
eagerly where the bug never showed up).

Fixes #125394

Tested: `python -m py_compile` on both changed files. Kicked off
`bazel test //tensorflow/python/kernel_tests/array_ops:shape_ops_test
--test_filter='*OutTypeMustBeIntegral*'` locally and let it run for about
an hour — it's a cold build (no prior cache for this target), and after
that hour it was still compiling core MLIR/XLA/LLVM dependencies
(~26k/30k actions), not yet at the actual test. Didn't want to sit on the
PR indefinitely waiting on that, so this is still source-verified and
py_compile-clean rather than test-run-verified locally. Should be quick
for CI or anyone with a warm bazel cache — happy to report back once
either finishes.
