### PR TITLE
guard empty metadata in VariantTensorDataReader constructor

### DIFF
--- a/tensorflow/core/data/serialization_utils.cc
+++ b/tensorflow/core/data/serialization_utils.cc
@@ -188,6 +188,10 @@ VariantTensorDataReader::VariantTensorDataReader(
     std::string metadata;
     d->get_metadata(&metadata);
     auto keys = str_util::Split(metadata, kDelimiter, str_util::SkipEmpty());
+    if (keys.empty()) {
+      LOG(WARNING) << "Found empty metadata in VariantTensorData; skipping.";
+      continue;
+    }
     const std::string name = keys[0];
     data_[name] = d;
     map_[name] = std::map<std::string, size_t>();

--- a/tensorflow/core/data/serialization_utils.cc
+++ b/tensorflow/core/data/serialization_utils.cc
@@ -189,7 +189,7 @@ VariantTensorDataReader::VariantTensorDataReader(
     d->get_metadata(&metadata);
     auto keys = str_util::Split(metadata, kDelimiter, str_util::SkipEmpty());
     if (keys.empty()) {
-      LOG(WARNING) << "Found empty metadata in VariantTensorData; skipping.";
+      VLOG(1) << "Found empty metadata in VariantTensorData; skipping.";
       continue;
     }
     const std::string name = keys[0];

--- a/tensorflow/core/data/serialization_utils_test.cc
+++ b/tensorflow/core/data/serialization_utils_test.cc
@@ -185,6 +185,22 @@ TEST(SerializationUtilsTest, VariantTensorDataReaderOOB) {
             error::OUT_OF_RANGE);
 }
 
+TEST(SerializationUtilsTest, VariantTensorDataReaderEmptyMetadata) {
+  // Metadata that splits into no keys (empty or delimiter-only) must not cause
+  // the reader to index the first key out of bounds while building its maps.
+  for (const std::string& metadata : {std::string(""), std::string("@@")}) {
+    VariantTensorData data;
+    data.metadata_ = metadata;
+    data.tensors_.push_back(Tensor(DT_INT64, {1}));
+    std::vector<const VariantTensorData*> reader_data;
+    reader_data.push_back(&data);
+    VariantTensorDataReader reader(reader_data);
+    int64_t val_int64;
+    EXPECT_EQ(reader.ReadScalar("Iterator", "key1", &val_int64).code(),
+              error::NOT_FOUND);
+  }
+}
+
 class ParameterizedIteratorStateVariantTest
     : public DatasetOpsTestBase,
       public ::testing::WithParamInterface<std::vector<Tensor>> {


### PR DESCRIPTION
The VariantTensorDataReader constructor splits each VariantTensorData's metadata on the `@@` delimiter and reads `keys[0]` without checking the split produced any keys, but str_util::Split returns an empty vector for empty input and, under SkipEmpty, for delimiter-only metadata too, so `keys[0]` reads past an empty vector. It is reachable from untrusted data through the DeserializeIterator op, since IteratorStateVariant::Decode keeps the supplied metadata verbatim, so a crafted iterator-state variant with type_name `tensorflow::Iterator` and empty or `@@` metadata faults in the constructor. Skip entries whose metadata yields no keys; the sibling read paths already bounds-check their index accesses. Added a regression test alongside the existing VariantTensorDataReaderOOB case.