### PR TITLE
Make op-def bindings safe for free-threaded Python

### DIFF
--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -1129,6 +1129,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
         "@xla//third_party/python_runtime:headers",  # buildcleaner: keep
     ],
     alwayslink = 1,

--- a/tensorflow/python/framework/op_def_library_pybind.cc
+++ b/tensorflow/python/framework/op_def_library_pybind.cc
@@ -87,7 +87,7 @@ inline std::string PyRepr(const py::handle& value) {
 }
 
 py::object DataTypeToPybindObject(const DataType& data_type) {
-  return py::reinterpret_borrow<py::object>(
+  return py::reinterpret_steal<py::object>(
       DataTypeToPyObject(data_type).release());
 }
 
@@ -99,7 +99,7 @@ py::object ToAttributeType(const py::handle& value, const AttributeType type) {
   if (result == nullptr) {
     throw std::runtime_error("Failed to perform conversion.");
   }
-  return py::reinterpret_borrow<py::object>(result.release());
+  return py::reinterpret_steal<py::object>(result.release());
 }
 
 inline bool MakeBool(const py::handle& value, const std::string& arg_name) {
@@ -611,7 +611,8 @@ void CheckAllInputsUsed(const std::string& op_type_name,
 
 // This module provides a subset of the functionality from op_def_library.py
 // and relies on op_def_library_test.py for test coverage.
-PYBIND11_MODULE(_op_def_library_pybind, m) {
+PYBIND11_MODULE(
+    _op_def_library_pybind, m, pybind11::mod_gil_not_used()) {
   // Method assumes all inputs in `keywords` are of type tf.Tensor.
   m.def("process_inputs", [](std::string& op_type_name, int producer_version,
                              py::dict& keywords) {

--- a/tensorflow/python/framework/op_def_registry.cc
+++ b/tensorflow/python/framework/op_def_registry.cc
@@ -21,7 +21,8 @@ limitations under the License.
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(_op_def_registry, m) {
+PYBIND11_MODULE(
+    _op_def_registry, m, pybind11::mod_gil_not_used()) {
   m.def("get", [](const std::string& name) {
     const tensorflow::OpDef* op_def = nullptr;
     auto status = tensorflow::OpRegistry::Global()->LookUpOpDef(name, &op_def);

--- a/tensorflow/python/framework/op_def_util.cc
+++ b/tensorflow/python/framework/op_def_util.cc
@@ -201,9 +201,17 @@ Safe_PyObjectPtr ConvertListAttr(PyObject* value, T convert_functor) {
   // invalidating the raw items pointer.
   for (Py_ssize_t i = 0; i < PyList_Size(result.get()); ++i) {
     if (!PyFloat_Check(value)) {
+#ifdef Py_GIL_DISABLED
+      // Keep a strong reference across conversion because convert_functor may
+      // execute arbitrary Python code.
+      Safe_PyObjectPtr elem(PyList_GetItemRef(result.get(), i));
+      if (!elem) return nullptr;
+      Safe_PyObjectPtr item = convert_functor(elem.get());
+#else
       PyObject* elem = PyList_GetItem(result.get(), i);
       if (!elem) return nullptr;
       Safe_PyObjectPtr item = convert_functor(elem);
+#endif
       if (!item) return nullptr;
       if (PyList_SetItem(result.get(), i, item.release()) < 0) return nullptr;
     }

--- a/tensorflow/python/framework/op_def_util_pybind.cc
+++ b/tensorflow/python/framework/op_def_util_pybind.cc
@@ -19,18 +19,17 @@ namespace py = pybind11;
 
 namespace {
 
-py::handle ConvertAttr(py::handle value, std::string attr_type) {
+py::object ConvertAttr(py::handle value, std::string attr_type) {
   tensorflow::Safe_PyObjectPtr result =
       ::tensorflow::ConvertPyObjectToAttributeType(
           value.ptr(), ::tensorflow::AttributeTypeFromName(attr_type));
   if (!result) {
     throw py::error_already_set();
   }
-  Py_INCREF(result.get());
-  return result.release();
+  return py::reinterpret_steal<py::object>(result.release());
 }
 
-py::handle SerializedAttrValueToPyObject(std::string attr_value_string) {
+py::object SerializedAttrValueToPyObject(std::string attr_value_string) {
   tensorflow::AttrValue attr_value;
   attr_value.ParseFromString(attr_value_string);
   tensorflow::Safe_PyObjectPtr result =
@@ -38,14 +37,13 @@ py::handle SerializedAttrValueToPyObject(std::string attr_value_string) {
   if (!result) {
     throw py::error_already_set();
   }
-  Py_INCREF(result.get());
-  return result.release();
+  return py::reinterpret_steal<py::object>(result.release());
 }
 
 }  // namespace
 
 // Expose op_def_util.h functions via Python.
-PYBIND11_MODULE(_op_def_util, m) {
+PYBIND11_MODULE(_op_def_util, m, py::mod_gil_not_used()) {
   // Note: the bindings below are added for testing purposes; but the functions
   // are expected to be called from c++, not Python.
   m.def("ConvertPyObjectToAttributeType", ConvertAttr, py::arg("value"),


### PR DESCRIPTION
## Summary

Make TensorFlow's op-def Python bindings compatible with CPython free-threaded builds.

This PR focuses on:

- pybind11 free-threaded module declarations
- correct Python object ownership transfer
- safe list element lifetime during attribute conversion

## Changes

### Mark op-def modules as GIL-independent

Declare:

```text
py::mod_gil_not_used()
```

for:

- `_op_def_registry`
- `_op_def_library_pybind`
- `_op_def_util`

### Fix pybind ownership transfers

Replace borrowed pybind conversions of newly owned Python references with ownership-taking conversions using:

```text
py::reinterpret_steal<py::object>()
```

This avoids incorrect reference ownership when converting TensorFlow-owned `PyObject*` values into pybind objects.

### Keep list elements alive during conversion

Under `Py_GIL_DISABLED`, use:

```text
PyList_GetItemRef()
```

instead of relying on a borrowed reference from `PyList_GetItem()`.

The strong reference is kept alive across the attribute conversion call, which may execute arbitrary Python code.

## Validation

Validated with CPython 3.14 free-threaded hermetic Python using:

```text
--repo_env=HERMETIC_PYTHON_VERSION=3.14-freethreaded
--repo_env=USE_PYWRAP_RULES=True
--@rules_python//python/config_settings:py_freethreaded=yes
```

The following affected native targets built successfully:

```text
//tensorflow/python/framework:_op_def_registry
//tensorflow/python/framework:_op_def_library_pybind
//tensorflow/python/framework:_op_def_util
```

The clean PR branch build completed successfully.

`op_def_util_test` was also validated earlier on the full working free-threaded TensorFlow snapshot. A clean-worktree re-run was not completed locally because the Python test target expands to a very large dependency graph.

## Dependency

Local CPython 3.14 free-threaded validation uses:

TensorFlow hermetic Python support:
https://github.com/tensorflow/tensorflow/pull/125634

and:

rules_ml_toolchain:
https://github.com/tensorflow/rules_ml_toolchain/pull/302

## Scope

This PR is intentionally limited to op-def bindings, ownership correctness, and free-threaded safety.

Other TensorFlow free-threading changes are being submitted separately.