### PR TITLE
Make profiler and tracing bindings safe for free-threaded Python

### DIFF
--- a/tensorflow/python/profiler/internal/profiler_pywrap_impl.cc
+++ b/tensorflow/python/profiler/internal/profiler_pywrap_impl.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/python/profiler/internal/profiler_pywrap_impl.h"
 
+#include <mutex>
 #include <string>
 #include <variant>
 
@@ -39,6 +40,7 @@ absl::Status ProfilerSessionWrapper::Start(
     const char* logdir,
     const absl::flat_hash_map<std::string,
                               std::variant<bool, int, std::string>>& options) {
+  std::lock_guard<std::mutex> lock(mu_);
   auto opts = GetRemoteSessionManagerOptionsLocked(logdir, options);
   session_ = tsl::ProfilerSession::Create(opts.profiler_options());
   logdir_ = logdir;
@@ -46,6 +48,7 @@ absl::Status ProfilerSessionWrapper::Start(
 }
 
 absl::Status ProfilerSessionWrapper::Stop(std::string* result) {
+  std::lock_guard<std::mutex> lock(mu_);
   if (session_ != nullptr) {
     tensorflow::profiler::XSpace xspace;
     absl::Status status = session_->CollectData(&xspace);
@@ -57,6 +60,7 @@ absl::Status ProfilerSessionWrapper::Stop(std::string* result) {
 }
 
 absl::Status ProfilerSessionWrapper::ExportToTensorBoard() {
+  std::lock_guard<std::mutex> lock(mu_);
   if (!session_ || logdir_.empty()) {
     return absl::OkStatus();
   }

--- a/tensorflow/python/profiler/internal/profiler_pywrap_impl.h
+++ b/tensorflow/python/profiler/internal/profiler_pywrap_impl.h
@@ -16,6 +16,7 @@ limitations under the License.
 #define TENSORFLOW_PYTHON_PROFILER_INTERNAL_PROFILER_PYWRAP_IMPL_H_
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <variant>
 
@@ -39,6 +40,10 @@ class ProfilerSessionWrapper {
   absl::Status ExportToTensorBoard();
 
  private:
+  // Serializes concurrent operations on a single Python ProfilerSession.
+  // Python bindings release the GIL around Start/Stop/ExportToTensorBoard,
+  // so the GIL cannot be used to protect this mutable state.
+  std::mutex mu_;
   std::unique_ptr<tsl::ProfilerSession> session_;
   std::string logdir_;
 };

--- a/tensorflow/python/profiler/internal/profiler_wrapper.cc
+++ b/tensorflow/python/profiler/internal/profiler_wrapper.cc
@@ -40,7 +40,17 @@ using ::tensorflow::profiler::pywrap::ProfilerSessionWrapper;
 // will increase its reference count.
 ToolOptions ToolOptionsFromPythonDict(const py::dict& dictionary) {
   ToolOptions map;
-  for (const auto& item : dictionary) {
+
+  // PyDict_Copy takes a stable snapshot of the options before iteration.
+  // This prevents concurrent mutation of the caller's dict from invalidating
+  // the iteration on free-threaded Python.
+  PyObject* copied = PyDict_Copy(dictionary.ptr());
+  if (copied == nullptr) {
+    throw py::error_already_set();
+  }
+  py::dict snapshot = py::reinterpret_steal<py::dict>(copied);
+
+  for (const auto& item : snapshot) {
     std::variant<bool, int, std::string> value;
     try {
       value = item.second.cast<bool>();
@@ -62,7 +72,7 @@ ToolOptions ToolOptionsFromPythonDict(const py::dict& dictionary) {
 
 }  // namespace
 
-PYBIND11_MODULE(_pywrap_profiler, m) {
+PYBIND11_MODULE(_pywrap_profiler, m, pybind11::mod_gil_not_used()) {
   py::class_<ProfilerSessionWrapper> profiler_session_class(m,
                                                             "ProfilerSession");
   profiler_session_class.def(py::init<>())

--- a/tensorflow/python/profiler/internal/traceme_wrapper.cc
+++ b/tensorflow/python/profiler/internal/traceme_wrapper.cc
@@ -36,7 +36,8 @@ static PyMethodDef traceme_method_def = {"traceme_enabled", traceme_enabled,
                                          METH_NOARGS,
                                          "Returns true if TraceMe is enabled."};
 
-PYBIND11_MODULE(_pywrap_traceme, m) {
+PYBIND11_MODULE(
+    _pywrap_traceme, m, pybind11::mod_gil_not_used()) {
   py::class_<TraceMeWrapper>(m, "TraceMe", py::module_local())
       .def(py::init<const py::str&, const py::kwargs&>())
       .def("SetMetadata", &TraceMeWrapper::SetMetadata)

--- a/tensorflow/python/util/tfprof_wrapper.cc
+++ b/tensorflow/python/util/tfprof_wrapper.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <mutex>
 #include <string>
 
 #include "pybind11/pybind11.h"  // from @pybind11
@@ -20,7 +21,15 @@ limitations under the License.
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(_pywrap_tfprof, m) {
+namespace {
+
+// The legacy multi-step tfprof API owns one process-global TFStats pointer.
+// Serialize its lifecycle and all accesses from free-threaded Python.
+std::mutex tfprof_mu;
+
+}  // namespace
+
+PYBIND11_MODULE(_pywrap_tfprof, m, pybind11::mod_gil_not_used()) {
   m.def("PrintModelAnalysis",
         [](const std::string* graph, const std::string* run_meta,
            const std::string* op_log, const std::string* command,
@@ -29,16 +38,36 @@ PYBIND11_MODULE(_pywrap_tfprof, m) {
               graph, run_meta, op_log, command, options);
           return py::bytes(temp);
         });
-  m.def("NewProfiler", &tensorflow::tfprof::NewProfiler);
-  m.def("ProfilerFromFile", &tensorflow::tfprof::ProfilerFromFile);
-  m.def("DeleteProfiler", &tensorflow::tfprof::DeleteProfiler);
-  m.def("AddStep", &tensorflow::tfprof::AddStep);
+  m.def("NewProfiler",
+        [](const std::string* graph, const std::string* op_log) {
+          std::lock_guard<std::mutex> lock(tfprof_mu);
+          return tensorflow::tfprof::NewProfiler(graph, op_log);
+        });
+  m.def("ProfilerFromFile", [](const std::string* filename) {
+    std::lock_guard<std::mutex> lock(tfprof_mu);
+    tensorflow::tfprof::ProfilerFromFile(filename);
+  });
+  m.def("DeleteProfiler", []() {
+    std::lock_guard<std::mutex> lock(tfprof_mu);
+    tensorflow::tfprof::DeleteProfiler();
+  });
+  m.def("AddStep",
+        [](int64_t step, const std::string* graph,
+           const std::string* run_meta, const std::string* op_log) {
+          std::lock_guard<std::mutex> lock(tfprof_mu);
+          return tensorflow::tfprof::AddStep(step, graph, run_meta, op_log);
+        });
   m.def("SerializeToString", []() {
+    std::lock_guard<std::mutex> lock(tfprof_mu);
     std::string temp = tensorflow::tfprof::SerializeToString();
     return py::bytes(temp);
   });
-  m.def("WriteProfile", &tensorflow::tfprof::WriteProfile);
+  m.def("WriteProfile", [](const std::string* filename) {
+    std::lock_guard<std::mutex> lock(tfprof_mu);
+    tensorflow::tfprof::WriteProfile(filename);
+  });
   m.def("Profile", [](const std::string* command, const std::string* options) {
+    std::lock_guard<std::mutex> lock(tfprof_mu);
     std::string temp = tensorflow::tfprof::Profile(command, options);
     return py::bytes(temp);
   });

--- a/third_party/xla/third_party/tsl/tsl/profiler/lib/traceme.h
+++ b/third_party/xla/third_party/tsl/tsl/profiler/lib/traceme.h
@@ -334,6 +334,15 @@ class TraceMe {
 #endif
   }
 
+  // Returns whether this TraceMe instance is currently recording.
+  bool IsRecording() const {
+#if !defined(IS_MOBILE_PLATFORM)
+    return start_time_ != kUntracedActivity && TraceMeRecorder::Active();
+#else
+    return false;
+#endif
+  }
+
   static int64_t NewActivityId() {
 #if !defined(IS_MOBILE_PLATFORM)
     return TraceMeRecorder::NewActivityId();

--- a/third_party/xla/xla/python/profiler/internal/BUILD
+++ b/third_party/xla/xla/python/profiler/internal/BUILD
@@ -81,6 +81,7 @@ cc_library(
         "//xla/tsl/platform:macros",
         "//xla/tsl/platform:types",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
         "@pybind11",
         "@tsl//tsl/profiler/lib:traceme_for_pybind",
     ],

--- a/third_party/xla/xla/python/profiler/internal/traceme_wrapper.h
+++ b/third_party/xla/xla/python/profiler/internal/traceme_wrapper.h
@@ -19,6 +19,9 @@ limitations under the License.
 #include <utility>
 
 #include "absl/strings/str_cat.h"
+#ifdef Py_GIL_DISABLED
+#include "absl/synchronization/mutex.h"
+#endif
 #include "absl/strings/string_view.h"
 #include "pybind11/pytypes.h"
 #include "xla/tsl/platform/macros.h"
@@ -48,15 +51,42 @@ class TraceMeWrapper {
   // reference-counting overhead.
   void SetMetadata(const pybind11::kwargs& kwargs) {
     if (TF_PREDICT_FALSE(!kwargs.empty())) {
-      traceme_.AppendMetadata([&]() {
-        std::string metadata;
-        AppendMetadata(&metadata, kwargs);
-        return metadata;
-      });
+#ifndef NDEBUG
+      // Preserve TraceMe's debug behavior: metadata generators are evaluated
+      // even when tracing is disabled.
+#else
+#ifdef Py_GIL_DISABLED
+      {
+        absl::MutexLock lock(&mu_);
+        if (!traceme_.IsRecording()) {
+          return;
+        }
+      }
+#else
+      if (!traceme_.IsRecording()) {
+        return;
+      }
+#endif
+#endif  // NDEBUG
+
+      // Convert Python objects outside the native mutex so Python-level
+      // string conversion cannot re-enter TraceMe while the mutex is held.
+      std::string metadata;
+      AppendMetadata(&metadata, kwargs);
+
+#ifdef Py_GIL_DISABLED
+      absl::MutexLock lock(&mu_);
+#endif
+      traceme_.AppendMetadata([&metadata]() { return metadata; });
     }
   }
 
-  void Stop() { traceme_.Stop(); }
+  void Stop() {
+#ifdef Py_GIL_DISABLED
+    absl::MutexLock lock(&mu_);
+#endif
+    traceme_.Stop();
+  }
 
  private:
   // Converts kwargs to strings and appends them to name encoded as TraceMe
@@ -78,6 +108,9 @@ class TraceMeWrapper {
     return std::string(pybind11::str(handle));
   }
 
+#ifdef Py_GIL_DISABLED
+  absl::Mutex mu_;
+#endif
   tsl::profiler::TraceMe traceme_;
 };
 


### PR DESCRIPTION
## Summary

Make TensorFlow profiler and tracing bindings compatible with CPython free-threaded builds.

This PR covers:

- TensorFlow profiler session bindings
- TraceMe bindings
- legacy `tfprof`
- XLA/TSL TraceMe wrapper synchronization

The changes focus on native synchronization, stable Python snapshots, and GIL-independent pybind module declarations.

## Changes

### Profiler session synchronization

Add a native mutex to `ProfilerSessionWrapper` to serialize operations on mutable profiler session state.

This protects:

- `Start`
- `Stop`
- `ExportToTensorBoard`

The Python binding already releases the legacy GIL around these operations, so the GIL cannot be relied on for synchronization.

### Stable profiler options snapshot

Copy the Python options dictionary before iterating over it.

This prevents concurrent mutation of the caller-provided dictionary from invalidating iteration under free-threaded Python.

### GIL-independent profiler bindings

Declare:

```text
pybind11::mod_gil_not_used()
```

for:

```text
_pywrap_profiler
_pywrap_traceme
_pywrap_tfprof
```

### Legacy `tfprof` synchronization

The legacy tfprof API uses process-global profiler state.

Add a native mutex around its lifecycle and operations, including:

- `NewProfiler`
- `ProfilerFromFile`
- `DeleteProfiler`
- `AddStep`
- `SerializeToString`
- `WriteProfile`
- `Profile`

### TraceMe synchronization

Protect concurrent access to TraceMe mutable state under free-threaded Python.

Metadata conversion is performed outside the native mutex so Python-level string conversion cannot re-enter TraceMe while the lock is held.

The wrapper also avoids unnecessary metadata work when tracing is not active.

### XLA/TSL integration

Add the synchronization dependency required by the TraceMe wrapper and expose an `IsRecording()` helper used by the binding.

## Validation

Validated with CPython 3.14 free-threaded hermetic Python using:

```text
--repo_env=HERMETIC_PYTHON_VERSION=3.14-freethreaded
--repo_env=USE_PYWRAP_RULES=True
--@rules_python//python/config_settings:py_freethreaded=yes
```

The affected targets built successfully:

```text
//tensorflow/python/profiler/internal:_pywrap_profiler
//tensorflow/python/profiler/internal:_pywrap_traceme
//tensorflow/python/util:_pywrap_tfprof
@xla//xla/python/profiler/internal:traceme_wrapper
```

Result:

```text
PROFILER_TRACING_WARM_BUILD_EXIT=0
PROFILER_TRACING_FINAL_DIFF_CHECK_EXIT=0
```

## Dependency

Local CPython 3.14 free-threaded validation uses:

TensorFlow hermetic Python support:
https://github.com/tensorflow/tensorflow/pull/125634

and:

rules_ml_toolchain:
https://github.com/tensorflow/rules_ml_toolchain/pull/302

## Scope

This PR is intentionally limited to profiler and tracing synchronization.

Other TensorFlow free-threading changes are submitted separately.