### PR TITLE
fix int narrowing of first data_splits value in StringNGrams

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5999,6 +5999,7 @@ tf_cc_test(
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
         "//tensorflow/core:testlib",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/tensorflow/core/kernels/string_ngrams_op.cc
+++ b/tensorflow/core/kernels/string_ngrams_op.cc
@@ -89,7 +89,7 @@ class StringNGramsOp : public tensorflow::OpKernel {
     const int input_data_size = data->flat<tstring>().size();
     const int splits_vec_size = splits_vec.size();
     if (splits_vec_size > 0) {
-      int prev_split = splits_vec(0);
+      SPLITS_TYPE prev_split = splits_vec(0);
       OP_REQUIRES(context, prev_split == 0,
                   absl::InvalidArgumentError(absl::StrCat(
                       "First split value must be 0, got ", prev_split)));

--- a/tensorflow/core/kernels/string_ngrams_op_test.cc
+++ b/tensorflow/core/kernels/string_ngrams_op_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "absl/strings/match.h"
 #include "xla/tsl/lib/core/status_test_util.h"
 #include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/node_def_builder.h"
@@ -605,6 +606,18 @@ TEST_F(NgramKernelTest, TestIntegerOverflow) {
   EXPECT_FALSE(s.ok());
   EXPECT_NE(s.message().find("exceeds maximum for SPLITS_TYPE"),
             std::string::npos);
+}
+
+TEST_F(NgramKernelTest, TestFirstSplitValueOverflowRejected) {
+  MakeOp("|", {3}, "LP", "RP", -1, false);
+  AddInputFromArray<tstring>(TensorShape({1}), {"a"});
+  // A first split value of 2^32 was narrowed to int (== 0) before the
+  // "First split value must be 0" check, passing validation and then indexing
+  // `data` at the full-width offset. It must be rejected at full width.
+  AddInputFromArray<int64_t>(TensorShape({2}), {int64_t{1} << 32, 1});
+  Status s = RunOpKernel();
+  EXPECT_FALSE(s.ok());
+  EXPECT_TRUE(absl::StrContains(s.message(), "First split value must be 0"));
 }
 
 TEST_F(NgramKernelTest, ShapeFn) {


### PR DESCRIPTION
StringNGramsOp::Compute reads the first data_splits value into an int before the "First split value must be 0" check, so with Tsplits=int64 a first element that is a multiple of 2^32 (for example 2^32) narrows to 0 and passes validation, after which the full-width value is used as &input_data[splits_vec(0)] and read out of bounds, with those bytes copied into the ngrams output. The values come directly from the data_splits tensor, so tf.raw_ops.StringNGrams reaches this with untrusted input. Widening prev_split to SPLITS_TYPE validates the first split at full width; a regression test covers the crafted split.