### PR TITLE
tf2xla: validate minval < maxval in StatelessRandomUniformIntV2

### DIFF
--- a/tensorflow/compiler/tests/stateless_random_ops_test.py
+++ b/tensorflow/compiler/tests/stateless_random_ops_test.py
@@ -24,6 +24,7 @@ from tensorflow.python.client import device_lib
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import config
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.kernel_tests.random import util as \
@@ -216,6 +217,23 @@ class StatelessRandomOpsTest(xla_test.XLATestCase, parameterized.TestCase):
         y = sess.run(x, {seed_t: [0x12345678, 0xabcdef1]})
         self.assertTrue(np.all(y >= 0))
         self.assertTrue(np.all(y < maxval))
+
+  def testUniformIntEmptyRangeRaises(self):
+    # minval == maxval is an empty range. The CPU/eager kernel
+    # (StatelessRandomUniformIntOp in
+    # tensorflow/core/kernels/stateless_random_ops_v2.cc) rejects this; the
+    # XLA op used to silently compile it and return garbage instead.
+    with self.session():
+      with self.test_scope():
+
+        @def_function.function(jit_compile=True)
+        def f():
+          return stateless.stateless_random_uniform(
+              shape=[2], seed=[1, 2], minval=0, maxval=0, dtype=dtypes.int32)
+
+        with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                    "Need minval < maxval"):
+          self.evaluate(f())
 
   @parameterized.named_parameters(
       (f'_{alg.name}_{dtype.name}_{seed}', alg, dtype, seed)  # pylint: disable=g-complex-comprehension

--- a/tensorflow/compiler/tf2xla/kernels/stateless_random_ops_v2.cc
+++ b/tensorflow/compiler/tf2xla/kernels/stateless_random_ops_v2.cc
@@ -167,6 +167,22 @@ class StatelessRandomUniformIntOp : public XlaOpKernel {
             "maxval must be scalar, got shape ", maxval_shape.DebugString())));
     xla::XlaOp minval = ctx->Input(minval_input_idx);
     xla::XlaOp maxval = ctx->Input(maxval_input_idx);
+
+    // When minval/maxval are compile-time constants, reject an empty range
+    // the same way the CPU/eager kernel does (StatelessRandomUniformIntOp
+    // in stateless_random_ops_v2.cc), instead of silently compiling a
+    // program that returns garbage. If they aren't compile-time constants
+    // (or are an unsigned dtype not supported by ConstantInputAsIntScalar),
+    // there's nothing to check here and we fall back to the prior behavior.
+    int64_t minval_const, maxval_const;
+    if (ctx->ConstantInputAsIntScalar(minval_input_idx, &minval_const).ok() &&
+        ctx->ConstantInputAsIntScalar(maxval_input_idx, &maxval_const).ok()) {
+      OP_REQUIRES(ctx, minval_const < maxval_const,
+                  absl::InvalidArgumentError(absl::StrCat(
+                      "Need minval < maxval, got ", minval_const, " >= ",
+                      maxval_const)));
+    }
+
     xla::Shape xla_shape;
     OP_REQUIRES_OK(ctx, TensorShapeToXLAShape(dtype_, shape, &xla_shape));
 


### PR DESCRIPTION
`tf.random.stateless_uniform(..., dtype=int32/int64)` requires
`minval < maxval`. The CPU/eager kernel (`StatelessRandomUniformIntOp` in
`tensorflow/core/kernels/stateless_random_ops_v2.cc`) checks this and
raises `InvalidArgumentError` for an empty range. The XLA lowering
(`StatelessRandomUniformIntOp` in
`tensorflow/compiler/tf2xla/kernels/stateless_random_ops_v2.cc`) never
checked it, so under `jit_compile=True` the op silently compiled and
returned an arbitrary value instead of erroring.

This showed up through a Keras `Conv2D` layer built with `dtype='int32'`:
the default weight initializer computes `minval`/`maxval` from
fan-in/fan-out, which round to `0, 0` for a small int32 kernel. Eager
raises while building the layer; `jit_compile=True` built it anyway and
returned a garbage-filled tensor.

Added the same check for the case where `minval`/`maxval` are
compile-time constants (the common case — almost always literals or
small computed constants, not runtime values), matching the eager
kernel's error message, plus a regression test that exercises the XLA
path directly with `jit_compile=True`.

Fixes #125531

Tested: `python -m py_compile` on the test file. Didn't get a bazel run
to finish locally in reasonable time (cold build, same as the last PR
from this branch's predecessor) — source-verified and py_compile-clean
rather than test-run-verified locally. Should be quick for CI or anyone
with a warm bazel cache.
