### PR TITLE
Fix eager tf.while_loop corrupting shape for single-var loop

### DIFF
--- a/tensorflow/python/ops/control_flow_ops_test.py
+++ b/tensorflow/python/ops/control_flow_ops_test.py
@@ -1648,6 +1648,25 @@ class WhileLoopTestCase(test_util.TensorFlowTestCase):
         c, b, [i], return_same_structure=True, maximum_iterations=50)
     self.assertEqual(self.evaluate(r), [10])
 
+  @test_util.run_v2_only
+  def testEagerWhileLoopSingleLoopVarBareTensorBodyPreservesShape(self):
+    x = constant_op.constant([[5.0]], shape=[1, 1])
+    shapes_seen = []
+
+    def cond(x):
+      shapes_seen.append(x.shape.as_list())
+      return math_ops.greater(x[0, 0], 3)
+
+    def body(x):
+      return x - 1
+
+    r = while_loop.while_loop(cond, body, [x], return_same_structure=True)
+
+    self.assertAllEqual(shapes_seen, [[1, 1]] * len(shapes_seen))
+    self.assertLen(shapes_seen, 3)
+    self.assertIsInstance(r, list)
+    self.assertAllClose(self.evaluate(r), [[[3.0]]])
+
   @test_util.enable_control_flow_v2
   @test_util.run_in_graph_and_eager_modes
   def testSkipsUnnecessaryCaptureGradients(self):

--- a/tensorflow/python/ops/while_loop.py
+++ b/tensorflow/python/ops/while_loop.py
@@ -483,7 +483,7 @@ def while_loop(cond,
       packed = False  # whether the body result was packed into a 1-item tuple
 
       orig_loop_vars_type = (
-          type(loop_vars) if isinstance(loop_vars, (list, tuple)) else list)
+          type(loop_vars) if type(loop_vars) in (list, tuple) else list)
 
       loop_var_structure = nest.map_structure(type_spec.type_spec_from_value,
                                               list(loop_vars))

--- a/tensorflow/python/ops/while_loop.py
+++ b/tensorflow/python/ops/while_loop.py
@@ -482,13 +482,17 @@ def while_loop(cond,
     if executing_eagerly:
       packed = False  # whether the body result was packed into a 1-item tuple
 
+      orig_loop_vars_type = (
+          type(loop_vars) if isinstance(loop_vars, (list, tuple)) else list)
+
       loop_var_structure = nest.map_structure(type_spec.type_spec_from_value,
                                               list(loop_vars))
       while cond(*loop_vars):
         loop_vars = body(*loop_vars)
-        if try_to_pack and not isinstance(loop_vars, (list, tuple)):
-          packed = True
-          loop_vars = (loop_vars,)
+        if not isinstance(loop_vars, (list, tuple)):
+          if try_to_pack:
+            packed = True
+          loop_vars = orig_loop_vars_type((loop_vars,))
         nest.assert_same_structure(loop_var_structure, list(loop_vars))
 
       def convert(x):


### PR DESCRIPTION
Fixes #125538.

tf.while_loop could corrupt the shape of a single-element loop_vars list when the body returned a bare Tensor, e.g. tf.while_loop(cond, lambda x: x + 1, [x]). In eager mode, the Tensor could be incorrectly iterated over between iterations, changing its shape from (1, 1) to (1,) and causing a later indexing error.

Root cause - The eager execution path did not re-pack a bare Tensor body result when called through the v2 tf.while_loop API. As a result, the loop variable lost its original list structure and was implicitly unpacked using Python iteration.

Graph mode and XLA were unaffected because they preserve the structured loop-variable signature during tracing.

Fix - Always re-pack bare Tensor/TensorArray body results using the original top-level container type (list or tuple). This preserves loop-variable structure and prevents shape corruption across iterations.

Malformed body functions now also fail fast with a clear structure-mismatch error.

Testing - Added a regression test covering a single loop variable with a bare-Tensor body.