### PR TITLE
Fix tf.tuple() AttributeError for tf.Variable inputs under tf.function

### DIFF
--- a/tensorflow/python/ops/control_flow_ops.py
+++ b/tensorflow/python/ops/control_flow_ops.py
@@ -2148,8 +2148,9 @@ def tuple(tensors, name=None, control_inputs=None):  # pylint: disable=redefined
     return tensors
   with ops.name_scope(name, "tuple", tensors) as name:
     tensors = [
-        t if (isinstance(t, ops.Operation) or tensor_util.is_tf_type(t) or
-              t is None) else ops.convert_to_tensor(t) for t in tensors
+        t if (isinstance(t, ops.Operation) or
+              isinstance(t, (tensor_lib.Tensor, indexed_slices.IndexedSlices))
+              or t is None) else ops.convert_to_tensor(t) for t in tensors
     ]
     gating_ops = [
         t if isinstance(t, ops.Operation) else t.op

--- a/tensorflow/python/ops/control_flow_ops_test.py
+++ b/tensorflow/python/ops/control_flow_ops_test.py
@@ -228,6 +228,19 @@ class TupleTestCase(test_util.TensorFlowTestCase):
     res = control_flow_ops.tuple([a, b])
     self.assertLen(res, 2)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testRepeatedVariableUnderTFFunction(self):
+    v = variables.Variable([10.0, 20.0])
+    self.evaluate(v.initializer)
+
+    @def_function.function
+    def compute():
+      return control_flow_ops.tuple([v, v, v])
+
+    result = self.evaluate(compute())
+    for t in result:
+      self.assertAllClose(t, [10.0, 20.0])
+
 
 class SwitchTestCase(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
Fixes #125397

tuple() skipped ops.convert_to_tensor() for tf.Variable inputs because
tensor_util.is_tf_type() treated them as already graph-safe, leaving
the raw eager handle uncaptured. Calling .op on it then raised
"Tensor.op is undefined when eager execution is enabled" under
tf.function/jit_compile.

Fix: only skip conversion for real Tensor/IndexedSlices instances, so
Variables always go through convert_to_tensor().

Added testRepeatedVariableUnderTFFunction to TupleTestCase covering
the issue's repro.