### PR TITLE
Synchronize data service and Grappler bindings for free-threaded Python

### DIFF
--- a/tensorflow/core/data/service/server_lib.cc
+++ b/tensorflow/core/data/service/server_lib.cc
@@ -104,10 +104,16 @@ void GrpcDataServerBase::Stop() {
 }
 
 void GrpcDataServerBase::Join() {
-  if (!server_) {
-    return;
+  ::grpc::Server* server = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(ExternalMutex());
+    if (!server_) {
+      return;
+    }
+    server = server_.get();
   }
-  server_->Wait();
+
+  server->Wait();
 }
 
 int GrpcDataServerBase::BoundPort() { return bound_port(); }

--- a/tensorflow/core/data/service/server_lib.h
+++ b/tensorflow/core/data/service/server_lib.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_CORE_DATA_SERVICE_SERVER_LIB_H_
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -61,6 +62,12 @@ class GrpcDataServerBase {
   // Returns the port bound by the server. Only valid after calling Start().
   int BoundPort();
 
+  // Serializes compound external operations on this server instance.
+  //
+  // Join() deliberately only holds this mutex while snapshotting server_, since
+  // holding it while waiting would prevent Stop() from shutting the server down.
+  std::mutex& ExternalMutex() const { return external_mu_; }
+
   // Exports the server state to improve debuggability.
   virtual ServerStateExport ExportState() const = 0;
 
@@ -79,6 +86,8 @@ class GrpcDataServerBase {
   const std::string server_type_;
 
  private:
+  mutable std::mutex external_mu_;
+
   int bound_port_;
   bool started_ = false;
   bool stopped_ = false;

--- a/tensorflow/core/grappler/clusters/cluster.h
+++ b/tensorflow/core/grappler/clusters/cluster.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_GRAPPLER_CLUSTERS_CLUSTER_H_
 #define TENSORFLOW_CORE_GRAPPLER_CLUSTERS_CLUSTER_H_
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -43,6 +44,13 @@ class Cluster {
  public:
   explicit Cluster(int timeout_s);
   virtual ~Cluster();
+
+  // Serializes compound external operations on this Cluster instance.
+  //
+  // This mutex intentionally lives in Cluster rather than in an individual
+  // Python extension so separate extension modules can coordinate access to
+  // the same native Cluster object.
+  std::mutex& ExternalMutex() const { return external_mu_; }
 
   // Returns a string that represent the type of cluster that was instantiated.
   virtual std::string type() const = 0;
@@ -142,6 +150,9 @@ class Cluster {
   const int timeout_s_;
   SessionOptions options_;
   RunOptions run_options_;
+
+ private:
+  mutable std::mutex external_mu_;
 };
 
 }  // end namespace grappler

--- a/tensorflow/python/data/experimental/service/server_lib_wrapper.cc
+++ b/tensorflow/python/data/experimental/service/server_lib_wrapper.cc
@@ -15,6 +15,7 @@ limitations under the License.
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -42,20 +43,35 @@ limitations under the License.
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(_pywrap_server_lib, m) {
+PYBIND11_MODULE(
+    _pywrap_server_lib, m, pybind11::mod_gil_not_used()) {
   pybind11_protobuf::ImportNativeProtoCasters();
 
-  py::class_<tensorflow::data::DispatchGrpcDataServer>(m,
-                                                       "DispatchGrpcDataServer")
-      .def("start", &tensorflow::data::DispatchGrpcDataServer::Start)
-      .def("stop", &tensorflow::data::DispatchGrpcDataServer::Stop)
+  py::class_<tensorflow::data::DispatchGrpcDataServer>(
+      m, "DispatchGrpcDataServer")
+      .def("start", [](tensorflow::data::DispatchGrpcDataServer* server) {
+        std::lock_guard<std::mutex> lock(server->ExternalMutex());
+        return server->Start();
+      })
+      .def("stop", [](tensorflow::data::DispatchGrpcDataServer* server) {
+        std::lock_guard<std::mutex> lock(server->ExternalMutex());
+        server->Stop();
+      })
       .def("join", &tensorflow::data::DispatchGrpcDataServer::Join,
            py::call_guard<py::gil_scoped_release>())
-      .def("bound_port", &tensorflow::data::DispatchGrpcDataServer::BoundPort)
+      .def("bound_port",
+           [](tensorflow::data::DispatchGrpcDataServer* server) {
+             std::lock_guard<std::mutex> lock(server->ExternalMutex());
+             return server->BoundPort();
+           })
       .def("num_workers",
            [](tensorflow::data::DispatchGrpcDataServer* server) -> int {
              int num_workers;
-             absl::Status status = server->NumWorkers(&num_workers);
+             absl::Status status;
+             {
+               std::lock_guard<std::mutex> lock(server->ExternalMutex());
+               status = server->NumWorkers(&num_workers);
+             }
              tensorflow::MaybeRaiseFromStatus(status);
              return num_workers;
            })
@@ -64,21 +80,40 @@ PYBIND11_MODULE(_pywrap_server_lib, m) {
               const std::string& path)
                -> std::vector<tensorflow::data::SnapshotStreamInfoWrapper> {
              std::vector<tensorflow::data::SnapshotStreamInfoWrapper> streams;
-             absl::Status status = server->SnapshotStreams(path, &streams);
+             absl::Status status;
+             {
+               std::lock_guard<std::mutex> lock(server->ExternalMutex());
+               status = server->SnapshotStreams(path, &streams);
+             }
              tensorflow::MaybeRaiseFromStatus(status);
              return streams;
            });
 
-  py::class_<tensorflow::data::WorkerGrpcDataServer>(m, "WorkerGrpcDataServer")
-      .def("start", &tensorflow::data::WorkerGrpcDataServer::Start)
-      .def("stop", &tensorflow::data::WorkerGrpcDataServer::Stop)
+  py::class_<tensorflow::data::WorkerGrpcDataServer>(
+      m, "WorkerGrpcDataServer")
+      .def("start", [](tensorflow::data::WorkerGrpcDataServer* server) {
+        std::lock_guard<std::mutex> lock(server->ExternalMutex());
+        return server->Start();
+      })
+      .def("stop", [](tensorflow::data::WorkerGrpcDataServer* server) {
+        std::lock_guard<std::mutex> lock(server->ExternalMutex());
+        server->Stop();
+      })
       .def("join", &tensorflow::data::WorkerGrpcDataServer::Join,
            py::call_guard<py::gil_scoped_release>())
-      .def("bound_port", &tensorflow::data::WorkerGrpcDataServer::BoundPort)
+      .def("bound_port",
+           [](tensorflow::data::WorkerGrpcDataServer* server) {
+             std::lock_guard<std::mutex> lock(server->ExternalMutex());
+             return server->BoundPort();
+           })
       .def("num_tasks",
            [](tensorflow::data::WorkerGrpcDataServer* server) -> int {
              int num_tasks;
-             absl::Status status = server->NumTasks(&num_tasks);
+             absl::Status status;
+             {
+               std::lock_guard<std::mutex> lock(server->ExternalMutex());
+               status = server->NumTasks(&num_tasks);
+             }
              tensorflow::MaybeRaiseFromStatus(status);
              return num_tasks;
            })
@@ -87,8 +122,12 @@ PYBIND11_MODULE(_pywrap_server_lib, m) {
                -> std::vector<tensorflow::data::SnapshotTaskProgressWrapper> {
              std::vector<tensorflow::data::SnapshotTaskProgressWrapper>
                  snapshot_task_progresses;
-             absl::Status status =
-                 server->SnapshotTaskProgresses(&snapshot_task_progresses);
+             absl::Status status;
+             {
+               std::lock_guard<std::mutex> lock(server->ExternalMutex());
+               status =
+                   server->SnapshotTaskProgresses(&snapshot_task_progresses);
+             }
              tensorflow::MaybeRaiseFromStatus(status);
              return snapshot_task_progresses;
            });
@@ -120,7 +159,8 @@ PYBIND11_MODULE(_pywrap_server_lib, m) {
               "Failed to deserialize worker config."));
         }
         std::unique_ptr<tensorflow::data::WorkerGrpcDataServer> server;
-        absl::Status status = tensorflow::data::NewWorkerServer(config, server);
+        absl::Status status =
+            tensorflow::data::NewWorkerServer(config, server);
         tensorflow::MaybeRaiseFromStatus(status);
         return server;
       },
@@ -170,6 +210,7 @@ PYBIND11_MODULE(_pywrap_server_lib, m) {
                  snapshot_task_progress_wrapper) -> bool {
             return snapshot_task_progress_wrapper.completed;
           });
+
   py::class_<tensorflow::data::SnapshotStreamInfoWrapper>
       snapshot_stream_info_wrapper(m, "SnapshotStreamInfoWrapper");
   snapshot_stream_info_wrapper.def(py::init<>())

--- a/tensorflow/python/data/experimental/service/utils_wrapper.cc
+++ b/tensorflow/python/data/experimental/service/utils_wrapper.cc
@@ -20,7 +20,8 @@ limitations under the License.
 #include "tensorflow/core/data/service/py_utils.h"
 #include "tensorflow/python/lib/core/pybind11_lib.h"
 
-PYBIND11_MODULE(_pywrap_utils_exp, m) {
+PYBIND11_MODULE(
+    _pywrap_utils_exp, m, pybind11::mod_gil_not_used()) {
   m.def("TF_DATA_DefaultProtocol",
         []() -> std::string { return tensorflow::data::DefaultProtocol(); });
 };

--- a/tensorflow/python/grappler/cluster_wrapper.cc
+++ b/tensorflow/python/grappler/cluster_wrapper.cc
@@ -156,18 +156,17 @@ PYBIND11_MODULE(
             return {};
           }
 
-          std::unordered_map<std::string, tensorflow::DeviceProperties> devices;
+          std::vector<py::bytes> named_devices;
           {
             std::lock_guard<std::mutex> lock(cluster->ExternalMutex());
-            devices = cluster->GetDevices();
-          }
+            const auto& devices = cluster->GetDevices();
 
-          std::vector<py::bytes> named_devices;
-          for (const auto& dev : devices) {
-            tensorflow::NamedDevice d;
-            d.set_name(dev.first);
-            *d.mutable_properties() = dev.second;
-            named_devices.push_back(d.SerializeAsString());
+            for (const auto& dev : devices) {
+              tensorflow::NamedDevice d;
+              d.set_name(dev.first);
+              *d.mutable_properties() = dev.second;
+              named_devices.push_back(d.SerializeAsString());
+            }
           }
           return named_devices;
         });
@@ -195,17 +194,17 @@ PYBIND11_MODULE(
               absl::InternalError("You need both a cluster and an "
                                   "item to get supported devices.")));
         }
-        std::unordered_map<std::string, tensorflow::DeviceProperties> devices;
+        std::unordered_map<std::string, std::vector<std::string>> device_types;
         std::string cluster_type;
+
         {
           std::lock_guard<std::mutex> lock(cluster->ExternalMutex());
-          devices = cluster->GetDevices();
+          const auto& devices = cluster->GetDevices();
           cluster_type = cluster->type();
-        }
 
-        std::unordered_map<std::string, std::vector<std::string>> device_types;
-        for (const auto& dev : devices) {
-          device_types[dev.second.type()].push_back(dev.first);
+          for (const auto& dev : devices) {
+            device_types[dev.second.type()].push_back(dev.first);
+          }
         }
 
         std::unordered_map<std::string, std::set<std::string>>

--- a/tensorflow/python/grappler/cluster_wrapper.cc
+++ b/tensorflow/python/grappler/cluster_wrapper.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstdint>
 #include <iterator>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -53,6 +54,15 @@ limitations under the License.
 
 namespace py = pybind11;
 
+
+namespace {
+
+// SingleMachine uses process-global provisioning state. Serialize Python
+// creation/shutdown paths that update that state.
+std::mutex cluster_lifecycle_mu;
+
+}  // namespace
+
 absl::Status _GetOpPerformanceDataAndRunTime(
     const tensorflow::grappler::GrapplerItem& item,
     tensorflow::grappler::CostEstimator* cost_measure,
@@ -74,7 +84,8 @@ absl::Status _GetOpPerformanceDataAndRunTime(
 
 PYBIND11_MAKE_OPAQUE(tensorflow::grappler::Cluster);
 
-PYBIND11_MODULE(_pywrap_tf_cluster, m) {
+PYBIND11_MODULE(
+    _pywrap_tf_cluster, m, pybind11::mod_gil_not_used()) {
   py::class_<tensorflow::grappler::Cluster> grappler_cluster(m, "Cluster");
 
   m.def("TF_NewCluster",
@@ -82,6 +93,8 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
            bool disable_detailed_stats) -> tensorflow::grappler::Cluster* {
           // TODO(petebu): Make these named arguments with default values
           // instead.
+          std::unique_lock<std::mutex> lifecycle_lock(cluster_lifecycle_mu);
+
           int num_cpu_cores =
               tensorflow::grappler::GetNumAvailableLogicalCPUCores();
           int num_gpus = tensorflow::grappler::GetNumAvailableGPUs();
@@ -92,7 +105,9 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
           cluster->DisableDetailedStats(disable_detailed_stats);
           cluster->AllowSoftPlacement(allow_soft_placement);
           cluster->SetNumWarmupSteps(10);
-          tsl::MaybeRaiseRegisteredFromStatus(cluster->Provision());
+          absl::Status provision_status = cluster->Provision();
+          lifecycle_lock.unlock();
+          tsl::MaybeRaiseRegisteredFromStatus(provision_status);
           return cluster.release();
         });
 
@@ -125,17 +140,30 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
         });
 
   m.def("TF_ShutdownCluster", [](tensorflow::grappler::Cluster* cluster) {
-    // TODO(petebu): Do we need to hold the GIL here?
-    py::gil_scoped_acquire acquire;
+    if (cluster == nullptr) {
+      return;
+    }
+    std::lock_guard<std::mutex> lifecycle_lock(cluster_lifecycle_mu);
+    std::lock_guard<std::mutex> cluster_lock(cluster->ExternalMutex());
     (void)cluster->Shutdown();
   });
 
   m.def("TF_ListDevices",
         [](tensorflow::grappler::Cluster* cluster) -> std::vector<py::bytes> {
-          const std::unordered_map<std::string, tensorflow::DeviceProperties>&
-              devices = cluster->GetDevices();
+          if (cluster == nullptr) {
+            tsl::MaybeRaiseRegisteredFromStatus(
+                absl::InvalidArgumentError("Cluster cannot be None."));
+            return {};
+          }
+
+          std::unordered_map<std::string, tensorflow::DeviceProperties> devices;
+          {
+            std::lock_guard<std::mutex> lock(cluster->ExternalMutex());
+            devices = cluster->GetDevices();
+          }
+
           std::vector<py::bytes> named_devices;
-          for (auto& dev : devices) {
+          for (const auto& dev : devices) {
             tensorflow::NamedDevice d;
             d.set_name(dev.first);
             *d.mutable_properties() = dev.second;
@@ -167,8 +195,14 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
               absl::InternalError("You need both a cluster and an "
                                   "item to get supported devices.")));
         }
-        const std::unordered_map<std::string, tensorflow::DeviceProperties>&
-            devices = cluster->GetDevices();
+        std::unordered_map<std::string, tensorflow::DeviceProperties> devices;
+        std::string cluster_type;
+        {
+          std::lock_guard<std::mutex> lock(cluster->ExternalMutex());
+          devices = cluster->GetDevices();
+          cluster_type = cluster->type();
+        }
+
         std::unordered_map<std::string, std::vector<std::string>> device_types;
         for (const auto& dev : devices) {
           device_types[dev.second.type()].push_back(dev.first);
@@ -182,7 +216,7 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
         for (const auto& node : item->graph.node()) {
           for (const auto& dev : device_types) {
             const std::string& type = dev.first;
-            if (cluster->type() != "single_machine") {
+            if (cluster_type != "single_machine") {
               // The actual kernel may not be linked in this binary.
               supported_device_types[node.name()].insert(type);
             } else {
@@ -259,6 +293,14 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
         [](tensorflow::grappler::GrapplerItem* item,
            tensorflow::grappler::Cluster* cluster, bool generate_timeline)
             -> std::tuple<std::vector<py::bytes>, double, py::bytes> {
+          if (cluster == nullptr || item == nullptr) {
+            tsl::MaybeRaiseRegisteredFromStatus(absl::InvalidArgumentError(
+                "You need both a cluster and an item to measure costs."));
+            return {};
+          }
+
+          std::lock_guard<std::mutex> lock(cluster->ExternalMutex());
+
           const int num_measurements = cluster->type() == "virtual" ? 1 : 10;
           tensorflow::grappler::MeasuringCostEstimator cost_measure(
               cluster, num_measurements, 0);
@@ -305,6 +347,8 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
               "You need both a cluster and an item to determine peak "
               "memory usage.")));
         }
+        std::lock_guard<std::mutex> lock(cluster->ExternalMutex());
+
         tensorflow::grappler::GraphMemory memory(*item);
 
         if (cluster->DetailedStatsEnabled()) {

--- a/tensorflow/python/grappler/cluster_wrapper.cc
+++ b/tensorflow/python/grappler/cluster_wrapper.cc
@@ -72,7 +72,7 @@ absl::Status _GetOpPerformanceDataAndRunTime(
   if (!status.ok()) return status;
 
   tensorflow::RunMetadata run_metadata;
-  tsl::MaybeRaiseRegisteredFromStatus(
+  tsl::MaybeRaiseRegisteredFromStatusWithGIL(
       cost_measure->PredictCosts(item.graph, &run_metadata, costs));
 
   if (op_performance_data) {
@@ -107,7 +107,7 @@ PYBIND11_MODULE(
           cluster->SetNumWarmupSteps(10);
           absl::Status provision_status = cluster->Provision();
           lifecycle_lock.unlock();
-          tsl::MaybeRaiseRegisteredFromStatus(provision_status);
+          tsl::MaybeRaiseRegisteredFromStatusWithGIL(provision_status);
           return cluster.release();
         });
 
@@ -151,7 +151,7 @@ PYBIND11_MODULE(
   m.def("TF_ListDevices",
         [](tensorflow::grappler::Cluster* cluster) -> std::vector<py::bytes> {
           if (cluster == nullptr) {
-            tsl::MaybeRaiseRegisteredFromStatus(
+            tsl::MaybeRaiseRegisteredFromStatusWithGIL(
                 absl::InvalidArgumentError("Cluster cannot be None."));
             return {};
           }
@@ -190,7 +190,7 @@ PYBIND11_MODULE(
          tensorflow::grappler::GrapplerItem* item)
           -> std::unordered_map<std::string, std::vector<std::string>> {
         if (cluster == nullptr || item == nullptr) {
-          tsl::MaybeRaiseRegisteredFromStatus(absl::Status(
+          tsl::MaybeRaiseRegisteredFromStatusWithGIL(absl::Status(
               absl::InternalError("You need both a cluster and an "
                                   "item to get supported devices.")));
         }
@@ -293,7 +293,7 @@ PYBIND11_MODULE(
            tensorflow::grappler::Cluster* cluster, bool generate_timeline)
             -> std::tuple<std::vector<py::bytes>, double, py::bytes> {
           if (cluster == nullptr || item == nullptr) {
-            tsl::MaybeRaiseRegisteredFromStatus(absl::InvalidArgumentError(
+            tsl::MaybeRaiseRegisteredFromStatusWithGIL(absl::InvalidArgumentError(
                 "You need both a cluster and an item to measure costs."));
             return {};
           }
@@ -315,7 +315,7 @@ PYBIND11_MODULE(
           tensorflow::StepStats step_stats;
           if (generate_timeline) {
             tensorflow::RunMetadata metadata;
-            tsl::MaybeRaiseRegisteredFromStatus(
+            tsl::MaybeRaiseRegisteredFromStatusWithGIL(
                 cluster->Run(item->graph, item->feed, item->fetch, &metadata));
             step_stats = metadata.step_stats();
           }
@@ -342,7 +342,7 @@ PYBIND11_MODULE(
           -> std::unordered_map<std::string,
                                 std::tuple<int64_t, std::vector<MemoryUsage>>> {
         if (item == nullptr || cluster == nullptr) {
-          tsl::MaybeRaiseRegisteredFromStatus(absl::Status(absl::InternalError(
+          tsl::MaybeRaiseRegisteredFromStatusWithGIL(absl::Status(absl::InternalError(
               "You need both a cluster and an item to determine peak "
               "memory usage.")));
         }
@@ -351,9 +351,9 @@ PYBIND11_MODULE(
         tensorflow::grappler::GraphMemory memory(*item);
 
         if (cluster->DetailedStatsEnabled()) {
-          tsl::MaybeRaiseRegisteredFromStatus(memory.InferDynamically(cluster));
+          tsl::MaybeRaiseRegisteredFromStatusWithGIL(memory.InferDynamically(cluster));
         } else {
-          tsl::MaybeRaiseRegisteredFromStatus(
+          tsl::MaybeRaiseRegisteredFromStatusWithGIL(
               memory.InferStatically(cluster->GetDevices()));
         }
 

--- a/tensorflow/python/grappler/tf_optimizer_wrapper.cc
+++ b/tensorflow/python/grappler/tf_optimizer_wrapper.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -92,8 +93,16 @@ tensorflow::GraphDef TF_OptimizeGraph(
     tensorflow::DeviceBase* cpu_device = nullptr;
     tensorflow::grappler::MetaOptimizer optimizer(cpu_device, config_proto);
 
-    tsl::MaybeRaiseRegisteredFromStatusWithGIL(
-        optimizer.Optimize(cluster, *grappler_item, &out_graph));
+    absl::Status optimize_status;
+    if (cluster != nullptr) {
+      std::lock_guard<std::mutex> lock(cluster->ExternalMutex());
+      optimize_status =
+          optimizer.Optimize(cluster, *grappler_item, &out_graph);
+    } else {
+      optimize_status =
+          optimizer.Optimize(nullptr, *grappler_item, &out_graph);
+    }
+    tsl::MaybeRaiseRegisteredFromStatusWithGIL(optimize_status);
     if (strip_default_attributes) {
       tensorflow::StripDefaultAttributes(*tensorflow::OpRegistry::Global(),
                                          out_graph.mutable_node());
@@ -114,7 +123,8 @@ tensorflow::GraphDef TF_OptimizeGraph(
 // larger than 2GiB.
 // At the moment, the open source python API defaults to the serialized
 // implementation.
-PYBIND11_MODULE(_pywrap_tf_optimizer, m) {
+PYBIND11_MODULE(
+    _pywrap_tf_optimizer, m, pybind11::mod_gil_not_used()) {
   pybind11_protobuf::ImportNativeProtoCasters();
   m.def("TF_OptimizeGraphSerialized",
         [](tensorflow::grappler::Cluster* cluster,


### PR DESCRIPTION
## Summary

Synchronize TensorFlow Data Service and Grappler native state for CPython free-threaded execution.

The affected Python bindings can execute concurrently when the interpreter no longer provides process-wide GIL serialization, so mutable native state must be protected explicitly.

## Scope

This PR covers:

- Data Service server lifecycle/state
- Data Service Python server/util bindings
- Grappler cluster state
- Grappler cluster Python binding
- Grappler optimizer Python binding

## Changes

### Data Service

Add explicit native synchronization around mutable Data Service server state and lifecycle operations that can be reached from Python concurrently under free-threaded execution.

The affected Python wrappers are updated so they no longer rely on the legacy GIL as an implicit serialization mechanism.

### Grappler

Add explicit synchronization for mutable Grappler cluster and optimizer state accessed through Python bindings.

This avoids races when the same native objects are reached concurrently from multiple Python threads in CPython free-threaded builds.

## Validation

Validation used CPython 3.14 free-threaded hermetic Python with:

    --repo_env=HERMETIC_PYTHON_VERSION=3.14-freethreaded
    --repo_env=USE_PYWRAP_RULES=True
    --@rules_python//python/config_settings:py_freethreaded=yes

The exact Grappler targets built successfully:

    //tensorflow/core/grappler/clusters:cluster
    //tensorflow/python/grappler:_pywrap_tf_cluster
    //tensorflow/python/grappler:_pywrap_tf_optimizer

Data Service validation was also attempted with:

    //tensorflow/core/data/service:server_lib
    //tensorflow/python/data/experimental/service:_pywrap_server_lib
    //tensorflow/python/data/experimental/service:_pywrap_utils_exp

The Data Service build was locally blocked inside the external gRPC dependency by a Bazel/module dependency declaration error involving generated protobuf UPB headers.

Observed failures occurred under `external/grpc`, including missing module/dependency declarations for generated headers such as:

    google/protobuf/any.upb.h
    google/protobuf/descriptor.upb.h
    google/protobuf/descriptor.upb_minitable.h

The failure occurred in the external gRPC dependency graph, not in the changed TensorFlow sources.

## Dependencies for local CPython 3.14t validation

TensorFlow hermetic Python support:

https://github.com/tensorflow/tensorflow/pull/125634

rules_ml_toolchain free-threaded Python version-kind handling:

https://github.com/tensorflow/rules_ml_toolchain/pull/302

## Scope note

This PR is intentionally limited to TensorFlow Data Service and Grappler synchronization.

Other TensorFlow free-threading changes are submitted separately in focused PRs.