### PR TITLE
Reject non-int64 SparseTensor indices consistently

### DIFF
--- a/tensorflow/python/framework/sparse_tensor.py
+++ b/tensorflow/python/framework/sparse_tensor.py
@@ -128,6 +128,11 @@ class SparseTensor(internal.NativeObject, composite_tensor.CompositeTensor):
         unknown or contains unknown elements (None or -1).
     """
     with ops.name_scope(None, "SparseTensor", [indices, values, dense_shape]):
+      if (tensor_util.is_tf_type(indices) and
+          indices.dtype != dtypes.int64):
+        raise TypeError(
+            "`indices` must be a Tensor of dtype int64. "
+            f"Received dtype={indices.dtype}.")
       indices = ops.convert_to_tensor(
           indices, name="indices", dtype=dtypes.int64)
       # TODO(touts): Consider adding mutable_values() when 'values'

--- a/tensorflow/python/framework/sparse_tensor.py
+++ b/tensorflow/python/framework/sparse_tensor.py
@@ -129,7 +129,7 @@ class SparseTensor(internal.NativeObject, composite_tensor.CompositeTensor):
     """
     with ops.name_scope(None, "SparseTensor", [indices, values, dense_shape]):
       if (tensor_util.is_tf_type(indices) and
-          indices.dtype != dtypes.int64):
+          indices.dtype.base_dtype != dtypes.int64):
         raise TypeError(
             "`indices` must be a Tensor of dtype int64. "
             f"Received dtype={indices.dtype}.")

--- a/tensorflow/python/framework/sparse_tensor_test.py
+++ b/tensorflow/python/framework/sparse_tensor_test.py
@@ -60,6 +60,21 @@ class SparseTensorTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(sp_value.values, value.values)
       self.assertAllEqual(sp_value.dense_shape, value.dense_shape)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testRejectsNonInt64TensorIndices(self):
+    indices = ops.convert_to_tensor([[0, 1]], dtype=dtypes.int32)
+    with self.assertRaisesRegex(TypeError, "indices.*dtype int64"):
+      sparse_tensor.SparseTensor(indices, [1], [2, 2])
+
+  def testRejectsNonInt64TensorIndicesInFunction(self):
+    @def_function.function
+    def create_sparse_tensor(indices):
+      return sparse_tensor.SparseTensor(indices, [1], [2, 2])
+
+    indices = ops.convert_to_tensor([[0, 1]], dtype=dtypes.int32)
+    with self.assertRaisesRegex(TypeError, "indices.*dtype int64"):
+      create_sparse_tensor(indices)
+
   def testShape(self):
 
     @def_function.function


### PR DESCRIPTION
Validate Tensor and Variable indices before dtype conversion so eager and tf.function reject int32 indices consistently instead of allowing graph tracing to cast them silently. Preserve Python-list conversion to int64 and add eager, graph, and tf.function regression coverage.