### PR TITLE
Fix typo in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3496,7 +3496,7 @@ This release introduces several vulnerability fixes:
     *   Add `keepdims` argument to all `GlobalPooling` layers.
     *   Add `include_preprocessing` argument to `MobileNetV3` architectures to
         control the inclusion of `Rescaling` layer in the model.
-    *   Add optional argument (`force`) to `make_(train|test|predict)_funtion`
+    *   Add optional argument (`force`) to `make_(train|test|predict)_function`
         methods to skip the cached function and generate a new one. This is
         useful to regenerate in a single call the compiled training function
         when any `.trainable` attribute of any model's layer has changed.


### PR DESCRIPTION
Fixes a spelling mistake in RELEASE.md:

- `make_(train|test|predict)_funtion` -> `make_(train|test|predict)_function` (line 3499)

The text refers to the real Keras `Model` methods `make_train_function`, `make_test_function`, and `make_predict_function` (see `tensorflow/python/keras/engine/training.py`). `_funtion` is a misspelling of the actual method suffix. No code or behavior changes.