### PR TITLE
Make TFLite Python runtime bindings safe for free-threaded Python

### DIFF
--- a/tensorflow/lite/python/analyzer_wrapper/analyzer_wrapper.cc
+++ b/tensorflow/lite/python/analyzer_wrapper/analyzer_wrapper.cc
@@ -18,7 +18,7 @@ limitations under the License.
 #include "pybind11/pybind11.h"  // from @pybind11
 #include "tensorflow/lite/python/analyzer_wrapper/model_analyzer.h"
 
-PYBIND11_MODULE(_pywrap_analyzer_wrapper, m) {
+PYBIND11_MODULE(_pywrap_analyzer_wrapper, m, pybind11::mod_gil_not_used()) {
   m.def(
       "ModelAnalyzer",
       [](const std::string& model_path, bool input_is_filepath,

--- a/tensorflow/lite/python/interpreter_wrapper/BUILD
+++ b/tensorflow/lite/python/interpreter_wrapper/BUILD
@@ -44,6 +44,7 @@ cc_library(
     ],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        "@com_google_absl//absl/synchronization",
         ":numpy",
         ":python_error_reporter",
         ":python_utils",

--- a/tensorflow/lite/python/interpreter_wrapper/BUILD
+++ b/tensorflow/lite/python/interpreter_wrapper/BUILD
@@ -116,6 +116,7 @@ pybind_extension(
     wrap_py_init = True,
     deps = [
         ":interpreter_wrapper_lib",
+        "@com_google_absl//absl/synchronization",
         "//tensorflow/lite:framework",
         "//tensorflow/lite/core:framework_stable",
         "//tensorflow/python/lib/core:pybind11_lib",

--- a/tensorflow/lite/python/interpreter_wrapper/BUILD
+++ b/tensorflow/lite/python/interpreter_wrapper/BUILD
@@ -28,6 +28,7 @@ cc_library(
     hdrs = ["numpy.h"],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        "@com_google_absl//absl/base",
         "//tensorflow/lite:string_util",
         "//tensorflow/lite/core/c:c_api_types",
         "//tensorflow/lite/core/c:common",

--- a/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.cc
+++ b/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.cc
@@ -83,6 +83,42 @@ namespace interpreter_wrapper {
 
 namespace {
 
+// Waiting for the per-interpreter mutex while holding the legacy GIL can
+// deadlock with Invoke(), because Invoke intentionally releases the GIL while
+// keeping this native mutex held. On GIL builds, release the GIL only while
+// waiting for the mutex. Free-threaded Python has no global GIL to release.
+class ScopedInterpreterLock {
+ public:
+  explicit ScopedInterpreterLock(
+      absl::Mutex* mu)
+      : mu_(mu) {
+#ifndef Py_GIL_DISABLED
+    Py_BEGIN_ALLOW_THREADS
+    mu_->Lock();
+    Py_END_ALLOW_THREADS
+#else
+    mu_->Lock();
+#endif
+  }
+
+  ~ScopedInterpreterLock() {
+    mu_->Unlock();
+  }
+
+  ScopedInterpreterLock(
+      const ScopedInterpreterLock&) = delete;
+
+  ScopedInterpreterLock& operator=(
+      const ScopedInterpreterLock&) = delete;
+
+ private:
+  absl::Mutex* const mu_;
+};
+
+}  // namespace
+
+namespace {
+
 using python_utils::PyDecrefDeleter;
 
 std::unique_ptr<Interpreter> CreateInterpreter(
@@ -448,6 +484,7 @@ InterpreterWrapper::~InterpreterWrapper() = default;
 static constexpr int kUndeterminedSubgraphIndex = -1;
 // LINT.ThenChange(//tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper_pybind11.cc)
 PyObject* InterpreterWrapper::AllocateTensors(int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   if (subgraph_index == kUndeterminedSubgraphIndex) {
     TFLITE_PY_CHECK(interpreter_->AllocateTensors());
@@ -462,6 +499,7 @@ PyObject* InterpreterWrapper::AllocateTensors(int subgraph_index) {
 }
 
 PyObject* InterpreterWrapper::Invoke(int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_BOUNDS_CHECK(subgraph_index);
 
@@ -485,6 +523,7 @@ PyObject* InterpreterWrapper::Invoke(int subgraph_index) {
 }
 
 PyObject* InterpreterWrapper::InputIndices() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   PyObject* np_array = PyArrayFromIntVector(interpreter_->inputs().data(),
                                             interpreter_->inputs().size());
@@ -493,6 +532,7 @@ PyObject* InterpreterWrapper::InputIndices() const {
 }
 
 PyObject* InterpreterWrapper::OutputIndices() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   PyObject* np_array = PyArrayFromIntVector(interpreter_->outputs().data(),
                                             interpreter_->outputs().size());
 
@@ -530,6 +570,7 @@ PyObject* InterpreterWrapper::ResizeInputTensorImpl(int i, PyObject* value) {
 PyObject* InterpreterWrapper::ResizeInputTensor(int i, PyObject* value,
                                                 bool strict,
                                                 int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_BOUNDS_CHECK(subgraph_index);
 
@@ -554,6 +595,7 @@ PyObject* InterpreterWrapper::ResizeInputTensor(int i, PyObject* value,
 }
 
 int InterpreterWrapper::NumTensors(int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   if (!interpreter_) {
     return 0;
   }
@@ -561,6 +603,7 @@ int InterpreterWrapper::NumTensors(int subgraph_index) const {
 }
 
 int InterpreterWrapper::NumSubgraphs() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   if (interpreter_ == nullptr) {
     return 0;
   }
@@ -569,6 +612,7 @@ int InterpreterWrapper::NumSubgraphs() const {
 
 std::string InterpreterWrapper::TensorName(int tensor_index,
                                            int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   const Subgraph* subgraph = interpreter_->subgraph(subgraph_index);
   if (!interpreter_ || tensor_index >= subgraph->tensors_size() ||
       tensor_index < 0) {
@@ -581,6 +625,7 @@ std::string InterpreterWrapper::TensorName(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorType(int tensor_index,
                                          int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -601,6 +646,7 @@ PyObject* InterpreterWrapper::TensorType(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorSize(int tensor_index,
                                          int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -618,6 +664,7 @@ PyObject* InterpreterWrapper::TensorSize(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorSizeSignature(int tensor_index,
                                                   int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -632,6 +679,7 @@ PyObject* InterpreterWrapper::TensorSizeSignature(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorSparsityParameters(
     int tensor_index, int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -646,6 +694,7 @@ PyObject* InterpreterWrapper::TensorSparsityParameters(
 
 PyObject* InterpreterWrapper::TensorQuantization(int tensor_index,
                                                  int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -656,6 +705,7 @@ PyObject* InterpreterWrapper::TensorQuantization(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorQuantizationParameters(
     int tensor_index, int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -722,6 +772,7 @@ PyObject* InterpreterWrapper::TensorQuantizationParameters(
 
 PyObject* InterpreterWrapper::SetTensor(int tensor_index, PyObject* value,
                                         int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_BOUNDS_CHECK(subgraph_index);
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
@@ -810,6 +861,7 @@ PyObject* InterpreterWrapper::SetTensor(int tensor_index, PyObject* value,
 }
 
 int InterpreterWrapper::NumNodes() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   if (!interpreter_) {
     return 0;
   }
@@ -817,6 +869,7 @@ int InterpreterWrapper::NumNodes() const {
 }
 
 PyObject* InterpreterWrapper::NodeInputs(int i) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_NODES_BOUNDS_CHECK(i);
 
@@ -827,6 +880,7 @@ PyObject* InterpreterWrapper::NodeInputs(int i) const {
 }
 
 PyObject* InterpreterWrapper::NodeOutputs(int i) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_NODES_BOUNDS_CHECK(i);
 
@@ -837,6 +891,7 @@ PyObject* InterpreterWrapper::NodeOutputs(int i) const {
 }
 
 std::string InterpreterWrapper::NodeName(int i) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   if (!interpreter_ || i >= interpreter_->nodes_size() || i < 0) {
     return "";
   }
@@ -894,6 +949,7 @@ PyObject* CheckGetTensorArgs(Interpreter* interpreter_, int tensor_index,
 }  // namespace
 
 PyObject* InterpreterWrapper::GetSignatureDefs() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   PyObject* result = PyDict_New();
   if (result == nullptr) return nullptr;
 
@@ -960,6 +1016,7 @@ PyObject* InterpreterWrapper::GetSignatureDefs() const {
 
 PyObject* InterpreterWrapper::GetSubgraphIndexFromSignature(
     const char* signature_key) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
 
   int32_t subgraph_index =
@@ -974,6 +1031,7 @@ PyObject* InterpreterWrapper::GetSubgraphIndexFromSignature(
 
 PyObject* InterpreterWrapper::GetTensor(int tensor_index,
                                         int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   // Sanity check accessor
   TfLiteTensor* tensor = nullptr;
   int type_num = 0;
@@ -1103,6 +1161,7 @@ PyObject* InterpreterWrapper::GetTensor(int tensor_index,
 
 PyObject* InterpreterWrapper::tensor(PyObject* base_object, int tensor_index,
                                      int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   // Sanity check accessor
   TfLiteTensor* tensor = nullptr;
   int type_num = 0;
@@ -1199,12 +1258,14 @@ InterpreterWrapper* InterpreterWrapper::CreateWrapperCPPFromBuffer(
 }
 
 PyObject* InterpreterWrapper::ResetVariableTensors() {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_CHECK(interpreter_->ResetVariableTensors());
   Py_RETURN_NONE;
 }
 
 PyObject* InterpreterWrapper::SetNumThreads(int num_threads) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   interpreter_->SetNumThreads(num_threads);
   Py_RETURN_NONE;
@@ -1212,6 +1273,7 @@ PyObject* InterpreterWrapper::SetNumThreads(int num_threads) {
 
 PyObject* InterpreterWrapper::ModifyGraphWithDelegate(
     TfLiteDelegate* delegate) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_CHECK(interpreter_->ModifyGraphWithDelegate(delegate));
   Py_RETURN_NONE;

--- a/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.h
+++ b/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.h
@@ -27,6 +27,7 @@ limitations under the License.
 // automatically move <Python.h> before <locale>.
 #include <Python.h>
 
+#include "absl/synchronization/mutex.h"
 #include "tensorflow/lite/core/interpreter.h"
 
 struct TfLiteDelegate;
@@ -157,6 +158,12 @@ class InterpreterWrapper {
   // The public functions which creates `InterpreterWrapper` should ensure all
   // these member variables are initialized successfully. Otherwise it should
   // report the error and return `nullptr`.
+  // Serializes access to the mutable TFLite Interpreter owned by this wrapper.
+  //
+  // The lock must remain held across Invoke(), including while Invoke()
+  // temporarily detaches from the Python thread state.
+  mutable absl::Mutex interpreter_mu_;
+
   const std::unique_ptr<Model> model_;
   const std::unique_ptr<PythonErrorReporter> error_reporter_;
   const std::unique_ptr<tflite::MutableOpResolver> resolver_;

--- a/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper_pybind11.cc
+++ b/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper_pybind11.cc
@@ -29,7 +29,7 @@ limitations under the License.
 namespace py = pybind11;
 using tflite::interpreter_wrapper::InterpreterWrapper;
 
-PYBIND11_MODULE(_pywrap_tensorflow_interpreter_wrapper, m) {
+PYBIND11_MODULE(_pywrap_tensorflow_interpreter_wrapper, m, py::mod_gil_not_used()) {
   m.doc() = R"pbdoc(
     _pywrap_tensorflow_interpreter_wrapper
     -----

--- a/tensorflow/lite/python/interpreter_wrapper/numpy.cc
+++ b/tensorflow/lite/python/interpreter_wrapper/numpy.cc
@@ -16,7 +16,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <mutex>
+#include "absl/base/call_once.h"
 
 #define TFLITE_IMPORT_NUMPY  // See numpy.h for explanation.
 #include "tensorflow/lite/core/c/c_api_types.h"
@@ -27,8 +27,8 @@ namespace tflite {
 namespace python {
 
 void ImportNumpy() {
-  static std::once_flag flag;
-  std::call_once(flag, []() {
+  static absl::once_flag flag;
+  absl::call_once(flag, []() {
     import_array1();
   });
 }

--- a/tensorflow/lite/python/interpreter_wrapper/numpy.cc
+++ b/tensorflow/lite/python/interpreter_wrapper/numpy.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 
 #define TFLITE_IMPORT_NUMPY  // See numpy.h for explanation.
 #include "tensorflow/lite/core/c/c_api_types.h"
@@ -25,7 +26,12 @@ limitations under the License.
 namespace tflite {
 namespace python {
 
-void ImportNumpy() { import_array1(); }
+void ImportNumpy() {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    import_array1();
+  });
+}
 
 }  // namespace python
 

--- a/tensorflow/lite/python/metrics/BUILD
+++ b/tensorflow/lite/python/metrics/BUILD
@@ -34,6 +34,7 @@ cc_library(
     compatible_with = get_compatible_with_portable(),
     visibility = ["//visibility:private"],
     deps = [
+        "@com_google_absl//absl/synchronization",
         "@xla//third_party/python_runtime:headers",
     ] + if_portable(
         if_false = [

--- a/tensorflow/lite/python/metrics/BUILD
+++ b/tensorflow/lite/python/metrics/BUILD
@@ -61,6 +61,7 @@ pybind_extension(
     wrap_py_init = True,
     deps = [
         ":metrics_wrapper_lib",
+        "@com_google_absl//absl/synchronization",
         "//tensorflow/python/lib/core:pybind11_lib",
         "@com_google_protobuf//:protobuf",
         "@pybind11",

--- a/tensorflow/lite/python/metrics/wrapper/metrics_wrapper.h
+++ b/tensorflow/lite/python/metrics/wrapper/metrics_wrapper.h
@@ -25,6 +25,8 @@ limitations under the License.
 // automatically move <Python.h> before <locale>.
 #include <Python.h>
 
+#include "absl/synchronization/mutex.h"
+
 // We forward declare TFLite classes here to avoid exposing them to SWIG.
 namespace tensorflow {
 namespace monitoring {
@@ -49,6 +51,7 @@ class MetricsWrapper {
  private:
   explicit MetricsWrapper(std::unique_ptr<MetricsExporter> exporter);
 
+  absl::Mutex exporter_mu_;
   const std::unique_ptr<MetricsExporter> exporter_;
 };
 

--- a/tensorflow/lite/python/metrics/wrapper/metrics_wrapper_nonportable.cc
+++ b/tensorflow/lite/python/metrics/wrapper/metrics_wrapper_nonportable.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <vector>
 
 #include "learning/brain/google/monitoring/metrics_exporter.h"
+#include "absl/synchronization/mutex.h"
 #include "tensorflow/lite/python/metrics/wrapper/metrics_wrapper.h"
 
 namespace tflite {
@@ -54,7 +55,10 @@ PyObject* MetricsWrapper::ExportMetrics() {
     return nullptr;
   }
 
-  exporter_->ExportMetrics();
+  {
+    absl::MutexLock lock(&exporter_mu_);
+    exporter_->ExportMetrics();
+  }
 
   Py_RETURN_NONE;
 }

--- a/tensorflow/lite/python/metrics/wrapper/metrics_wrapper_portable.cc
+++ b/tensorflow/lite/python/metrics/wrapper/metrics_wrapper_portable.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/synchronization/mutex.h"
 #include "tensorflow/lite/python/metrics/wrapper/metrics_wrapper.h"
 
 namespace tensorflow {
@@ -50,7 +51,10 @@ PyObject* MetricsWrapper::ExportMetrics() {
     return nullptr;
   }
 
-  exporter_->ExportMetrics();
+  {
+    absl::MutexLock lock(&exporter_mu_);
+    exporter_->ExportMetrics();
+  }
 
   Py_RETURN_NONE;
 }

--- a/tensorflow/lite/python/metrics/wrapper/metrics_wrapper_pybind11.cc
+++ b/tensorflow/lite/python/metrics/wrapper/metrics_wrapper_pybind11.cc
@@ -24,7 +24,8 @@ limitations under the License.
 namespace py = pybind11;
 using tflite::metrics_wrapper::MetricsWrapper;
 
-PYBIND11_MODULE(_pywrap_tensorflow_lite_metrics_wrapper, m) {
+PYBIND11_MODULE(_pywrap_tensorflow_lite_metrics_wrapper, m,
+                  py::mod_gil_not_used()) {
   m.doc() = R"pbdoc(
     _pywrap_tensorflow_lite_metrics_wrapper
     -----


### PR DESCRIPTION
## Summary

Make TensorFlow Lite Python runtime bindings compatible with CPython free-threaded builds.

This PR covers:

- model analyzer bindings
- TFLite interpreter bindings
- TFLite runtime metrics bindings

The changes focus on free-threaded pybind declarations and synchronization of mutable native state that may now be accessed concurrently from Python threads.

## Changes

### Analyzer binding

Declare:

```text
pybind11::mod_gil_not_used()
```

for:

```text
_pywrap_analyzer_wrapper
```

### Interpreter binding

Declare:

```text
py::mod_gil_not_used()
```

for:

```text
_pywrap_tensorflow_interpreter_wrapper
```

Add a native per-instance `absl::Mutex` to serialize access to the mutable TFLite `Interpreter`.

Python-facing methods that access or mutate interpreter state now take this lock, including operations such as:

- tensor allocation
- invocation
- input/output queries
- resize
- tensor reads/writes
- signature queries
- graph mutation
- thread-count changes

### Avoid legacy-GIL deadlocks

`Invoke()` intentionally releases the legacy GIL while native execution proceeds.

To avoid lock-order deadlocks on GIL-enabled Python builds, waiting for the interpreter mutex is done without holding the legacy GIL.

On free-threaded Python, where there is no global GIL, the native mutex is acquired directly.

### Runtime metrics binding

Declare:

```text
py::mod_gil_not_used()
```

for:

```text
_pywrap_tensorflow_lite_metrics_wrapper
```

Add a native `absl::Mutex` around the shared `MetricsExporter` so concurrent calls to `ExportMetrics()` on the same wrapper instance are serialized safely.

The required synchronization dependencies are added to the corresponding BUILD targets.

## Validation

Validated with CPython 3.14 free-threaded hermetic Python using:

```text
--repo_env=HERMETIC_PYTHON_VERSION=3.14-freethreaded
--repo_env=USE_PYWRAP_RULES=True
--@rules_python//python/config_settings:py_freethreaded=yes
```

The affected targets built successfully:

```text
//tensorflow/lite/python/analyzer_wrapper:_pywrap_analyzer_wrapper
//tensorflow/lite/python/interpreter_wrapper:_pywrap_tensorflow_interpreter_wrapper
//tensorflow/lite/python/metrics:_pywrap_tensorflow_lite_metrics_wrapper
```

Result:

```text
TFLITE_RUNTIME_WARM_BUILD_EXIT=0
TFLITE_RUNTIME_FINAL_DIFF_CHECK_EXIT=0
```

The interpreter and runtime-metrics concurrency behavior was also validated earlier on the full working free-threaded TensorFlow snapshot.

## Dependency

Local CPython 3.14 free-threaded validation uses:

TensorFlow hermetic Python support:
https://github.com/tensorflow/tensorflow/pull/125634

and:

rules_ml_toolchain:
https://github.com/tensorflow/rules_ml_toolchain/pull/302

## Scope

This PR is intentionally limited to TFLite runtime bindings.

TFLite conversion and quantization bindings are handled separately to keep review scope focused.