### PR TITLE
Keep the argument's dtype in `tf.experimental.numpy.angle`

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -915,7 +915,13 @@ def angle(z, deg=False):  # pylint: disable=missing-function-docstring
   def f(x):
     if x.dtype in _tf_float_types:
       # Workaround for b/147515503
-      return array_ops.where_v2(x < 0, np.pi, 0)
+      # `np.pi` and `0` are Python scalars, which would make the result
+      # float32 whatever `x` is, so build them in `x`'s dtype instead.
+      return array_ops.where_v2(
+          x < 0,
+          constant_op.constant(np.pi, dtype=x.dtype),
+          constant_op.constant(0, dtype=x.dtype),
+      )
     else:
       return math_ops.angle(x)
 

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -159,6 +159,29 @@ class MathTest(test.TestCase, parameterized.TestCase):
   def testSqrt(self):
     self._testUnaryOp(np_math_ops.sqrt, np.sqrt, 'sqrt')
 
+  def testAngle(self):
+    # The result must keep the dtype of the argument. Building the real-input
+    # branch out of Python scalars made it float32 for every real dtype, which
+    # for float64 also cost precision.
+    for dtype in [np.float16, np.float32, np.float64]:
+      arg = np.array([-2.0, -0.5, 0.0, 0.5, 2.0], dtype=dtype)
+      self.match(
+          np_math_ops.angle(arg), np.angle(arg),
+          msg='angle({})'.format(arg))
+      self.match(
+          np_math_ops.angle(arg, deg=True), np.angle(arg, deg=True),
+          msg='angle({}, deg=True)'.format(arg))
+
+    for dtype in [np.complex64, np.complex128]:
+      arg = np.array([1 + 2j, -1 - 2j, 0j], dtype=dtype)
+      self.match(
+          np_math_ops.angle(arg), np.angle(arg),
+          msg='angle({})'.format(arg))
+
+    # An integer argument is promoted to the default float type.
+    arg = np.array([-3, 0, 3], dtype=np.int32)
+    self.match(np_math_ops.angle(arg), np.angle(arg), msg='angle(int32)')
+
   def testHypot(self):
     self._testBinaryOp(np_math_ops.hypot, np.hypot, 'hypot')
 


### PR DESCRIPTION
`tf.experimental.numpy.angle` returns float32 for every real argument, whatever dtype you gave it. For float64 that costs precision:

```python
>>> import numpy as np, tensorflow.experimental.numpy as tnp

>>> tnp.angle(np.array([-2.0], dtype=np.float64))
<tf.Tensor: shape=(1,), dtype=float32, numpy=array([3.1415927], dtype=float32)>

>>> np.angle(np.array([-2.0], dtype=np.float64))
array([3.14159265])
```

float16 and bfloat16 arguments widen to float32 the same way, and `deg=True` inherits the wrong type from the same place. An integer argument is promoted to the default float type and then hits it too, so it also comes back float32 instead of float64.

### Cause

The real-input branch builds its result out of two Python scalars:

```python
def f(x):
  if x.dtype in _tf_float_types:
    # Workaround for b/147515503
    return array_ops.where_v2(x < 0, np.pi, 0)
  else:
    return math_ops.angle(x)
```

`np.pi` and `0` convert to float32 by default, so `where_v2` produces float32 regardless of `x`, and `np.pi` is itself rounded to float32 on the way in — which is where the `3.1415927` above comes from. The complex branch was never affected, because `math_ops.angle` takes its result type from the argument.

### Fix

Build both branch values in `x`'s dtype. `heaviside` in this same module already handles the identical problem this way:

```python
return array_ops.where_v2(
    x1 < 0,
    constant_op.constant(0, dtype=x2.dtype),
    array_ops.where_v2(x1 > 0, constant_op.constant(1, dtype=x2.dtype), x2),
)
```

so this just follows the existing convention. `constant_op.constant(np.pi, dtype=x.dtype)` also converts straight to the target type rather than going through float32 first, so float64 keeps all of `np.pi`.

### Tests

`angle` had no test in `np_math_ops_test.py` at all, which is how this went unnoticed. Added `testAngle`, covering float16/float32/float64 with and without `deg=True`, complex64/complex128, and an integer argument for the promotion path, each compared against numpy for both dtype and value.

It fails on master with `tf.float32 != dtype('float16')` and passes with the change.

I don't have a Bazel build here, so I checked this by applying the change to an installed TF 2.21 wheel and running the updated `np_math_ops_test.py` against it. `testAngle` was the only difference: 12 failures before, 11 after. The 11 that remain fail identically with and without the change and are just this test file from master running against an older wheel — the `isclose` group, the `hypot` tests, and `testLinSpaceDtype`/`testLogSpaceDtype` from #124932, which the 2.21 wheel predates.

### User-facing change

`tnp.angle` now returns float16/bfloat16/float64 where it previously returned float32 for those inputs. That is the numpy behaviour and what the `np_doc` contract on this function promises, but code that depended on always receiving float32 will see a different dtype.
