### PR TITLE
Set free-threaded Python wheel ABI tag

### DIFF
--- a/tensorflow/tools/pip_package/utils/tf_wheel.bzl
+++ b/tensorflow/tools/pip_package/utils/tf_wheel.bzl
@@ -30,6 +30,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "@python_version_repo//:py_version.bzl",
     "HERMETIC_PYTHON_VERSION",
+    "HERMETIC_PYTHON_VERSION_KIND",
     "MACOSX_DEPLOYMENT_TARGET",
     "WHEEL_COLLAB",
     "WHEEL_NAME",
@@ -64,11 +65,23 @@ def _get_full_wheel_name(
         platform_name,
         platform_tag,
         wheel_version):
-    python_version = HERMETIC_PYTHON_VERSION.replace(".", "")
-    return "{wheel_name}-{wheel_version}-cp{python_version}-cp{python_version}-{wheel_platform_tag}.whl".format(
+    python_version = HERMETIC_PYTHON_VERSION
+    is_freethreaded = HERMETIC_PYTHON_VERSION_KIND == "freethreaded"
+
+    for suffix in ["-freethreaded", "-ft"]:
+        if python_version.endswith(suffix):
+            python_version = python_version[:-len(suffix)]
+            is_freethreaded = True
+            break
+
+    python_version = python_version.replace(".", "")
+    abi_tag_suffix = "t" if is_freethreaded else ""
+
+    return "{wheel_name}-{wheel_version}-cp{python_version}-cp{python_version}{abi_tag_suffix}-{wheel_platform_tag}.whl".format(
         wheel_name = WHEEL_NAME,
         wheel_version = wheel_version,
         python_version = python_version,
+        abi_tag_suffix = abi_tag_suffix,
         wheel_platform_tag = _get_wheel_platform_name(
             platform_name,
             platform_tag,


### PR DESCRIPTION
## Summary

Generate the correct wheel ABI tag for free-threaded CPython builds.

Regular CPython wheels continue to use tags such as:

`cp314-cp314`

while free-threaded CPython uses:

`cp314-cp314t`

## Problem

TensorFlow currently constructs the Python and ABI portions of the wheel filename from the Python version alone:

`cp{python_version}-cp{python_version}`

This produces a regular CPython ABI tag even when the selected hermetic interpreter is a free-threaded build.

For example, Python 3.14 free-threaded should produce:

`cp314-cp314t`

rather than:

`cp314-cp314`

## Fix

Detect a free-threaded hermetic Python configuration from either:

- `HERMETIC_PYTHON_VERSION_KIND == "freethreaded"`
- a `-freethreaded` version suffix
- a `-ft` version suffix

Strip the configuration suffix from the Python version and append `t` only to the ABI portion of the wheel tag.

Regular Python wheel naming remains unchanged.

## Validation

The wheel-tag logic was checked for the following cases:

- `3.14` -> `cp314-cp314`
- `3.14` with kind `freethreaded` -> `cp314-cp314t`
- `3.14-freethreaded` -> `cp314-cp314t`
- `3.14-ft` -> `cp314-cp314t`
- `3.13` -> `cp313-cp313`

All cases produced the expected result.

As additional end-to-end validation in a broader TensorFlow Python 3.14 free-threaded integration workspace using the same wheel naming logic, TensorFlow successfully produced:

`tensorflow-2.22.0.dev0+selfbuilt-cp314-cp314t-linux_x86_64.whl`

The installed wheel was recognized under CPython 3.14 free-threaded with:

- `SOABI: cpython-314t-x86_64-linux-gnu`
- `Py_GIL_DISABLED: 1`

This PR is intentionally limited to wheel naming and does not include the separate runtime free-threading changes.

## Related work

Free-threaded Python toolchain kind normalization is being handled separately in:

https://github.com/google-ml-infra/rules_ml_toolchain/pull/302