### PR TITLE
Require select_range when select is 'i' or 'v' in eigh_tridiagonal

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -677,6 +677,23 @@ class EighTridiagonalTest(test.TestCase, parameterized.TestCase):
         self.assertAllClose(
             eigvals_all[first:(last + 1)], eigvals_value, atol=atol)
 
+  @parameterized.parameters("i", "v")
+  def test_select_range_required(self, select):
+    # Regression test for GitHub issue 113321: both of these select modes
+    # index into select_range, so omitting it surfaced as a TypeError from
+    # subscripting None rather than naming the missing argument.
+    alpha = np.array([1.0, 2.0, 3.0], np.float32)
+    beta = np.array([0.5, 0.5], np.float32)
+    with self.assertRaisesRegex(ValueError, "select_range must be specified"):
+      linalg.eigh_tridiagonal(alpha, beta, select=select)
+
+  def test_select_range_not_required_for_a(self):
+    # select='a' ignores select_range and must keep working without it.
+    alpha = np.array([1.0, 2.0, 3.0], np.float32)
+    beta = np.array([0.5, 0.5], np.float32)
+    self.assertAllEqual(
+        [3], linalg.eigh_tridiagonal(alpha, beta, select="a").shape)
+
   @parameterized.parameters((np.float32), (np.float64), (np.complex64),
                             (np.complex128))
   def test_extreme_eigenvalues_test(self, dtype):

--- a/tensorflow/python/ops/linalg/linalg_impl.py
+++ b/tensorflow/python/ops/linalg/linalg_impl.py
@@ -1296,6 +1296,13 @@ def eigh_tridiagonal(alpha,
 
   """
   with ops.name_scope(name or 'eigh_tridiagonal'):
+    if select in ('i', 'v') and select_range is None:
+      # Both of these select modes index into select_range below. Reject the
+      # missing value here rather than letting it surface as a TypeError from
+      # subscripting None.
+      raise ValueError(
+          f"select_range must be specified when select is '{select}'; it is "
+          "only optional for select='a'.")
 
     def _compute_eigenvalues(alpha, beta):
       """Computes all eigenvalues of a Hermitian tridiagonal matrix."""


### PR DESCRIPTION
## Summary

Fixes #113321.

`tf.linalg.eigh_tridiagonal` with `select='v'` or `select='i'` and no `select_range` fails with an error that does not name the missing argument:

```
TypeError: 'NoneType' object is not subscriptable
```

Both modes index into `select_range` (`linalg_impl.py`), and the docstring describes `'v'` as "eigenvalues in the interval (min, max] given by `select_range`" and `'i'` as "eigenvalues with indices min <= i <= max", so the argument is effectively required for them. Only `select='a'` ignores it.

## Fix

Raise `ValueError` naming the argument at the entry point. The check fires only for `'i'` and `'v'`, so an invalid `select` value still produces the existing "select must have a value in {'a', 'i', 'v'}" error rather than a misleading one about `select_range`.

## Note on the issue as filed

The issue reports that this succeeds in eager and fails only inside `tf.function`. That divergence does not reproduce on 2.21.0: both paths now fail identically, and with a different message than the one quoted (`'NoneType' object is not subscriptable` rather than `int() argument must be ...`). What remains is the unhelpful error, which is what this PR addresses. Worth noting in case the reported symptom is what gets checked at review time.

## Verification

Behavior with the change, on 2.21.0:

| call | before | after |
| --- | --- | --- |
| `select='v'`, no range (eager) | TypeError | ValueError naming select_range |
| `select='i'`, no range (eager) | TypeError | ValueError naming select_range |
| `select='v'`, no range (`tf.function`) | TypeError | ValueError naming select_range |
| `select='a'` (default) | ok | ok |
| `select='v'` with range | ok | ok |
| `select='i'` with range | ok | ok |
| invalid `select='x'` | existing ValueError | existing ValueError |

`EighTridiagonalTest` passes in full (28 tests, including the 3 added here). Against unpatched `linalg_impl.py` the two new parameterized tests error in both graph and eager mode and never pass, so they gate the change; the `select='a'` test passes either way, as intended, since it does not depend on the fix.

Credit to @AGFACBNNR for the report.