### PR TITLE
Document that tf.io.gfile APIs do not prevent path traversal

### DIFF
--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""File IO methods that wrap the C++ FileSystem API."""
+"""File IO methods that wrap the C++ FileSystem API.
+
+**Security Note:** These file I/O functions do not perform path validation or
+sandboxing. They do not prevent path traversal (e.g., using `..`), do not
+restrict access to any directory, and will follow symbolic links. Applications
+that accept file paths from untrusted sources (such as user input, model
+configurations, or checkpoint metadata) must validate and canonicalize paths
+before passing them to these functions.
+"""
 import binascii
 import io
 import os

--- a/tensorflow/python/platform/gfile.py
+++ b/tensorflow/python/platform/gfile.py
@@ -108,6 +108,13 @@ class GFile(_FileIO):
   >>> f.tell()
   7
   >>> f.close()
+
+  **Security Note:** The `tf.io.gfile` APIs do not perform path validation
+  or sandboxing. They do not prevent path traversal (e.g., using `..`), do
+  not restrict access to any directory, and will follow symbolic links. If your
+  application accepts file paths from untrusted sources (such as user input,
+  model configurations, or checkpoint metadata), you must validate and
+  canonicalize paths before passing them to these functions.
   """
 
   def __init__(self, name, mode='r'):


### PR DESCRIPTION
Fixes #110916

Adds a Security Note to the `tf.io.gfile` documentation stating that the file I/O APIs do not perform path validation or sandboxing: they do not prevent path traversal with `..`, do not restrict access to any directory, and follow symbolic links. Callers that accept paths from untrusted sources must validate and canonicalize them before passing them to these functions.

Two docstrings are updated, matching the scope reviewers previously accepted:

- `tensorflow/python/lib/io/file_io.py`: the module docstring, which is the implementation behind `tf.io.gfile`
- `tensorflow/python/platform/gfile.py`: the `GFile` class docstring, which renders on the `tf.io.gfile.GFile` API page

This continues PR #111090 by @rstar327, which was approved in substance by the issue reporter but closed as stale before the review-requested formatting fixes were applied. This PR incorporates those fixes: standard Markdown single backticks instead of RST-style double backticks, and a consistent `**Security Note:**` heading in both files, as requested by @ratgr.

Verification: both files compile, and the `GFile` docstring still parses to the same 16 doctest examples, with the new paragraph outside any example's expected output.
