### PR TITLE
Mark runtime flag extensions as free-threading safe

### DIFF
--- a/tensorflow/python/platform/enable_tf2.cc
+++ b/tensorflow/python/platform/enable_tf2.cc
@@ -16,7 +16,8 @@ limitations under the License.
 #include "pybind11/pybind11.h"  // from @pybind11
 #include "tensorflow/core/platform/enable_tf2_utils.h"
 
-PYBIND11_MODULE(_pywrap_tf2, m) {
+PYBIND11_MODULE(
+    _pywrap_tf2, m, pybind11::mod_gil_not_used()) {
   m.def("enable", &tensorflow::set_tf2_execution);
   m.def("is_enabled", &tensorflow::tf2_execution_enabled);
 }

--- a/tensorflow/python/util/determinism.cc
+++ b/tensorflow/python/util/determinism.cc
@@ -17,7 +17,8 @@ limitations under the License.
 
 #include "pybind11/pybind11.h"  // from @pybind11
 
-PYBIND11_MODULE(_pywrap_determinism, m) {
+PYBIND11_MODULE(
+    _pywrap_determinism, m, pybind11::mod_gil_not_used()) {
   m.def("enable", &tensorflow::EnableOpDeterminism);
   m.def("is_enabled", &tensorflow::OpDeterminismRequired);
 }

--- a/tensorflow/python/util/tensor_float_32.cc
+++ b/tensorflow/python/util/tensor_float_32.cc
@@ -16,7 +16,9 @@ limitations under the License.
 #include "pybind11/pybind11.h"  // from @pybind11
 #include "tensorflow/core/platform/tensor_float_32_utils.h"
 
-PYBIND11_MODULE(_pywrap_tensor_float_32_execution, m) {
+PYBIND11_MODULE(
+    _pywrap_tensor_float_32_execution, m,
+    pybind11::mod_gil_not_used()) {
   m.def("enable", &tensorflow::enable_tensor_float_32_execution);
   m.def("is_enabled", &tensorflow::tensor_float_32_execution_enabled);
 }


### PR DESCRIPTION
## Summary

Declare three TensorFlow runtime flag pybind extensions as safe to import without requiring the GIL on free-threaded CPython builds.

The affected modules are:

- `tensorflow.python.platform._pywrap_tf2`
- `tensorflow.python.util._pywrap_determinism`
- `tensorflow.python.util._pywrap_tensor_float_32_execution`

## Change

Each module now declares:

`pybind11::mod_gil_not_used()`

The underlying shared runtime state is already synchronized:

- TF2 uses `std::atomic<Enablement>`
- TensorFloat-32 uses `std::atomic<bool>`
- Determinism state is protected by `absl::Mutex`

## Validation

The three Bazel targets were built successfully using TensorFlow's hermetic free-threaded Python configuration:

- Python version: `3.14`
- Python kind: `freethreaded`

Targets:

- `//tensorflow/python/platform:_pywrap_tf2`
- `//tensorflow/python/util:_pywrap_determinism`
- `//tensorflow/python/util:_pywrap_tensor_float_32_execution`

The corresponding native extensions were also loaded directly in separate CPython 3.14.7 free-threaded processes.

For all three modules:

- `GIL before: False`
- module loaded successfully
- `GIL after: False`

The exported `is_enabled()` functions were also called successfully after loading.

This PR is intentionally limited to these runtime flag extensions. Other TensorFlow native extensions require separate free-threading review and are being handled independently.