### PR TITLE
Validate atrous_conv2d input ranks

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
@@ -177,6 +177,14 @@ class AtrousConv2DTest(test.TestCase):
           rate=1,
           padding="SAME")
 
+  def testAtrousConv2DInvalidFilterRank(self):
+    with self.assertRaisesRegex(ValueError, "rank 4"):
+      nn_ops.atrous_conv2d(
+          value=np.ones([1, 1, 1, 1]),
+          filters=np.ones([10]),
+          rate=1,
+          padding="SAME")
+
 
 class AtrousConv2DTransposeTest(test.TestCase):
 

--- a/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
@@ -169,6 +169,14 @@ class AtrousConv2DTest(test.TestCase):
             padding="SAME")
         self.evaluate(op)
 
+  def testAtrousConv2DInvalidInputRank(self):
+    with self.assertRaisesRegex(ValueError, "rank 4"):
+      nn_ops.atrous_conv2d(
+          value=np.ones([10]),
+          filters=np.ones([1, 1, 1, 1]),
+          rate=1,
+          padding="SAME")
+
 
 class AtrousConv2DTransposeTest(test.TestCase):
 

--- a/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
@@ -266,7 +266,7 @@ class AtrousDepthwiseConv2DTest(test.TestCase):
   def testInvalidInputRank(self):
     value = array_ops.zeros([10], dtype=dtypes.float32)
     filters = array_ops.zeros([5, 5, 1, 8], dtype=dtypes.float32)
-    with self.assertRaisesRegex(ValueError, "rank at least 3"):
+    with self.assertRaisesRegex(ValueError, "rank 4"):
       nn_ops.atrous_conv2d(value, filters, rate=1, padding="VALID")
 
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1912,8 +1912,9 @@ def atrous_conv2d(value, filters, rate, padding, name=None):
         [batch, height, width, out_channels].
 
   Raises:
-    ValueError: If input/output depth does not match `filters`' shape, or if
-      padding is other than `'VALID'` or `'SAME'`.
+    ValueError: If input/output depth does not match `filters`' shape, if
+      `value` or `filters` is not rank 4, or if padding is other than
+      `'VALID'` or `'SAME'`.
 
   References:
     Multi-Scale Context Aggregation by Dilated Convolutions:
@@ -1932,6 +1933,10 @@ def atrous_conv2d(value, filters, rate, padding, name=None):
       (https://ieeexplore.ieee.org/abstract/document/6738831)
       ([pdf](https://arxiv.org/pdf/1302.1700.pdf))
   """
+  value = ops.convert_to_tensor(value, name="value")
+  filters = ops.convert_to_tensor(filters, name="filters")
+  value.shape.assert_has_rank(4)
+  filters.shape.assert_has_rank(4)
   return convolution(
       input=value,
       filter=filters,


### PR DESCRIPTION
Reject non-rank-4 inputs and filters before native convolution code runs, preventing malformed CPU inputs from reaching shape indexing code that can abort the process. Add a regression test for invalid input rank.