### PR TITLE
Mark small Python extensions as free-threading safe

### DIFF
--- a/tensorflow/python/platform/cpu_feature_guard_wrapper.cc
+++ b/tensorflow/python/platform/cpu_feature_guard_wrapper.cc
@@ -16,7 +16,8 @@ limitations under the License.
 #include "pybind11/pybind11.h"  // from @pybind11
 #include "tensorflow/core/platform/cpu_feature_guard.h"
 
-PYBIND11_MODULE(_pywrap_cpu_feature_guard, m) {
+PYBIND11_MODULE(
+    _pywrap_cpu_feature_guard, m, pybind11::mod_gil_not_used()) {
   m.def("InfoAboutUnusedCPUFeatures",
         &tensorflow::port::InfoAboutUnusedCPUFeatures);
 };

--- a/tensorflow/python/pywrap_tensorflow_internal.cc
+++ b/tensorflow/python/pywrap_tensorflow_internal.cc
@@ -19,7 +19,8 @@ limitations under the License.
 // This logic allows Python to import _pywrap_tensorflow_internal.so by
 // creating a PyInit function and exposing it. It is required in opensource
 // only.
-PYBIND11_MODULE(_pywrap_tensorflow_internal, m) {
+PYBIND11_MODULE(
+    _pywrap_tensorflow_internal, m, pybind11::mod_gil_not_used()) {
   m.def("pywrap_library_dependency_symbol",
         &tensorflow::python::pywrap_library_dependency_symbol);
 };

--- a/tensorflow/python/sanitizers_wrapper.cc
+++ b/tensorflow/python/sanitizers_wrapper.cc
@@ -16,7 +16,8 @@ limitations under the License.
 #include "pybind11/pybind11.h"  // from @pybind11
 
 // Check if specific santizers are enabled.
-PYBIND11_MODULE(_pywrap_sanitizers, m) {
+PYBIND11_MODULE(
+    _pywrap_sanitizers, m, pybind11::mod_gil_not_used()) {
   m.def("is_asan_enabled", []() -> bool {
 #if defined(ADDRESS_SANITIZER)
     return true;

--- a/tensorflow/python/util/port_wrapper.cc
+++ b/tensorflow/python/util/port_wrapper.cc
@@ -17,7 +17,8 @@ limitations under the License.
 #include "pybind11/pytypes.h"  // from @pybind11
 #include "tensorflow/core/util/port.h"
 
-PYBIND11_MODULE(_pywrap_util_port, m) {
+PYBIND11_MODULE(
+    _pywrap_util_port, m, pybind11::mod_gil_not_used()) {
   m.def("IsGoogleCudaEnabled", tensorflow::IsGoogleCudaEnabled);
   m.def("IsBuiltWithROCm", tensorflow::IsBuiltWithROCm);
   m.def("IsBuiltWithXLA", tensorflow::IsBuiltWithXLA);


### PR DESCRIPTION
## Summary

Declare several small TensorFlow pybind extensions as safe to import without requiring the GIL on free-threaded CPython builds.

The affected modules are:

- `tensorflow.python.platform._pywrap_cpu_feature_guard`
- `tensorflow.python._pywrap_tensorflow_internal`
- `tensorflow.python._pywrap_sanitizers`
- `tensorflow.python.util._pywrap_util_port`

## Change

Each module now declares:

`pybind11::mod_gil_not_used()`

These wrappers are small and do not maintain Python-side mutable state that depends on the GIL.

## Validation

The four Bazel targets were built successfully using TensorFlow's hermetic free-threaded Python configuration:

- Python version: `3.14`
- Python kind: `freethreaded`

Targets:

- `//tensorflow/python/platform:_pywrap_cpu_feature_guard`
- `//tensorflow/python:_pywrap_tensorflow_internal`
- `//tensorflow/python:_pywrap_sanitizers`
- `//tensorflow/python/util:_pywrap_util_port`

The corresponding native extensions were also loaded directly in isolated CPython 3.14.7 free-threaded processes.

For all four modules:

- `GIL before: False`
- module loaded successfully
- `GIL after: False`

This PR is intentionally limited to these small extensions. Additional TensorFlow extension modules require separate free-threading review and are not part of this change.