### PR TITLE
Saturate large arguments in double-precision erf

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -844,6 +844,44 @@ struct functor_traits<scalar_erfinv_op<float>> {
   };
 };
 
+// Double-precision erf that saturates large arguments. Eigen's
+// scalar_erf_op<double> squares its argument, so for |x| > sqrt(DBL_MAX),
+// about 1.34e154, and for +/-infinity the intermediate overflows and the
+// result becomes NaN. erf(x) rounds to exactly +/-1 in double precision for
+// every |x| >= 6, so such arguments are answered directly and the rest are
+// forwarded. NaN fails the saturation comparison and is forwarded, which
+// preserves erf(NaN) = NaN. The single-precision implementation saturates
+// internally and does not need this.
+struct scalar_erf_saturating_op {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE double
+  operator()(const double& x) const {
+    if (TF_PREDICT_FALSE(Eigen::numext::abs(x) >= 6.0)) {
+      return x > 0.0 ? 1.0 : -1.0;
+    }
+    return scalar_erf_op<double>()(x);
+  }
+  template <typename Packet>
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet& x) const {
+    const Packet six = pset1<Packet>(6.0);
+    const Packet one = pset1<Packet>(1.0);
+    const Packet saturated =
+        pselect(pcmp_lt(x, pzero(x)), pnegate(one), one);
+    const Packet erf_val = scalar_erf_op<double>().packetOp(x);
+    // The mask is true only for saturated lanes: NaN compares false against
+    // the threshold and therefore keeps the forwarded erf value.
+    return pselect(pcmp_le(six, pabs(x)), saturated, erf_val);
+  }
+};
+
+template <>
+struct functor_traits<scalar_erf_saturating_op> {
+  enum {
+    Cost = functor_traits<scalar_erf_op<double>>::Cost +
+           2 * NumTraits<double>::AddCost,
+    PacketAccess = functor_traits<scalar_erf_op<double>>::PacketAccess,
+  };
+};
+
 }  // end namespace internal
 }  // end namespace Eigen
 
@@ -985,6 +1023,10 @@ struct digamma : base<T, Eigen::internal::scalar_digamma_op<T>> {};
 
 template <typename T>
 struct erf : base<T, Eigen::internal::scalar_erf_op<T>> {};
+
+// See scalar_erf_saturating_op for why double is special-cased.
+template <>
+struct erf<double> : base<double, Eigen::internal::scalar_erf_saturating_op> {};
 
 template <typename T>
 struct erfc : base<T, Eigen::internal::scalar_erfc_op<T>> {};

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -323,6 +323,20 @@ class UnaryOpTest(test.TestCase):
     self._compareBothSparse(x, np.sign, math_ops.sign)
     self._compareBothSparse(x, np.sign, math_ops.erf)
 
+  def testErfDoubleSpecialValues(self):
+    # Regression test for GitHub issue 108483. The double-precision erf
+    # squared its argument, so |x| > sqrt(DBL_MAX), about 1.34e154, and
+    # +/-inf overflowed the intermediate and returned NaN. Values on both
+    # sides of that overflow threshold are covered, along with the
+    # saturation seam at 6 and NaN propagation.
+    x = np.array([np.inf, -np.inf, 1e300, -1e300, 1.35e154, -1.35e154,
+                  1.34e154, 5.9, 6.0, 6.1, -7.0], dtype=np.float64)
+    expected = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0,
+                         1.0, 1.0, 1.0, 1.0, -1.0], dtype=np.float64)
+    self.assertAllEqual(expected, self.evaluate(math_ops.erf(x)))
+    nan_result = self.evaluate(math_ops.erf(np.float64(np.nan)))
+    self.assertTrue(np.isnan(nan_result))
+
   @test_util.run_deprecated_v1
   def testDoubleBasic(self):
     x = np.arange(-3, 3).reshape(1, 3, 2).astype(np.float64)

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -329,11 +329,17 @@ class UnaryOpTest(test.TestCase):
     # +/-inf overflowed the intermediate and returned NaN. Values on both
     # sides of that overflow threshold are covered, along with the
     # saturation seam at 6 and NaN propagation.
-    x = np.array([np.inf, -np.inf, 1e300, -1e300, 1.35e154, -1.35e154,
-                  1.34e154, 5.9, 6.0, 6.1, -7.0], dtype=np.float64)
-    expected = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0,
-                         1.0, 1.0, 1.0, 1.0, -1.0], dtype=np.float64)
-    self.assertAllEqual(expected, self.evaluate(math_ops.erf(x)))
+    # These arguments take the saturating branch, which returns the literal
+    # +/-1.0, so exact equality cannot flake.
+    saturated = np.array([np.inf, -np.inf, 1e300, -1e300, 1.35e154,
+                          -1.35e154, 6.0, 6.1, -7.0], dtype=np.float64)
+    expected = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 1.0, -1.0],
+                        dtype=np.float64)
+    self.assertAllEqual(expected, self.evaluate(math_ops.erf(saturated)))
+    # These stay just below the threshold on the forwarded implementation,
+    # whose last-ulp rounding may differ across platforms.
+    near_threshold = np.array([5.9, 1.34e154], dtype=np.float64)
+    self.assertAllClose([1.0, 1.0], self.evaluate(math_ops.erf(near_threshold)))
     nan_result = self.evaluate(math_ops.erf(np.float64(np.nan)))
     self.assertTrue(np.isnan(nan_result))
 


### PR DESCRIPTION
## Summary

Fixes #108483.

`tf.math.erf` returns NaN for `+/-inf` in float64, inconsistent with PyTorch, SciPy and `math.erf`. Investigating on 2.21.0 showed the defect is wider than the report:

- **float64 only.** float16, bfloat16 and float32 already return +/-1 for +/-inf, and `erfc` handles infinity in every dtype.
- **Large finite inputs are affected too.** `erf(1.34e154) = 1.0` but `erf(1.35e154) = NaN`; the breakdown threshold is exactly `sqrt(DBL_MAX) ~= 1.3408e154`, because Eigen's `scalar_erf_op<double>` squares its argument and the intermediate overflows. So an inf-only guard would leave `erf(1e300) = NaN`.

## Fix

Specialize `tensorflow::functor::erf` for double with a saturating wrapper in `cwise_ops.h`: `erf(x)` rounds to exactly +/-1 in double precision for every `|x| >= 6` (verified: the current implementation already returns exactly 1.0 from 5.8 upward), so such arguments are answered directly and everything else forwards to the Eigen implementation unchanged.

Design points, mapped to the feedback on the earlier attempt (#108592, closed by the stale bot while waiting for review):

- **Perf** (@mihaimaruseac's concern about a branch slowing the kernel): the packet path stays fully vectorized, using one compare and select around the existing `packetOp`; the scalar path marks the saturation branch `TF_PREDICT_FALSE`. The float path, which is the hot dtype in practice, is untouched.
- **dtype compatibility** (raised in that PR's review): moot by construction, since only the double instantiation changes; float, half and bfloat16 keep the existing functor.
- **NaN**: the saturation mask is written as `|x| >= 6` selecting the saturated value, so NaN fails the comparison and keeps the forwarded value, preserving `erf(NaN) = NaN` on both scalar and packet paths.
- **No correct value changes**: for `6 <= |x| <= 1.34e154` the current implementation already returns exactly +/-1, so the select replaces 1.0 with 1.0; below 6 nothing changes.

All packet primitives used (`pcmp_le`, `pselect`, `pabs`, `pnegate`, `pzero`) are already used elsewhere in this header.

## Verification

The regression test covers +/-inf, values on both sides of the overflow threshold (1.34e154 / 1.35e154), a large finite value (1e300), the saturation seam (5.9, 6.0, 6.1) and NaN propagation. Against the unpatched 2.21.0 wheel it fails as expected, so it gates the change; the C++ itself is not compiled locally (no Bazel on this machine), so CI is the first build.

Arguably the root fix belongs in Eigen's `erf<double>`; this addresses it at the TF layer as #108592 did, which @mihaimaruseac considered reasonable pending review. Happy to also file the upstream Eigen issue if useful.

Credit to @Thrsu for the report and to @shahid1330 for the earlier attempt in #108592.