### PR TITLE
Raise a clear error for unsupported dtypes in tf.linalg.eig and eigvals

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/eig_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/eig_op_test.py
@@ -100,6 +100,21 @@ class EigTest(test.TestCase):
               Tout=dtypes_lib.complex128,  # Expected dtype: complex64.
               compute_v=True))
 
+  def testUnsupportedDtype(self):
+    # Only float32, float64, complex64 and complex128 are supported. Any other
+    # dtype left `out_dtype` unassigned and raised an UnboundLocalError.
+    for dtype in [
+        dtypes_lib.half,
+        dtypes_lib.bfloat16,
+        dtypes_lib.int32,
+        dtypes_lib.int64,
+    ]:
+      tensor = constant_op.constant([[0, 1], [2, 3]], dtype=dtype)
+      with self.assertRaisesRegex(ValueError, "must have dtype"):
+        linalg_ops.eig(tensor)
+      with self.assertRaisesRegex(ValueError, "must have dtype"):
+        linalg_ops.eigvals(tensor)
+
 
 def SortEigenValues(e):
   perm = np.argsort(e.real + e.imag, -1)

--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -407,6 +407,10 @@ def eig(tensor, name=None):
     out_dtype = dtypes.complex64
   elif tensor.dtype == dtypes.float64 or tensor.dtype == dtypes.complex128:
     out_dtype = dtypes.complex128
+  else:
+    raise ValueError(
+        "'tensor' must have dtype float32, float64, complex64, or "
+        f"complex128, got {tensor.dtype}")
   e, v = gen_linalg_ops.eig(tensor, Tout=out_dtype, compute_v=True, name=name)
   return e, v
 
@@ -434,6 +438,10 @@ def eigvals(tensor, name=None):
     out_dtype = dtypes.complex64
   elif tensor.dtype == dtypes.float64 or tensor.dtype == dtypes.complex128:
     out_dtype = dtypes.complex128
+  else:
+    raise ValueError(
+        "'tensor' must have dtype float32, float64, complex64, or "
+        f"complex128, got {tensor.dtype}")
   e, _ = gen_linalg_ops.eig(tensor, Tout=out_dtype, compute_v=False, name=name)
   return e
 


### PR DESCRIPTION
`tf.linalg.eig` and `tf.linalg.eigvals` fail with an `UnboundLocalError` when given a dtype they don't support:

```python
>>> tf.linalg.eigvals(tf.constant([[1, 2], [3, 4]], dtype=tf.half))
UnboundLocalError: cannot access local variable 'out_dtype' where it is not associated with a value
```

Same for `bfloat16`, `int32`, `int64` and anything else outside the four supported dtypes, and `eig` behaves identically to `eigvals` here.

The cause is visible in the source. Both functions choose the output dtype with an if/elif that has no else:

```python
if tensor.dtype == dtypes.float32 or tensor.dtype == dtypes.complex64:
  out_dtype = dtypes.complex64
elif tensor.dtype == dtypes.float64 or tensor.dtype == dtypes.complex128:
  out_dtype = dtypes.complex128
e, v = gen_linalg_ops.eig(tensor, Tout=out_dtype, compute_v=True, name=name)
```

so for any other dtype `out_dtype` is never bound and the next line raises. The user gets an error about a local variable in TensorFlow's own source rather than being told their input dtype isn't supported.

This adds the missing else, raising a `ValueError` naming the dtype, in the style already used elsewhere in `linalg_ops.py`:

```
ValueError: 'tensor' must have dtype float32, float64, complex64, or complex128, got <dtype: 'float16'>
```

The four supported dtypes are unchanged, so working code is unaffected — this only replaces one error with a better one.

### History

This was reported for `eigvals` in #61827 in September 2023 and reproduced by a maintainer at the time. Two people offered to pick it up and neither sent a patch, and the stale bot closed the issue in September 2025 without a fix. I ran into it independently while checking which Python-level ops raise internal errors on unusual dtypes, then found the old report. It still reproduces on master, and the `eig` half of it was never mentioned in that issue.

### Testing

`EigTest.testUnsupportedDtype` covers both functions over `half`, `bfloat16`, `int32` and `int64`. It fails on master with the `UnboundLocalError` above and passes with this change.

I don't have a Bazel build available, so I applied the change to an installed TF 2.21 wheel and ran `eig_op_test.py` against it both ways. Exactly one test moved and it was this one: 139 tests, 2 errors before and 1 after. The one that remains is `testMatrixThatFailsWhenFlushingDenormsToZero`, which fails identically with and without the change and is unrelated — it's the known denormal-flushing case, and this machine flushes denormals.
