### PR TITLE
Add CPU XLA regression test for chained reduce_sum precision

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: github.repository == 'tensorflow/tensorflow'
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@375a0e8ebdc98e99b02ac4338a724f5750f21213" # v2.3.1
     with:
       scan-args: |-
         --lockfile=requirements.txt:./requirements_lock_3_9.txt

--- a/tensorflow/compiler/tests/reduce_ops_test.py
+++ b/tensorflow/compiler/tests/reduce_ops_test.py
@@ -183,6 +183,32 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
 
 class ReduceOpPrecisionTest(xla_test.XLATestCase):
 
+  def testChainedReduceSumF32(self):
+    """Tests that chained large reductions do not accumulate excessive error."""
+
+    if self.device != 'XLA_CPU':
+      self.skipTest('This test covers the CPU reduction implementation.')
+
+    shape = (20, 32, 24, 38)
+    values = (3.14, 2.72, 2.07, 0.58)
+    inputs = [np.full(shape, value, dtype=np.float32) for value in values]
+
+    with self.session() as sess:
+      with self.test_scope():
+        placeholders = [
+            array_ops.placeholder(dtypes.float32, shape=shape)
+            for _ in values
+        ]
+        sums = [math_ops.reduce_sum(value) for value in placeholders]
+        result = (sums[0] + sums[1]) + (sums[2] + sums[3])
+
+      actual = sess.run(result, dict(zip(placeholders, inputs)))
+
+    element_count = np.prod(shape, dtype=np.int64)
+    expected = sum(np.float64(np.float32(value)) * element_count
+                   for value in values)
+    self.assertAllClose(actual, expected, rtol=1e-5, atol=1e-4)
+
   def _testReduceSum(self,
                      expected_result,
                      dtype,


### PR DESCRIPTION
## Summary

Adds a regression test for #125396 covering excessive precision loss when multiple large `tf.reduce_sum` operations are chained on XLA CPU.

The test:

- Reproduces the reported tensor shape and float32 values.
- Runs four reductions followed by the same scalar addition tree.
- Compares the result against the sum of the represented float32 inputs.
- Uses a tolerance that permits normal reduction-order rounding differences while rejecting the excessive error reported in TensorFlow 2.14.
- Runs only on XLA CPU because the issue is specific to that backend.

## Results

The original report produced:

- Expected/eager: approximately `4,967,123.5`
- XLA CPU: `4,965,143.0`

On TensorFlow 2.21, the regression test produces:

- Reference: `4,967,116.829`
- XLA CPU: `4,967,130.0`
- Relative error: approximately `2.65e-6`

The current result is within the test tolerance of `1e-5`.

## Testing

- Verified the reproducer against TensorFlow CPU 2.21.
- `git diff --check` passes.
- Python syntax compilation passes.

A full Bazel test was not run locally because Bazel is unavailable in the development environment.

Fixes #125396