### PR TITLE
Make Python API helper bindings safe for free-threaded Python

### DIFF
--- a/tensorflow/python/framework/py_context_manager.cc
+++ b/tensorflow/python/framework/py_context_manager.cc
@@ -40,10 +40,17 @@ PyContextManager::~PyContextManager() {
     if (PyErr_Occurred()) {
       PyObject *type, *value, *traceback;
       PyErr_Fetch(&type, &value, &traceback);
-      value = value ? value : Py_None;
-      traceback = traceback ? traceback : Py_None;
+
+      Safe_PyObjectPtr type_ref(type);
+      Safe_PyObjectPtr value_ref(value);
+      Safe_PyObjectPtr traceback_ref(traceback);
+
+      PyObject* exit_value = value ? value : Py_None;
+      PyObject* exit_traceback = traceback ? traceback : Py_None;
+
       Safe_PyObjectPtr result(PyObject_CallMethod(
-          context_manager_.get(), _exit, _ooo, type, value, traceback));
+          context_manager_.get(), _exit, _ooo, type, exit_value,
+          exit_traceback));
       if (result) {
         if (PyObject_IsTrue(result.get())) {
           PyErr_SetString(
@@ -51,7 +58,8 @@ PyContextManager::~PyContextManager() {
               "tensorflow::PyContextManager::Enter does not support "
               "context managers that suppress exceptions.");
         } else {
-          PyErr_Restore(type, value, traceback);
+          PyErr_Restore(type_ref.release(), value_ref.release(),
+                        traceback_ref.release());
         }
       }
     } else {

--- a/tensorflow/python/framework/py_context_manager_pybind.cc
+++ b/tensorflow/python/framework/py_context_manager_pybind.cc
@@ -23,7 +23,7 @@ namespace {
 // Test harness for PyContextManager.  Creates a PyContextManager `cm` that
 // wraps `context_manager`, calls `cm.Enter()`, and then calls `body_func`
 // with `cm.var()`.  Returns the result of the function.
-py::handle TestPyContextManager(py::handle context_manager,
+py::object TestPyContextManager(py::handle context_manager,
                                 py::handle body_func) {
   tensorflow::Safe_PyObjectPtr result;
   {
@@ -38,7 +38,7 @@ py::handle TestPyContextManager(py::handle context_manager,
   // cm gets destroyed here.
 
   if (result) {
-    return result.release();
+    return py::reinterpret_steal<py::object>(result.release());
   } else {
     throw py::error_already_set();
   }
@@ -46,6 +46,6 @@ py::handle TestPyContextManager(py::handle context_manager,
 
 }  // namespace
 
-PYBIND11_MODULE(_py_context_manager, m) {
+PYBIND11_MODULE(_py_context_manager, m, py::mod_gil_not_used()) {
   m.def("test_py_context_manager", TestPyContextManager);
 }

--- a/tensorflow/python/framework/python_api_info_wrapper.cc
+++ b/tensorflow/python/framework/python_api_info_wrapper.cc
@@ -55,7 +55,8 @@ std::string DebugInfo(PythonAPIInfo* api_info) { return api_info->DebugInfo(); }
 using PythonAPIInfo = tensorflow::PythonAPIInfo;
 using InferredAttributes = tensorflow::PythonAPIInfo::InferredAttributes;
 
-PYBIND11_MODULE(_pywrap_python_api_info, m) {
+PYBIND11_MODULE(
+    _pywrap_python_api_info, m, py::mod_gil_not_used()) {
   py::class_<PythonAPIInfo>(m, "PythonAPIInfo")
       .def(py::init<const std::string&>())
       .def("InitializeFromRegisteredOp",

--- a/tensorflow/python/framework/python_api_parameter_converter_wrapper.cc
+++ b/tensorflow/python/framework/python_api_parameter_converter_wrapper.cc
@@ -79,7 +79,17 @@ PythonAPIInfo::InferredAttributes Convert(
   if (PyList_Check(arg_list.ptr())) {
     for (Py_ssize_t i = 0; i < size; ++i) {
       PyObject* new_item = args_raw_vec[i];
-      PyList_SET_ITEM(arg_list.ptr(), i, new_item);
+
+      // Transfer the owned reference in args_raw_vec to the list.
+      // PyList_SetItem also releases the reference previously owned by
+      // the list at this index.
+      args_raw_vec[i] = nullptr;
+      if (PyList_SetItem(arg_list.ptr(), i, new_item) < 0) {
+        for (Py_ssize_t j = i + 1; j < size; ++j) {
+          Py_XDECREF(args_raw_vec[j]);
+        }
+        throw py::error_already_set();
+      }
     }
   } else {
     for (Py_ssize_t i = 0; i < size; ++i) {
@@ -93,6 +103,7 @@ PythonAPIInfo::InferredAttributes Convert(
 }  // namespace
 }  // namespace tensorflow
 
-PYBIND11_MODULE(_pywrap_python_api_parameter_converter, m) {
+PYBIND11_MODULE(_pywrap_python_api_parameter_converter, m,
+                  py::mod_gil_not_used()) {
   m.def("Convert", tensorflow::Convert);
 }

--- a/tensorflow/python/framework/python_tensor_converter_wrapper.cc
+++ b/tensorflow/python/framework/python_tensor_converter_wrapper.cc
@@ -93,7 +93,7 @@ PythonTensorConverter MakePythonTensorConverter(py::handle py_eager_context) {
   return PythonTensorConverter(py_eager_context.ptr(), ctx, device_name);
 }
 
-py::handle Convert(tensorflow::PythonTensorConverter* self, py::handle obj,
+py::object Convert(tensorflow::PythonTensorConverter* self, py::handle obj,
                    py::handle dtype) {
   DataType dtype_enum = static_cast<DataType>(PY_INT_AS_LONG(dtype.ptr()));
   bool used_fallback = false;
@@ -101,20 +101,31 @@ py::handle Convert(tensorflow::PythonTensorConverter* self, py::handle obj,
       self->Convert(obj.ptr(), dtype_enum, &used_fallback);
   if (!converted) throw py::error_already_set();
 
-  PyObject* result = PyTuple_New(3);
-  PyTuple_SET_ITEM(result, 0, converted.release());
-  PyTuple_SET_ITEM(result, 1, PY_INT_FROM_LONG(dtype_enum));
-  PyTuple_SET_ITEM(result, 2, used_fallback ? Py_True : Py_False);
-  Py_INCREF(PyTuple_GET_ITEM(result, 1));
-  Py_INCREF(PyTuple_GET_ITEM(result, 2));
-  return result;
+  Safe_PyObjectPtr result(PyTuple_New(3));
+  if (!result) throw py::error_already_set();
+
+  Safe_PyObjectPtr dtype_object(PY_INT_FROM_LONG(dtype_enum));
+  if (!dtype_object) throw py::error_already_set();
+
+  PyObject* used_fallback_object = used_fallback ? Py_True : Py_False;
+  Py_INCREF(used_fallback_object);
+
+  // The tuple is new and not yet published, so SET_ITEM is safe here.
+  // Each call transfers exactly one owned reference into the tuple.
+  PyTuple_SET_ITEM(result.get(), 0, converted.release());
+  PyTuple_SET_ITEM(result.get(), 1, dtype_object.release());
+  PyTuple_SET_ITEM(result.get(), 2, used_fallback_object);
+
+  return py::reinterpret_steal<py::object>(result.release());
 }
 
 }  // namespace
 }  // namespace tensorflow
 
-PYBIND11_MODULE(_pywrap_python_tensor_converter, m) {
+PYBIND11_MODULE(_pywrap_python_tensor_converter, m,
+                  py::mod_gil_not_used()) {
   py::class_<tensorflow::PythonTensorConverter>(m, "PythonTensorConverter")
-      .def(py::init(&tensorflow::MakePythonTensorConverter))
+      .def(py::init(&tensorflow::MakePythonTensorConverter),
+           py::keep_alive<1, 2>())
       .def("Convert", tensorflow::Convert);
 }


### PR DESCRIPTION
## Summary

Make a small set of TensorFlow Python API helper bindings compatible with CPython free-threaded builds.

This PR focuses on Python object ownership, lifetime correctness, and pybind11 free-threaded module declarations across:

- context-manager test bindings
- Python API metadata bindings
- Python API parameter conversion
- Python tensor conversion

## Changes

### Fix `PyContextManager` exception ownership

Wrap objects returned by `PyErr_Fetch()` in `Safe_PyObjectPtr` so the fetched exception type, value, and traceback are correctly owned.

When restoring the exception, ownership is transferred explicitly via `release()`.

This avoids leaking or mishandling exception references.

### Fix context-manager pybind return ownership

Change the test binding return type from a borrowed `py::handle` to an owning `py::object` and transfer ownership with:

```text
py::reinterpret_steal<py::object>()
```

The module is also declared with:

```text
py::mod_gil_not_used()
```

### Mark Python API info bindings as GIL-independent

Declare:

```text
py::mod_gil_not_used()
```

for:

```text
_pywrap_python_api_info
```

### Fix parameter-converter list ownership

Replace raw `PyList_SET_ITEM` mutation with checked `PyList_SetItem()` ownership transfer.

The converter now:

- transfers exactly one owned reference into the list
- nulls the transferred slot
- releases remaining owned references on failure
- propagates Python errors through `py::error_already_set`

The module is also marked GIL-independent.

### Fix Python tensor converter ownership

Return an owning `py::object` rather than a borrowed handle.

The result tuple now explicitly owns:

- the converted tensor
- the dtype object
- the fallback boolean

and transfers ownership with:

```text
py::reinterpret_steal<py::object>()
```

### Preserve eager-context lifetime

Add:

```text
py::keep_alive<1, 2>()
```

to the `PythonTensorConverter` constructor binding so the Python eager-context object remains alive for the lifetime of the converter.

The module is also declared with:

```text
py::mod_gil_not_used()
```

## Validation

Validated with CPython 3.14 free-threaded hermetic Python using:

```text
--repo_env=HERMETIC_PYTHON_VERSION=3.14-freethreaded
--repo_env=USE_PYWRAP_RULES=True
--@rules_python//python/config_settings:py_freethreaded=yes
```

The following affected targets built successfully:

```text
//tensorflow/python/framework:_py_context_manager
//tensorflow/python/framework:_pywrap_python_api_info
//tensorflow/python/framework:_pywrap_python_api_parameter_converter
//tensorflow/python/framework:_pywrap_python_tensor_converter
```

Result:

```text
PYHELPERS_WARM_BUILD_EXIT=0
PYHELPERS_FINAL_DIFF_CHECK_EXIT=0
```

The corresponding helper tests and free-threaded runtime stress cases were also validated earlier on the full working TensorFlow free-threaded snapshot.

## Dependency

Local CPython 3.14 free-threaded validation uses:

TensorFlow hermetic Python support:
https://github.com/tensorflow/tensorflow/pull/125634

and:

rules_ml_toolchain:
https://github.com/tensorflow/rules_ml_toolchain/pull/302

## Scope

This PR intentionally keeps the changes limited to small Python API helper bindings and ownership/lifetime correctness.

Larger runtime and subsystem-level free-threading changes are being submitted separately.