### PR TITLE
fix double unlocking by using scope block

### DIFF
--- a/tensorflow/core/util/tensor_slice_reader_cache.cc
+++ b/tensorflow/core/util/tensor_slice_reader_cache.cc
@@ -52,8 +52,6 @@ TensorSliceReaderCache::~TensorSliceReaderCache() {
 const TensorSliceReader* TensorSliceReaderCache::GetReader(
     const std::string& filepattern,
     TensorSliceReader::OpenTableFunction open_function, int preferred_shard) {
-  mutex_lock l(mu_);
-
 #if defined(__GXX_RTTI) || defined(_CPPRTTI)
   // Get the function pointer from the open_function value.
   TensorSliceReaderCache::OpenFuncType* func_ptr =
@@ -72,22 +70,42 @@ const TensorSliceReader* TensorSliceReaderCache::GetReader(
     return nullptr;
   }
 
-  // Wait if another thread is already trying to open the same files.
-  while (still_opening_.find(filepattern) != still_opening_.end()) {
-    cv_.wait(l);
+  TensorSliceReader* reader = nullptr;
+
+  // scope block for lock
+  {
+    mutex_lock l(mu_);
+
+    // Wait if another thread is already trying to open the same files.
+    while (still_opening_.find(filepattern) != still_opening_.end()) {
+      cv_.wait(l);
+    }
+
+    if (readers_.find(filepattern) != readers_.end()) {
+      auto cached_val = readers_[filepattern];
+      if (cached_val.first == *func_ptr) {
+        reader = cached_val.second;
+        VLOG(1) << "Using cached TensorSliceReader for " << filepattern << ": "
+                << reader;
+      } else {
+        LOG(WARNING) << "Caching disabled because the checkpoint file "
+                     << "is being opened with two different open functions: "
+                     << filepattern;
+      }
+      return reader;
+    }
+
+    still_opening_.insert(filepattern);
   }
 
-  TensorSliceReader* reader = nullptr;
-  if (readers_.find(filepattern) == readers_.end()) {
+  // no lock for expensive constructing TensorSliceReader
+  TensorSliceReader* tmp_reader(
+      new TensorSliceReader(filepattern, open_function, preferred_shard));
+
+  // scope block for lock
+  {
     VLOG(1) << "Creating new TensorSliceReader for " << filepattern;
-    still_opening_.insert(filepattern);
-    // Release the lock temporary as constructing TensorSliceReader is
-    // expensive.
-    mu_.unlock();
-    TensorSliceReader* tmp_reader(
-        new TensorSliceReader(filepattern, open_function, preferred_shard));
-    // Acquire the lock again.
-    mu_.lock();
+    mutex_lock l(mu_);
     if (tmp_reader->status().ok()) {
       reader = tmp_reader;
       readers_[filepattern] = std::make_pair(*func_ptr, reader);
@@ -96,20 +114,9 @@ const TensorSliceReader* TensorSliceReaderCache::GetReader(
     }
     CHECK_EQ(size_t{1}, still_opening_.erase(filepattern));
     VLOG(1) << "Cached TensorSliceReader for " << filepattern << ": " << reader;
-  } else {
-    auto cached_val = readers_[filepattern];
-    if (cached_val.first == *func_ptr) {
-      reader = cached_val.second;
-      VLOG(1) << "Using cached TensorSliceReader for " << filepattern << ": "
-              << reader;
-    } else {
-      LOG(WARNING) << "Caching disabled because the checkpoint file "
-                   << "is being opened with two different open functions: "
-                   << filepattern;
-    }
-  }
 
-  cv_.notify_all();
+    cv_.notify_all();
+  }
   return reader;
 }
 

--- a/tensorflow/core/util/tensor_slice_reader_cache.cc
+++ b/tensorflow/core/util/tensor_slice_reader_cache.cc
@@ -81,8 +81,9 @@ const TensorSliceReader* TensorSliceReaderCache::GetReader(
       cv_.wait(l);
     }
 
-    if (readers_.find(filepattern) != readers_.end()) {
-      auto cached_val = readers_[filepattern];
+    auto it = readers_.find(filepattern);
+    if (it != readers_.end()) {
+      auto cached_val = it->second;
       if (cached_val.first == *func_ptr) {
         reader = cached_val.second;
         VLOG(1) << "Using cached TensorSliceReader for " << filepattern << ": "


### PR DESCRIPTION
Fix #103924 

## Change:
- Adding 2 scope block for lock between the expensive compute
- Right after the first scope, it will return the `reader` pointer or mark the current file as `still_opening_`
- The second block does not need to wait or check, it's automatically grab the lock and process the change when cache miss
- before destroy the lock, unmark the file and notify all other threads that waiting for the lock here

## Additional Information
- I already ran the `clang-format` and also passed the test `//tensorflow/core/util:tensor_slice_reader_test`
- This is my first time contribute to Opensouce and into **tensorflow**, and I already signed the [Google Individual CLA](https://cla.developers.google.com/about/google-individual)
- I did not find any template related to open a Pull Request, so please let me know if there is a fixed template :)
