### PR TITLE
Add init to MLModelConfiguration

### DIFF
--- a/tensorflow/lite/delegates/coreml/coreml_executor.mm
+++ b/tensorflow/lite/delegates/coreml/coreml_executor.mm
@@ -207,7 +207,7 @@ NSURL* createTemporaryFile() {
   _compiledModelFilePath = [compileUrl path];
 
   if (@available(iOS 12.0, *)) {
-    MLModelConfiguration* config = [MLModelConfiguration alloc];
+    MLModelConfiguration* config = [[MLModelConfiguration alloc] init];
     config.computeUnits = MLComputeUnitsAll;
     _model = [MLModel modelWithContentsOfURL:compileUrl configuration:config error:&error];
   } else {


### PR DESCRIPTION
This is fixing a crash bug when using the CoreMLDelegate on IOS, this is due to Objective-C Object Lifecycle: +alloc only allocates raw memory on the heap and assigns the isa pointer; it does not initialize instance variables, internal properties, or backing objects. Apple's Modern CoreML Architecture: On iOS 15+,CoreML's Neural Engine (ANE) and GPU backends
(MLNeuralEngineEngine, MLComputeDeviceProtocol) are written largely in Swift. -[MLModelConfiguration init] initializes default compute device descriptors, optimization hints, and internal Swift bridging structures.