### PR TITLE
Validate conv2d_transpose output shape

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
@@ -321,6 +321,14 @@ class Conv2DTransposeTest(test.TestCase):
             strides=[1])
         self.evaluate(op)
 
+  def testConv2DTransposeInvalidOutputShapeRank(self):
+    with self.assertRaisesRegex(ValueError, "four elements"):
+      nn_ops.conv2d_transpose(
+          input=np.ones((1, 1, 1, 1)),
+          filters=np.ones((1, 1, 1, 1)),
+          output_shape=[2, 4, 2],
+          strides=[1])
+
   def testConv2DTransposeLargeOutputShape(self):
     # On GPU, this test does try to allocate the output tensor and OOMs.
     with test_util.device(use_gpu=False):

--- a/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
@@ -331,29 +331,29 @@ class Conv2DTransposeTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testConv2DTransposeUnknownOutputShapeRank(self):
-    with self.session():
+    with self.session() as sess:
       output_shape = array_ops.placeholder(dtypes.int32, shape=None)
       op = nn_ops.conv2d_transpose(
           input=np.ones((1, 1, 1, 1)),
           filters=np.ones((1, 1, 1, 1)),
           output_shape=output_shape,
           strides=[1])
-      self.evaluate(op, feed_dict={output_shape: [1, 1, 1, 1]})
+      sess.run(op, feed_dict={output_shape: [1, 1, 1, 1]})
       with self.assertRaises(errors.InvalidArgumentError):
-        self.evaluate(op, feed_dict={output_shape: [[1, 1, 1, 1]]})
+        sess.run(op, feed_dict={output_shape: [[1, 1, 1, 1]]})
 
   @test_util.run_deprecated_v1
   def testConv2DTransposeUnknownOutputShapeSize(self):
-    with self.session():
+    with self.session() as sess:
       output_shape = array_ops.placeholder(dtypes.int32, shape=[None])
       op = nn_ops.conv2d_transpose(
           input=np.ones((1, 1, 1, 1)),
           filters=np.ones((1, 1, 1, 1)),
           output_shape=output_shape,
           strides=[1])
-      self.evaluate(op, feed_dict={output_shape: [1, 1, 1, 1]})
+      sess.run(op, feed_dict={output_shape: [1, 1, 1, 1]})
       with self.assertRaises(errors.InvalidArgumentError):
-        self.evaluate(op, feed_dict={output_shape: [1, 1, 1]})
+        sess.run(op, feed_dict={output_shape: [1, 1, 1]})
 
   def testConv2DTransposeLargeOutputShape(self):
     # On GPU, this test does try to allocate the output tensor and OOMs.

--- a/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
@@ -329,6 +329,32 @@ class Conv2DTransposeTest(test.TestCase):
           output_shape=[2, 4, 2],
           strides=[1])
 
+  @test_util.run_deprecated_v1
+  def testConv2DTransposeUnknownOutputShapeRank(self):
+    with self.session():
+      output_shape = array_ops.placeholder(dtypes.int32, shape=None)
+      op = nn_ops.conv2d_transpose(
+          input=np.ones((1, 1, 1, 1)),
+          filters=np.ones((1, 1, 1, 1)),
+          output_shape=output_shape,
+          strides=[1])
+      self.evaluate(op, feed_dict={output_shape: [1, 1, 1, 1]})
+      with self.assertRaises(errors.InvalidArgumentError):
+        self.evaluate(op, feed_dict={output_shape: [[1, 1, 1, 1]]})
+
+  @test_util.run_deprecated_v1
+  def testConv2DTransposeUnknownOutputShapeSize(self):
+    with self.session():
+      output_shape = array_ops.placeholder(dtypes.int32, shape=[None])
+      op = nn_ops.conv2d_transpose(
+          input=np.ones((1, 1, 1, 1)),
+          filters=np.ones((1, 1, 1, 1)),
+          output_shape=output_shape,
+          strides=[1])
+      self.evaluate(op, feed_dict={output_shape: [1, 1, 1, 1]})
+      with self.assertRaises(errors.InvalidArgumentError):
+        self.evaluate(op, feed_dict={output_shape: [1, 1, 1]})
+
   def testConv2DTransposeLargeOutputShape(self):
     # On GPU, this test does try to allocate the output tensor and OOMs.
     with test_util.device(use_gpu=False):

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2738,8 +2738,9 @@ def conv2d_transpose_v2(
     A `Tensor` with the same type as `input`.
 
   Raises:
-    ValueError: If input/output depth does not match `filter`'s shape, or if
-      padding is other than `'VALID'` or `'SAME'`.
+    ValueError: If input/output depth does not match `filter`'s shape, if
+      `output_shape` is not a rank-1 tensor with four elements, or if padding
+      is other than `'VALID'` or `'SAME'`.
 
   References:
     Deconvolutional Networks:
@@ -2750,6 +2751,23 @@ def conv2d_transpose_v2(
   """
   with ops.name_scope(name, "conv2d_transpose",
                       [input, filter, output_shape]) as name:
+    output_shape = ops.convert_to_tensor(output_shape, name="output_shape")
+    output_shape.shape.assert_has_rank(1)
+    output_shape_size = output_shape.shape[0].value
+    if output_shape_size is not None:
+      if output_shape_size != 4:
+        raise ValueError(
+            "`output_shape` must have four elements. "
+            f"Received: output_shape={output_shape.shape}")
+    else:
+      with ops.control_dependencies([
+          check_ops.assert_equal(
+              array_ops.size(output_shape),
+              4,
+              message="`output_shape` must have four elements.")
+      ]):
+        output_shape = array_ops.identity(output_shape)
+
     if data_format is None:
       data_format = "NHWC"
     channel_index = 1 if data_format.startswith("NC") else 3

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2752,15 +2752,30 @@ def conv2d_transpose_v2(
   with ops.name_scope(name, "conv2d_transpose",
                       [input, filter, output_shape]) as name:
     output_shape = ops.convert_to_tensor(output_shape, name="output_shape")
-    output_shape.shape.assert_has_rank(1)
-    output_shape_size = output_shape.shape[0].value
-    if output_shape_size is not None:
-      if output_shape_size != 4:
+    if output_shape.shape.rank is not None:
+      if output_shape.shape.rank != 1:
         raise ValueError(
-            "`output_shape` must have four elements. "
+            "`output_shape` must be a rank 1 Tensor. "
             f"Received: output_shape={output_shape.shape}")
+      if output_shape.shape[0] is not None:
+        if output_shape.shape[0] != 4:
+          raise ValueError(
+              "`output_shape` must have four elements. "
+              f"Received: output_shape={output_shape.shape}")
+      else:
+        with ops.control_dependencies([
+            check_ops.assert_equal(
+                array_ops.size(output_shape),
+                4,
+                message="`output_shape` must have four elements.")
+        ]):
+          output_shape = array_ops.identity(output_shape)
     else:
       with ops.control_dependencies([
+          check_ops.assert_rank(
+              output_shape,
+              1,
+              message="`output_shape` must be a rank 1 Tensor."),
           check_ops.assert_equal(
               array_ops.size(output_shape),
               4,


### PR DESCRIPTION
Validate the output_shape rank and element count before invoking Conv2DBackpropInput, preventing malformed CPU inputs from reaching native shape indexing code that can abort the process. Add a regression test for a three-element output shape.