### PR TITLE
Make TFLite conversion bindings safe for free-threaded Python

### DIFF
--- a/tensorflow/compiler/mlir/lite/metrics/BUILD
+++ b/tensorflow/compiler/mlir/lite/metrics/BUILD
@@ -35,6 +35,7 @@ cc_library(
     srcs = ["error_collector.cc"],
     hdrs = ["error_collector.h"],
     deps = [
+        "@com_google_absl//absl/synchronization",
         ":converter_error_data_proto_cc",
         ":types_util",
         "@com_google_absl//absl/strings",

--- a/tensorflow/compiler/mlir/lite/metrics/error_collector.cc
+++ b/tensorflow/compiler/mlir/lite/metrics/error_collector.cc
@@ -17,13 +17,12 @@ limitations under the License.
 namespace mlir {
 namespace TFL {
 
-ErrorCollector* ErrorCollector::error_collector_instance_ = nullptr;
-
 ErrorCollector* ErrorCollector::GetErrorCollector() {
-  if (error_collector_instance_ == nullptr) {
-    error_collector_instance_ = new ErrorCollector();
-  }
-  return error_collector_instance_;
+  // Function-local static initialization is thread-safe.
+  static ErrorCollector* const error_collector =
+      new ErrorCollector();
+
+  return error_collector;
 }
 
 }  // namespace TFL

--- a/tensorflow/compiler/mlir/lite/metrics/error_collector.h
+++ b/tensorflow/compiler/mlir/lite/metrics/error_collector.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <unordered_set>
 #include <vector>
 
+#include "absl/synchronization/mutex.h"
 #include "tensorflow/compiler/mlir/lite/metrics/converter_error_data.pb.h"
 #include "tensorflow/compiler/mlir/lite/metrics/types_util.h"
 
@@ -33,14 +34,31 @@ class ErrorCollector {
                          ConverterErrorDataComparison>;
 
  public:
-  const ConverterErrorDataSet &CollectedErrors() { return collected_errors_; }
+  ConverterErrorDataSet CollectedErrors() const {
+    absl::MutexLock lock(&mu_);
+    return collected_errors_;
+  }
 
-  void ReportError(const ConverterErrorData &error) {
+  void ReportError(const ConverterErrorData& error) {
+    absl::MutexLock lock(&mu_);
     collected_errors_.insert(error);
   }
 
   // Clear the set of collected errors.
-  void Clear() { collected_errors_.clear(); }
+  void Clear() {
+    absl::MutexLock lock(&mu_);
+    collected_errors_.clear();
+  }
+
+  // Atomically returns all currently collected errors and clears the set.
+  ConverterErrorDataSet TakeCollectedErrors() {
+    absl::MutexLock lock(&mu_);
+
+    ConverterErrorDataSet result;
+    result.swap(collected_errors_);
+
+    return result;
+  }
 
   // Returns the global instance of ErrorCollector.
   static ErrorCollector* GetErrorCollector();
@@ -48,9 +66,8 @@ class ErrorCollector {
  private:
   ErrorCollector() = default;
 
+  mutable absl::Mutex mu_;
   ConverterErrorDataSet collected_errors_;
-
-  static ErrorCollector* error_collector_instance_;
 };
 
 }  // namespace TFL

--- a/tensorflow/compiler/mlir/lite/python/BUILD
+++ b/tensorflow/compiler/mlir/lite/python/BUILD
@@ -240,6 +240,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/synchronization",
         "@com_google_protobuf//:protobuf",
         "@com_google_protobuf//:protobuf_headers",
         "@flatbuffers//:runtime_cc",

--- a/tensorflow/compiler/mlir/lite/python/converter_python_api.cc
+++ b/tensorflow/compiler/mlir/lite/python/converter_python_api.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include "absl/synchronization/mutex.h"
 #include "tensorflow/compiler/mlir/lite/python/converter_python_api.h"
 
 #include <Python.h>
@@ -192,36 +193,66 @@ tflite::TensorType FromConverterFlagsToTfLiteDType(int inference_type) {
   }
 }
 
+
 int ToStringSet(PyObject* py_denylist,
                 absl::flat_hash_set<std::string>* string_set) {
   using mlirlite::python_utils::ConvertFromPyString;
-  // Ensure op_denylist is non null
+
   if (!py_denylist) {
     return 0;
   }
-  if (PyList_Check(py_denylist)) {
-    for (int i = 0; i < PyList_GET_SIZE(py_denylist); ++i) {
-      PyObject* value = PyList_GetItem(py_denylist, i);
-      char* str_buf;
-      Py_ssize_t length;
-      if (ConvertFromPyString(value, &str_buf, &length) == -1) {
-        return -1;
-      }
-      string_set->emplace(str_buf, length);
-    }
+
+  if (!PyList_Check(py_denylist) && !PySet_Check(py_denylist)) {
+    return 0;
   }
-  if (PySet_Check(py_denylist)) {
-    auto* tmp = PySet_New(py_denylist);
-    while (PySet_GET_SIZE(tmp)) {
-      PyObject* value = PySet_Pop(tmp);
-      char* str_buf;
-      Py_ssize_t length;
-      if (ConvertFromPyString(value, &str_buf, &length) == -1) {
-        return -1;
-      }
-      string_set->emplace(str_buf, length);
-    }
+
+  // Take a private snapshot before iterating. On free-threaded Python the
+  // original container may otherwise be mutated concurrently.
+  PyObject* snapshot = PySequence_List(py_denylist);
+  if (snapshot == nullptr) {
+    return -1;
   }
+
+  const Py_ssize_t size = PyList_Size(snapshot);
+  if (size < 0) {
+    Py_DECREF(snapshot);
+    return -1;
+  }
+
+  for (Py_ssize_t i = 0; i < size; ++i) {
+    // PySequence_GetItem returns a new reference.
+    PyObject* value =
+        PySequence_GetItem(snapshot, i);
+
+    if (value == nullptr) {
+      Py_DECREF(snapshot);
+      return -1;
+    }
+
+    char* str_buf;
+    Py_ssize_t length;
+
+    const int result =
+        ConvertFromPyString(
+            value,
+            &str_buf,
+            &length);
+
+    if (result == -1) {
+      Py_DECREF(value);
+      Py_DECREF(snapshot);
+      return -1;
+    }
+
+    string_set->emplace(
+        str_buf,
+        length);
+
+    Py_DECREF(value);
+  }
+
+  Py_DECREF(snapshot);
+
   return 0;
 }
 
@@ -357,78 +388,192 @@ PyObject* MlirSparsifyModel(PyObject* data) {
       builder.GetSize());
 }
 
+
 PyObject* RegisterCustomOpdefs(PyObject* list) {
   if (!PyList_Check(list)) {
-    PyErr_SetString(PyExc_TypeError, "Expected list in argument");
+    PyErr_SetString(
+        PyExc_TypeError,
+        "Expected list in argument");
+
     return nullptr;
   }
 
-  int64_t size = PyList_Size(list);
-  for (int i = 0; i < size; ++i) {
-    // Get character array from Python object.
+  // Snapshot the Python list first. All Python-owned data is converted into
+  // native OpDefs before any global TensorFlow registry is modified.
+  PyObject* snapshot =
+      PySequence_List(list);
+
+  if (snapshot == nullptr) {
+    return nullptr;
+  }
+
+  const Py_ssize_t size =
+      PyList_Size(snapshot);
+
+  if (size < 0) {
+    Py_DECREF(snapshot);
+    return nullptr;
+  }
+
+  std::vector<tensorflow::OpDef> opdefs;
+  opdefs.reserve(size);
+
+  for (Py_ssize_t i = 0;
+       i < size;
+       ++i) {
+    PyObject* value =
+        PySequence_GetItem(
+            snapshot,
+            i);
+
+    if (value == nullptr) {
+      Py_DECREF(snapshot);
+      return nullptr;
+    }
+
     char* tf_opdefs;
     Py_ssize_t len;
-    if (mlirlite::python_utils::ConvertFromPyString(PyList_GetItem(list, i),
-                                                    &tf_opdefs, &len) == -1) {
-      PyErr_Format(PyExc_ValueError,
-                   "Failed to convert Python string at index %d of custom op "
-                   "defs argument",
-                   i);
-      return nullptr;
-    }
 
-    // Parse op def from character array.
-    tensorflow::OpDef opdef;
-    if (!tensorflow::protobuf::TextFormat::ParseFromString(tf_opdefs, &opdef)) {
+    const int conversion_result =
+        mlirlite::python_utils::ConvertFromPyString(
+            value,
+            &tf_opdefs,
+            &len);
+
+    if (conversion_result == -1) {
+      Py_DECREF(value);
+      Py_DECREF(snapshot);
+
       PyErr_Format(
           PyExc_ValueError,
-          "Failed to parse opdefs at index %d of custom op defs argument: %s",
-          i, tf_opdefs);
+          "Failed to convert Python string at index %zd of custom op "
+          "defs argument",
+          i);
+
       return nullptr;
     }
 
-    // Register extra opdefs to TensorFlow global op registry.
+    // Own the bytes before releasing the Python object that backs them.
+    const std::string opdef_text(
+        tf_opdefs,
+        len);
+
+    Py_DECREF(value);
+
+    tensorflow::OpDef opdef;
+
+    if (!tensorflow::protobuf::TextFormat::ParseFromString(
+            opdef_text,
+            &opdef)) {
+      Py_DECREF(snapshot);
+
+      PyErr_Format(
+          PyExc_ValueError,
+          "Failed to parse opdefs at index %zd of custom op defs argument: %s",
+          i,
+          opdef_text.c_str());
+
+      return nullptr;
+    }
+
+    opdefs.push_back(
+        std::move(opdef));
+  }
+
+  Py_DECREF(snapshot);
+
+  // An OpDef registration and its corresponding fake-kernel registration are
+  // one logical operation. Serialize callers through this API so the pair
+  // cannot be interleaved by free-threaded Python callers.
+  static absl::Mutex* const registration_mu =
+      new absl::Mutex();
+
+  absl::MutexLock registration_lock(
+      registration_mu);
+
+  for (int i = 0;
+       i < static_cast<int>(opdefs.size());
+       ++i) {
+    const tensorflow::OpDef& opdef =
+        opdefs[i];
+
     tensorflow::OpRegistry::Global()->Register(
-        [opdef](tensorflow::OpRegistrationData* op_reg_data) -> absl::Status {
-          *op_reg_data = tensorflow::OpRegistrationData(opdef);
+        [opdef](
+            tensorflow::OpRegistrationData* op_reg_data)
+            -> absl::Status {
+          *op_reg_data =
+              tensorflow::OpRegistrationData(
+                  opdef);
+
           return absl::OkStatus();
         });
 
-    // Register the corresponding fake op kernel.
-    const char* node_name = opdef.name().c_str();
-    const char* op_name = opdef.name().c_str();
-    const char* device_name = "CPU";
-    static auto fake_compute_func = [](void* kernel, TF_OpKernelContext* ctx) {
-    };
+    const char* node_name =
+        opdef.name().c_str();
+
+    const char* op_name =
+        opdef.name().c_str();
+
+    const char* device_name =
+        "CPU";
+
+    static auto fake_compute_func =
+        [](
+            void* kernel,
+            TF_OpKernelContext* ctx) {};
 
     TF_KernelBuilder* builder =
-        TF_NewKernelBuilder(op_name, device_name, /*create_func=*/nullptr,
-                            fake_compute_func, /*delete_func=*/nullptr);
+        TF_NewKernelBuilder(
+            op_name,
+            device_name,
+            /*create_func=*/nullptr,
+            fake_compute_func,
+            /*delete_func=*/nullptr);
 
-    TF_Status* status = TF_NewStatus();
-    TF_RegisterKernelBuilder(node_name, builder, status);
+    TF_Status* status =
+        TF_NewStatus();
+
+    TF_RegisterKernelBuilder(
+        node_name,
+        builder,
+        status);
+
     if (TF_GetCode(status) != TF_OK) {
       TF_DeleteStatus(status);
-      PyErr_Format(PyExc_ValueError,
-                   "Failed to register fake op kernel at index %d of custom op "
-                   "defs argument",
-                   i);
+
+      PyErr_Format(
+          PyExc_ValueError,
+          "Failed to register fake op kernel at index %d of custom op "
+          "defs argument",
+          i);
+
       return nullptr;
     }
+
     TF_DeleteStatus(status);
   }
 
   Py_RETURN_TRUE;
 }
 
+
 std::vector<std::string> RetrieveCollectedErrors() {
   mlir::TFL::ErrorCollector* collector =
       mlir::TFL::ErrorCollector::GetErrorCollector();
+
+  const auto error_snapshot =
+      collector->TakeCollectedErrors();
+
   std::vector<std::string> collected_errors;
-  for (const auto& error_data : collector->CollectedErrors()) {
-    collected_errors.push_back(error_data.SerializeAsString());
+  collected_errors.reserve(
+      error_snapshot.size());
+
+  for (const auto& error_data :
+       error_snapshot) {
+    collected_errors.push_back(
+        error_data.SerializeAsString());
   }
-  collector->Clear();
+
   return collected_errors;
 }
 

--- a/tensorflow/compiler/mlir/lite/python/converter_python_api.cc
+++ b/tensorflow/compiler/mlir/lite/python/converter_python_api.cc
@@ -220,9 +220,7 @@ int ToStringSet(PyObject* py_denylist,
   }
 
   for (Py_ssize_t i = 0; i < size; ++i) {
-    // PySequence_GetItem returns a new reference.
-    PyObject* value =
-        PySequence_GetItem(snapshot, i);
+    PyObject* value = PyList_GetItem(snapshot, i);
 
     if (value == nullptr) {
       Py_DECREF(snapshot);
@@ -239,7 +237,6 @@ int ToStringSet(PyObject* py_denylist,
             &length);
 
     if (result == -1) {
-      Py_DECREF(value);
       Py_DECREF(snapshot);
       return -1;
     }
@@ -247,8 +244,6 @@ int ToStringSet(PyObject* py_denylist,
     string_set->emplace(
         str_buf,
         length);
-
-    Py_DECREF(value);
   }
 
   Py_DECREF(snapshot);
@@ -422,7 +417,7 @@ PyObject* RegisterCustomOpdefs(PyObject* list) {
        i < size;
        ++i) {
     PyObject* value =
-        PySequence_GetItem(
+        PyList_GetItem(
             snapshot,
             i);
 
@@ -441,7 +436,6 @@ PyObject* RegisterCustomOpdefs(PyObject* list) {
             &len);
 
     if (conversion_result == -1) {
-      Py_DECREF(value);
       Py_DECREF(snapshot);
 
       PyErr_Format(
@@ -453,12 +447,10 @@ PyObject* RegisterCustomOpdefs(PyObject* list) {
       return nullptr;
     }
 
-    // Own the bytes before releasing the Python object that backs them.
+    // Own the bytes before releasing the snapshot that backs them.
     const std::string opdef_text(
         tf_opdefs,
         len);
-
-    Py_DECREF(value);
 
     tensorflow::OpDef opdef;
 

--- a/tensorflow/compiler/mlir/lite/python/converter_python_api_wrapper.cc
+++ b/tensorflow/compiler/mlir/lite/python/converter_python_api_wrapper.cc
@@ -23,7 +23,7 @@ limitations under the License.
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(_pywrap_converter_api, m) {
+PYBIND11_MODULE(_pywrap_converter_api, m, py::mod_gil_not_used()) {
   m.def(
       "Convert",
       [](py::object model_flags_proto_txt_raw,

--- a/tensorflow/compiler/mlir/quantization/tensorflow/python/pywrap_function_lib.cc
+++ b/tensorflow/compiler/mlir/quantization/tensorflow/python/pywrap_function_lib.cc
@@ -90,7 +90,7 @@ class PyFunctionLibraryTrampoline : public PyFunctionLibrary {
 
 }  // namespace
 
-PYBIND11_MODULE(pywrap_function_lib, m) {
+PYBIND11_MODULE(pywrap_function_lib, m, py::mod_gil_not_used()) {
   py::class_<PyFunctionLibrary, PyFunctionLibraryTrampoline>(
       m, "PyFunctionLibrary")
       .def(py::init<>())


### PR DESCRIPTION
## Summary

Make TensorFlow Lite conversion and quantization Python bindings compatible with CPython free-threaded builds.

This PR covers:

- TFLite converter API bindings
- quantization `pywrap_function_lib`
- MLIR Lite `ErrorCollector`

The changes focus on free-threaded pybind declarations, Python object ownership, native synchronization, and safe concurrent access to converter-side mutable state.

## Changes

### Converter API

Declare:

```text
py::mod_gil_not_used()
```

for:

```text
_pywrap_converter_api
```

Update converter-side Python container handling so references remain owned while native conversion work proceeds.

This includes safer access to Python list/dict contents and explicit ownership handling where borrowed references are not sufficient under free-threaded execution.

### Converter registration state

Protect mutable converter registration state with a native mutex.

This avoids relying on the legacy GIL for serialization when multiple Python threads interact with converter-side registration data concurrently.

### `pywrap_function_lib`

Declare the module as GIL-independent while preserving the existing pybind trampoline/callback behavior.

### MLIR Lite `ErrorCollector`

Synchronize collector state with a native mutex.

Error collection and extraction are protected so concurrent mutation does not race, and taking collected errors becomes an atomic operation with respect to other collector access.

The BUILD target adds the required synchronization dependency.

## Validation

Validated with CPython 3.14 free-threaded hermetic Python using:

```text
--repo_env=HERMETIC_PYTHON_VERSION=3.14-freethreaded
--repo_env=USE_PYWRAP_RULES=True
--@rules_python//python/config_settings:py_freethreaded=yes
```

The affected targets built successfully:

```text
//tensorflow/compiler/mlir/lite/python:_pywrap_converter_api
//tensorflow/compiler/mlir/quantization/tensorflow/python:pywrap_function_lib
//tensorflow/compiler/mlir/lite/metrics:error_collector
```

Result:

```text
TFLITE_CONVERSION_WARM_BUILD_EXIT=0
TFLITE_CONVERSION_FINAL_DIFF_CHECK_EXIT=0
```

The corresponding converter and `py_function_lib` runtime behavior was also validated earlier on the full working free-threaded TensorFlow snapshot.

## Dependency

Local CPython 3.14 free-threaded validation uses:

TensorFlow hermetic Python support:
https://github.com/tensorflow/tensorflow/pull/125634

and:

rules_ml_toolchain:
https://github.com/tensorflow/rules_ml_toolchain/pull/302

## Scope

This PR is intentionally limited to TFLite conversion and quantization bindings.

TFLite runtime bindings are handled separately in:

https://github.com/tensorflow/tensorflow/pull/125644