### PR TITLE
Reject maxlength below minlength in bincount

### DIFF
--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -1455,9 +1455,11 @@ py_library(
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/framework:tensor",
         "//tensorflow/python/framework:tensor_conversion",
+        "//tensorflow/python/framework:tensor_util",
         "//tensorflow/python/util:deprecation",
         "//tensorflow/python/util:dispatch",
         "//tensorflow/python/util:tf_export",
+        "//third_party/py/numpy",
     ],
 )
 
@@ -1470,11 +1472,13 @@ cuda_py_strict_test(
         ":count_ops_gen",
         ":sparse_ops",
         "//tensorflow/python/framework:config",
+        "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:errors",
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/framework:sparse_tensor",
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/platform:client_testlib",
+        "//third_party/py/numpy",
         "@absl_py//absl/testing:parameterized",
     ],
 )

--- a/tensorflow/python/ops/bincount_ops.py
+++ b/tensorflow/python/ops/bincount_ops.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """bincount ops."""
 
+import numpy as np
+
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor
@@ -173,7 +175,10 @@ def bincount(arr,
       min_value = tensor_util.constant_value(minlength)
       max_value = tensor_util.constant_value(maxlength)
       if (min_value is not None and max_value is not None and
+          np.ndim(min_value) == 0 and np.ndim(max_value) == 0 and
           max_value < min_value):
+        # Non-scalar bounds are skipped here; they are rejected by the op
+        # itself.
         raise ValueError(
             "Argument `maxlength` must be at least `minlength`, received "
             f"minlength={min_value} and maxlength={max_value}.")

--- a/tensorflow/python/ops/bincount_ops.py
+++ b/tensorflow/python/ops/bincount_ops.py
@@ -18,6 +18,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor
 from tensorflow.python.framework import tensor_conversion
+from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_math_ops
 from tensorflow.python.ops import math_ops
@@ -161,6 +162,21 @@ def bincount(arr,
     if axis not in [0, -1]:
       raise ValueError(f"Unsupported value for argument axis={axis}. Only 0 and"
                        " -1 are currently supported.")
+
+    if minlength is not None and maxlength is not None:
+      # `maxlength` is applied after `minlength` below, so a `maxlength`
+      # smaller than `minlength` silently wins and the documented "length at
+      # least minlength" guarantee is broken. The two bounds cannot both be
+      # satisfied, so reject them instead. Values that are not known
+      # statically are left to the bounds below, since they cannot be
+      # compared here.
+      min_value = tensor_util.constant_value(minlength)
+      max_value = tensor_util.constant_value(maxlength)
+      if (min_value is not None and max_value is not None and
+          max_value < min_value):
+        raise ValueError(
+            "Argument `maxlength` must be at least `minlength`, received "
+            f"minlength={min_value} and maxlength={max_value}.")
 
     array_is_nonempty = array_ops.size(arr) > 0
     output_size = math_ops.cast(array_is_nonempty, arr.dtype) * (

--- a/tensorflow/python/ops/bincount_ops_test.py
+++ b/tensorflow/python/ops/bincount_ops_test.py
@@ -18,6 +18,7 @@ from absl.testing import parameterized
 import numpy as np
 
 from tensorflow.python.framework import config as tf_config
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
@@ -406,6 +407,31 @@ class TestDenseBincount(test.TestCase, parameterized.TestCase):
             )
         ),
     )
+
+
+  def test_maxlength_below_minlength_raises(self):
+    # Regression test for GitHub issue 99513. `maxlength` is applied after
+    # `minlength`, so a smaller `maxlength` silently won and the output was
+    # shorter than `minlength` promises.
+    x = np.random.randint(0, 10, (100,))
+    with self.assertRaisesRegex(ValueError, "must be at least `minlength`"):
+      bincount_ops.bincount(x, minlength=10, maxlength=5)
+
+  def test_maxlength_below_minlength_raises_for_constants(self):
+    # The same check applies when the bounds are constant tensors.
+    x = np.random.randint(0, 10, (100,))
+    with self.assertRaisesRegex(ValueError, "must be at least `minlength`"):
+      bincount_ops.bincount(
+          x,
+          minlength=constant_op.constant(10),
+          maxlength=constant_op.constant(5))
+
+  @parameterized.parameters((5, 10), (3, 3), (0, 4))
+  def test_maxlength_at_least_minlength_is_accepted(self, minlength, maxlength):
+    # Consistent bounds keep working, including when they are equal.
+    x = np.random.randint(0, 10, (100,))
+    result = bincount_ops.bincount(x, minlength=minlength, maxlength=maxlength)
+    self.assertEqual(maxlength, int(self.evaluate(result).shape[0]))
 
 
 class RawOpsHeapOobTest(test.TestCase, parameterized.TestCase):

--- a/tensorflow/python/ops/bincount_ops_test.py
+++ b/tensorflow/python/ops/bincount_ops_test.py
@@ -413,13 +413,13 @@ class TestDenseBincount(test.TestCase, parameterized.TestCase):
     # Regression test for GitHub issue 99513. `maxlength` is applied after
     # `minlength`, so a smaller `maxlength` silently won and the output was
     # shorter than `minlength` promises.
-    x = np.random.randint(0, 10, (100,))
+    x = [1, 2, 3]
     with self.assertRaisesRegex(ValueError, "must be at least `minlength`"):
       bincount_ops.bincount(x, minlength=10, maxlength=5)
 
   def test_maxlength_below_minlength_raises_for_constants(self):
     # The same check applies when the bounds are constant tensors.
-    x = np.random.randint(0, 10, (100,))
+    x = [1, 2, 3]
     with self.assertRaisesRegex(ValueError, "must be at least `minlength`"):
       bincount_ops.bincount(
           x,
@@ -428,8 +428,10 @@ class TestDenseBincount(test.TestCase, parameterized.TestCase):
 
   @parameterized.parameters((5, 10), (3, 3), (0, 4))
   def test_maxlength_at_least_minlength_is_accepted(self, minlength, maxlength):
-    # Consistent bounds keep working, including when they are equal.
-    x = np.random.randint(0, 10, (100,))
+    # Consistent bounds keep working, including when they are equal. The
+    # input contains every value below maxlength so the expected output
+    # length is deterministic.
+    x = list(range(maxlength))
     result = bincount_ops.bincount(x, minlength=minlength, maxlength=maxlength)
     self.assertEqual(maxlength, int(self.evaluate(result).shape[0]))
 


### PR DESCRIPTION
## Summary

Fixes #99513.

`tf.math.bincount` silently violates its documented `minlength` guarantee when `maxlength` is smaller:

```python
arr = tf.random.uniform(shape=(100, 10), minval=0, maxval=10, dtype=tf.int32)
tf.math.bincount(arr, minlength=10, maxlength=5, dtype=tf.int32)
# -> shape (5,), despite minlength=10
```

The docstring states that `minlength` "ensures the output has length at least `minlength`" and `maxlength` "ensur[es] that the output has length at most `maxlength`". Those cannot both hold when `maxlength < minlength`.

## Cause

The bounds are applied in sequence, so the later one wins:

```python
output_size = gen_math_ops.maximum(minlength, output_size)   # then
output_size = gen_math_ops.minimum(maxlength, output_size)
```

There is no check that the two are consistent, so contradictory arguments produce a short result rather than an error.

## Fix

Raise `ValueError` when both bounds are known statically and `maxlength` is smaller. `tensor_util.constant_value` resolves Python ints and constant tensors uniformly and returns `None` for values only known at run time; those are left to the existing clamping, since they cannot be compared at trace time.

## Behavior change

Calls that pass contradictory bounds now raise instead of returning a truncated result. That is the point of the change, but it is a behavior change and worth calling out. No existing test relies on it: across `bincount_ops_test.py`, `sparse_bincount_ops_test.py`, `ragged_bincount_ops_test.py` and `bincount_op_test.py`, every combined use has `maxlength >= minlength` (5/10, 3/5, 2/3).

## Verification

| call | before | after |
| --- | --- | --- |
| `minlength=10, maxlength=5` | len 5 | ValueError |
| `minlength=10, maxlength=5` as constant tensors | len 5 | ValueError |
| `minlength=5, maxlength=10` | len 10 | len 10 |
| `minlength=3, maxlength=3` | len 3 | len 3 |
| `minlength` or `maxlength` alone | ok | ok |
| dynamic bounds inside `tf.function` | clamps | clamps, no error |

All four bincount test suites pass with the change (`bincount_ops_test.py` 126 tests, plus the sparse, ragged and kernel suites). Against unpatched `bincount_ops.py` the two new "raises" tests fail and never pass, so they gate the fix, while the three parameterized "accepted" cases pass either way as intended.

## Relation to the earlier attempt

@ILCSFNO opened #99514 for this, which was closed by the stale bot rather than rejected. This takes a different approach to the same problem: that patch extracted values through `try`/`except` around `.numpy()`, and its fallback branch built a `check_ops.assert_greater_equal` without a control dependency, so the assertion would not have run in graph mode. Using `tensor_util.constant_value` handles both Python ints and constant tensors without exception handling.

Credit to @ILCSFNO for the report and the original analysis.