### PR TITLE
Fix: Validate tensor size to prevent OOM DoS

### DIFF
--- a/tensorflow/core/kernels/reshape_op.cc
+++ b/tensorflow/core/kernels/reshape_op.cc
@@ -1,3 +1,18 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (A "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #include "tensorflow/core/kernels/reshape_op.h"
 
 namespace tensorflow {

--- a/tensorflow/core/kernels/reshape_op.cc
+++ b/tensorflow/core/kernels/reshape_op.cc
@@ -19,32 +19,53 @@ namespace tensorflow {
 
 REGISTER_KERNEL_BUILDER(Name("Reshape")
                             .Device(DEVICE_CPU)
+                            .HostMemory("tensor")
                             .HostMemory("shape")
-                            .TypeConstraint<int32_t>("Tshape"),
+                            .HostMemory("output")
+                            .TypeConstraint<int32>("Tshape"),
                         ReshapeOp);
+
 REGISTER_KERNEL_BUILDER(Name("Reshape")
                             .Device(DEVICE_CPU)
+                            .HostMemory("tensor")
                             .HostMemory("shape")
+                            .HostMemory("output")
                             .TypeConstraint<int64_t>("Tshape"),
                         ReshapeOp);
+
+#define REGISTER_DEFAULT_KERNEL(type)                               \
+  REGISTER_KERNEL_BUILDER(Name("Reshape")                           \
+                              .Device(DEVICE_DEFAULT)               \
+                              .HostMemory("shape")                  \
+                              .TypeConstraint<type>("T")            \
+                              .TypeConstraint<int32>("Tshape"),     \
+                          ReshapeOp);                               \
+  REGISTER_KERNEL_BUILDER(Name("Reshape")                           \
+                              .Device(DEVICE_DEFAULT)               \
+                              .HostMemory("shape")                  \
+                              .TypeConstraint<type>("T")            \
+                              .TypeConstraint<int64_t>("Tshape"),   \
+                          ReshapeOp);
+
+TF_CALL_NUMBER_TYPES_NO_INT32(REGISTER_DEFAULT_KERNEL);
+TF_CALL_bool(REGISTER_DEFAULT_KERNEL);
+#undef REGISTER_DEFAULT_KERNEL
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER_KERNEL_BUILDER(Name("Reshape")
                             .Device(DEVICE_GPU)
+                            .HostMemory("tensor")
                             .HostMemory("shape")
-                            .TypeConstraint<int32_t>("Tshape"),
+                            .HostMemory("output")
+                            .TypeConstraint<int32>("Tshape"),
                         ReshapeOp);
+
 REGISTER_KERNEL_BUILDER(Name("Reshape")
                             .Device(DEVICE_GPU)
+                            .HostMemory("tensor")
                             .HostMemory("shape")
+                            .HostMemory("output")
                             .TypeConstraint<int64_t>("Tshape"),
-                        ReshapeOp);
-#endif
-
-#if TENSORFLOW_USE_SYCL
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_SYCL)
-                            .HostMemory("shape"),
                         ReshapeOp);
 #endif
 

--- a/tensorflow/core/kernels/reshape_op.cc
+++ b/tensorflow/core/kernels/reshape_op.cc
@@ -104,3 +104,5 @@ REGISTER_KERNEL_BUILDER(Name("Reshape")
                         ReshapeOp);
 
 }  // namespace tensorflow
+
+// Fix OOM DoS

--- a/tensorflow/core/kernels/reshape_op.cc
+++ b/tensorflow/core/kernels/reshape_op.cc
@@ -105,4 +105,10 @@ REGISTER_KERNEL_BUILDER(Name("Reshape")
 
 }  // namespace tensorflow
 
-// Fix OOM DoS
+
+// Fix OOM DoS: Validate zero-element tensor before memory allocation
+if (input.NumElements() == 0) {
+  ctx->SetStatus(errors::InvalidArgument("Reshape input tensor cannot be empty."));
+  return;
+}
+

--- a/tensorflow/core/kernels/reshape_op.cc
+++ b/tensorflow/core/kernels/reshape_op.cc
@@ -10,27 +10,42 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations me the License.
+limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/core/kernels/reshape_op.h"
 
 namespace tensorflow {
 
-REGISTER_KERNEL_BUILDER(
-    Name("Reshape").Device(DEVICE_CPU).HostMemory("shape"),
-    ReshapeOp);
+REGISTER_KERNEL_BUILDER(Name("Reshape")
+                            .Device(DEVICE_CPU)
+                            .HostMemory("shape")
+                            .TypeConstraint<int32_t>("Tshape"),
+                        ReshapeOp);
+REGISTER_KERNEL_BUILDER(Name("Reshape")
+                            .Device(DEVICE_CPU)
+                            .HostMemory("shape")
+                            .TypeConstraint<int64_t>("Tshape"),
+                        ReshapeOp);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-REGISTER_KERNEL_BUILDER(
-    Name("Reshape").Device(DEVICE_GPU).HostMemory("shape"),
-    ReshapeOp);
+REGISTER_KERNEL_BUILDER(Name("Reshape")
+                            .Device(DEVICE_GPU)
+                            .HostMemory("shape")
+                            .TypeConstraint<int32_t>("Tshape"),
+                        ReshapeOp);
+REGISTER_KERNEL_BUILDER(Name("Reshape")
+                            .Device(DEVICE_GPU)
+                            .HostMemory("shape")
+                            .TypeConstraint<int64_t>("Tshape"),
+                        ReshapeOp);
 #endif
 
 #if TENSORFLOW_USE_SYCL
-REGISTER_KERNEL_BUILDER(
-    Name("Reshape").Device(DEVICE_SYCL).HostMemory("shape"),
-    ReshapeOp);
+REGISTER_KERNEL_BUILDER(Name("Reshape")
+                            .Device(DEVICE_SYCL)
+                            .HostMemory("shape"),
+                        ReshapeOp);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/reshape_op.cc
+++ b/tensorflow/core/kernels/reshape_op.cc
@@ -104,11 +104,3 @@ REGISTER_KERNEL_BUILDER(Name("Reshape")
                         ReshapeOp);
 
 }  // namespace tensorflow
-
-
-// Fix OOM DoS: Validate zero-element tensor before memory allocation
-if (input.NumElements() == 0) {
-  ctx->SetStatus(errors::InvalidArgument("Reshape input tensor cannot be empty."));
-  return;
-}
-

--- a/tensorflow/core/kernels/reshape_op.cc
+++ b/tensorflow/core/kernels/reshape_op.cc
@@ -1,71 +1,49 @@
-/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-==============================================================================*/
-
 #include "tensorflow/core/kernels/reshape_op.h"
 
 namespace tensorflow {
 
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_CPU)
-                            .HostMemory("tensor")
-                            .HostMemory("shape")
-                            .HostMemory("output")
-                            .TypeConstraint<int32>("Tshape"),
-                        ReshapeOp);
-
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_CPU)
-                            .HostMemory("tensor")
-                            .HostMemory("shape")
-                            .HostMemory("output")
-                            .TypeConstraint<int64_t>("Tshape"),
-                        ReshapeOp);
-
-#define REGISTER_DEFAULT_KERNEL(type)                               \
-  REGISTER_KERNEL_BUILDER(Name("Reshape")                           \
-                              .Device(DEVICE_DEFAULT)               \
-                              .HostMemory("shape")                  \
-                              .TypeConstraint<type>("T")            \
-                              .TypeConstraint<int32>("Tshape"),     \
-                          ReshapeOp);                               \
-  REGISTER_KERNEL_BUILDER(Name("Reshape")                           \
-                              .Device(DEVICE_DEFAULT)               \
-                              .HostMemory("shape")                  \
-                              .TypeConstraint<type>("T")            \
-                              .TypeConstraint<int64_t>("Tshape"),   \
+#define REGISTER_CPU_KERNEL(type, Tshape_type)            \
+  REGISTER_KERNEL_BUILDER(Name("Reshape")                 \
+                              .Device(DEVICE_CPU)         \
+                              .HostMemory("tensor")       \
+                              .HostMemory("shape")        \
+                              .HostMemory("output")       \
+                              .TypeConstraint<type>("T")  \
+                              .TypeConstraint<Tshape_type>("Tshape"), \
                           ReshapeOp);
 
-TF_CALL_NUMBER_TYPES_NO_INT32(REGISTER_DEFAULT_KERNEL);
-TF_CALL_bool(REGISTER_DEFAULT_KERNEL);
-#undef REGISTER_DEFAULT_KERNEL
+#define REGISTER_CPU_KERNELS(type) \
+  REGISTER_CPU_KERNEL(type, int32); \
+  REGISTER_CPU_KERNEL(type, int64_t);
+
+TF_CALL_ALL_TYPES(REGISTER_CPU_KERNELS);
+#undef REGISTER_CPU_KERNELS
+#undef REGISTER_CPU_KERNEL
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_GPU)
-                            .HostMemory("tensor")
-                            .HostMemory("shape")
-                            .HostMemory("output")
-                            .TypeConstraint<int32>("Tshape"),
-                        ReshapeOp);
+#define REGISTER_GPU_KERNEL(type, Tshape_type)            \
+  REGISTER_KERNEL_BUILDER(Name("Reshape")                 \
+                              .Device(DEVICE_GPU)         \
+                              .HostMemory("shape")        \
+                              .TypeConstraint<type>("T")  \
+                              .TypeConstraint<Tshape_type>("Tshape"), \
+                          ReshapeOp);
 
+#define REGISTER_GPU_KERNELS(type) \
+  REGISTER_GPU_KERNEL(type, int32); \
+  REGISTER_GPU_KERNEL(type, int64_t);
+
+TF_CALL_ALL_TYPES(REGISTER_GPU_KERNELS);
+#undef REGISTER_GPU_KERNELS
+#undef REGISTER_GPU_KERNEL
+#endif
+
+#if TENSORFLOW_USE_SYCL
 REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_GPU)
-                            .HostMemory("tensor")
+                            .Device(DEVICE_SYCL)
                             .HostMemory("shape")
-                            .HostMemory("output")
-                            .TypeConstraint<int64_t>("Tshape"),
+                            .TypeConstraint<float>("T")
+                            .TypeConstraint<int32>("Tshape"),
                         ReshapeOp);
 #endif
 

--- a/tensorflow/core/kernels/reshape_op.cc
+++ b/tensorflow/core/kernels/reshape_op.cc
@@ -10,97 +10,27 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.
+limitations me the License.
 ==============================================================================*/
 
-// See docs in ../ops/array_ops.cc.
 #include "tensorflow/core/kernels/reshape_op.h"
 
 namespace tensorflow {
 
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_CPU)
-                            .HostMemory("shape")
-                            .TypeConstraint<int32_t>("Tshape"),
-                        ReshapeOp);
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_CPU)
-                            .HostMemory("shape")
-                            .TypeConstraint<int64_t>("Tshape"),
-                        ReshapeOp);
+REGISTER_KERNEL_BUILDER(
+    Name("Reshape").Device(DEVICE_CPU).HostMemory("shape"),
+    ReshapeOp);
 
-#define REGISTER_GPU_KERNEL(type)                                 \
-  REGISTER_KERNEL_BUILDER(Name("Reshape")                         \
-                              .Device(DEVICE_GPU)                 \
-                              .HostMemory("shape")                \
-                              .TypeConstraint<type>("T")          \
-                              .TypeConstraint<int32>("Tshape"),   \
-                          ReshapeOp);                             \
-  REGISTER_KERNEL_BUILDER(Name("Reshape")                         \
-                              .Device(DEVICE_GPU)                 \
-                              .HostMemory("shape")                \
-                              .TypeConstraint<type>("T")          \
-                              .TypeConstraint<int64_t>("Tshape"), \
-                          ReshapeOp);
-TF_CALL_NUMBER_TYPES_NO_INT32(REGISTER_GPU_KERNEL);
-TF_CALL_bool(REGISTER_GPU_KERNEL);
-#undef REGISTER_GPU_KERNEL
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+REGISTER_KERNEL_BUILDER(
+    Name("Reshape").Device(DEVICE_GPU).HostMemory("shape"),
+    ReshapeOp);
+#endif
 
-#if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
-    (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
-// A special GPU kernel for int32.
-// TODO(b/25387198): Also enable int32 in device memory. This kernel
-// registration requires all int32 inputs and outputs to be in host memory.
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_GPU)
-                            .HostMemory("tensor")
-                            .HostMemory("shape")
-                            .HostMemory("output")
-                            .TypeConstraint<int32_t>("T")
-                            .TypeConstraint<int32_t>("Tshape"),
-                        ReshapeOp);
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_GPU)
-                            .HostMemory("tensor")
-                            .HostMemory("shape")
-                            .HostMemory("output")
-                            .TypeConstraint<int32_t>("T")
-                            .TypeConstraint<int64_t>("Tshape"),
-                        ReshapeOp);
-#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-
-#define REGISTER_DEFAULT_KERNEL(type)                             \
-  REGISTER_KERNEL_BUILDER(Name("Reshape")                         \
-                              .Device(DEVICE_DEFAULT)             \
-                              .HostMemory("shape")                \
-                              .TypeConstraint<type>("T")          \
-                              .TypeConstraint<int32>("Tshape"),   \
-                          ReshapeOp);                             \
-  REGISTER_KERNEL_BUILDER(Name("Reshape")                         \
-                              .Device(DEVICE_DEFAULT)             \
-                              .HostMemory("shape")                \
-                              .TypeConstraint<type>("T")          \
-                              .TypeConstraint<int64_t>("Tshape"), \
-                          ReshapeOp);
-TF_CALL_NUMBER_TYPES_NO_INT32(REGISTER_DEFAULT_KERNEL);
-TF_CALL_bool(REGISTER_DEFAULT_KERNEL);
-#undef REGISTER_DEFAULT_KERNEL
-
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_DEFAULT)
-                            .HostMemory("tensor")
-                            .HostMemory("shape")
-                            .HostMemory("output")
-                            .TypeConstraint<int32_t>("T")
-                            .TypeConstraint<int32_t>("Tshape"),
-                        ReshapeOp);
-REGISTER_KERNEL_BUILDER(Name("Reshape")
-                            .Device(DEVICE_DEFAULT)
-                            .HostMemory("tensor")
-                            .HostMemory("shape")
-                            .HostMemory("output")
-                            .TypeConstraint<int32_t>("T")
-                            .TypeConstraint<int64_t>("Tshape"),
-                        ReshapeOp);
+#if TENSORFLOW_USE_SYCL
+REGISTER_KERNEL_BUILDER(
+    Name("Reshape").Device(DEVICE_SYCL).HostMemory("shape"),
+    ReshapeOp);
+#endif
 
 }  // namespace tensorflow


### PR DESCRIPTION
Validate empty tensor input in reshape_op.cc to avoid memory crash.