### PR TITLE
fix off-by-one in RaggedGather intermediate split validation

### DIFF
--- a/tensorflow/core/kernels/ragged_gather_op.cc
+++ b/tensorflow/core/kernels/ragged_gather_op.cc
@@ -200,9 +200,13 @@ class RaggedGatherOpBase : public OpKernel {
     // Validate
     for (int dim = 0; dim < params_nested_splits.size(); ++dim) {
       const auto& splits = params_nested_splits[dim];
+      // For an intermediate ragged dimension, the split values are used as
+      // indices into the next dimension's splits tensor by MakeSplits, so the
+      // largest valid value is one less than that tensor's length. Only the
+      // innermost dimension may reference num_params_dense_values directly.
       SPLITS_TYPE last_split = (dim == params_nested_splits.size() - 1)
                                    ? num_params_dense_values
-                                   : params_nested_splits[dim + 1].size();
+                                   : params_nested_splits[dim + 1].size() - 1;
       if (splits.size() == 0) {
         return absl::InvalidArgumentError("Ragged splits may not be empty");
       }

--- a/tensorflow/core/kernels/ragged_gather_op_test.cc
+++ b/tensorflow/core/kernels/ragged_gather_op_test.cc
@@ -233,6 +233,22 @@ TEST_F(RaggedGatherOpTest, InvalidSplitsTooBig) {
             RunOpKernel().message());
 }
 
+TEST_F(RaggedGatherOpTest, InvalidInnerSplitsPointPastNextLevel) {
+  // The last value of the outer splits (3) equals the length of the inner
+  // splits tensor. Since outer split values index into the inner splits tensor,
+  // the largest legal value is one less, so this must be rejected before
+  // MakeSplits reads one element past the inner splits buffer.
+  BuildRaggedGatherGraph<float, int32_t>(
+      TensorShape({1}),     // indices.shape
+      {0},                  // indices
+      {{0, 3}, {0, 2, 3}},  // params_nested_splits
+      TensorShape({3}),     // params_dense_values.shape
+      {.1, .2, .3}          // params_dense_values
+  );
+  EXPECT_EQ("Ragged splits must not point past values",
+            RunOpKernel().message());
+}
+
 TEST_F(RaggedGatherOpTest, BadValuesShape) {
   BuildRaggedGatherGraph<float, int32_t>(
       TensorShape({0}),  // indices.shape


### PR DESCRIPTION
ValidateSplits bounds each intermediate row_splits by the length of the next splits tensor, but MakeSplits uses those split values as indices into that tensor, so a crafted RaggedGather with ragged_rank >= 2 whose inner split ends exactly at that length reads one element past the buffer and copies out-of-bounds params_dense_values heap into the returned values. Bound intermediate splits by that length minus one, which valid nested ragged tensors already satisfy since their inner split ends one before the next tensor's length. Reachable from untrusted data via tf.raw_ops.RaggedGather; a regression test is included.