### PR TITLE
Lock DTensor collective key cache before lookup

### DIFF
--- a/tensorflow/dtensor/mlir/utils/collective_lowering.cc
+++ b/tensorflow/dtensor/mlir/utils/collective_lowering.cc
@@ -178,9 +178,9 @@ int32_t GetCollectiveKeyBase(
   const llvm::SmallVector<int32_t, 4> group_key_offsets =
       GetGroupKeyOffsets(group_assignment, &group_size);
 
+  tensorflow::mutex_lock lock(*mtx);
   const auto iter =
       mesh_to_key_base->find({mesh.ToString(), group_key_offsets});
-  tensorflow::mutex_lock lock(*mtx);
   if (iter != mesh_to_key_base->end()) {
     return iter->second;
   }


### PR DESCRIPTION
## Summary

Protect the DTensor collective key cache lookup with the existing mutex.

## Problem

`GetCollectiveKeyBase()` reads from `mesh_to_key_base` using `find()` before acquiring the mutex, while insertions into the same `std::map` happen while holding that mutex.

This allows concurrent access to the same map without consistent synchronization.

## Fix

Acquire the existing mutex before calling `find()` so that both lookup and insertion are protected by the same lock.

## Validation

Built successfully with Bazel:

- `//tensorflow/dtensor/mlir/utils:dtensor_mlir_passes_internal`
- `//tensorflow/python:_pywrap_dtensor_device`

The build completed successfully with 9,237 actions.

This change is intentionally limited to the collective key cache synchronization and is independent of the Python free-threading work.