### PR TITLE
Mark DType extension as free-threading safe

### DIFF
--- a/tensorflow/python/framework/dtypes.cc
+++ b/tensorflow/python/framework/dtypes.cc
@@ -59,7 +59,8 @@ inline bool DataTypeIsNumPyCompatible(DataType dt) {
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(_dtypes, m) {
+PYBIND11_MODULE(
+    _dtypes, m, pybind11::mod_gil_not_used()) {
   py::class_<tensorflow::DataType>(m, "DType")
       .def(py::init([](py::object obj) {
         auto id = static_cast<int>(py::int_(obj));


### PR DESCRIPTION
## Summary

Declare TensorFlow's `_dtypes` pybind extension as safe to import without requiring the GIL on free-threaded CPython builds.

## Change

The module now declares:

`pybind11::mod_gil_not_used()`

The extension wraps TensorFlow `DataType` enum values and does not maintain Python-side mutable global state.

## Validation

The target was built successfully using TensorFlow's hermetic free-threaded Python configuration:

- Python version: `3.14`
- Python kind: `freethreaded`

Target:

- `//tensorflow/python/framework:_dtypes`

The native `_dtypes` extension was then loaded directly in CPython 3.14.7 free-threaded mode:

- `GIL before import: False`
- `GIL after import: False`

A concurrent stress test was also run with:

- 16 Python threads
- 50,000 iterations per thread
- 800,000 total DType operation cycles

Each cycle exercised:

- `DType(...)` construction
- integer conversion
- enum properties
- `name`
- `str` / `repr`
- `hash`
- size and type-classification properties

Results:

- `Errors: 0`
- `GIL after stress: False`
- `RESULT: PASS`

This PR is intentionally limited to the `_dtypes` extension. Other TensorFlow native extensions are being reviewed separately for free-threading compatibility.