### PR TITLE
Harden TensorListScatterIntoExistingList resize (follow-up to #121412)

### DIFF
--- a/tensorflow/core/kernels/list_kernels.h
+++ b/tensorflow/core/kernels/list_kernels.h
@@ -908,9 +908,25 @@ class TensorListScatterIntoExistingList : public OpKernel {
               "non-negative; got ",
               *minmax.first)));
       max_index = *minmax.second;
+      // Also honor the list's declared capacity. TensorListPushBack already
+      // enforces `size() < max_num_elements`; mirror it here so a scatter
+      // cannot silently grow the list past its cap. This also bounds the
+      // resize below by an attacker-controlled index.
+      OP_REQUIRES(
+          c,
+          output_list->max_num_elements == -1 ||
+              max_index < output_list->max_num_elements,
+          absl::InvalidArgumentError(absl::StrCat(
+              "TensorListScatterIntoExistingList: index ", max_index,
+              " is beyond the list's max_num_elements ",
+              output_list->max_num_elements)));
     }
-    if (max_index + 1 > output_list->tensors().size()) {
-      output_list->tensors().resize(max_index + 1);
+    // Compute the required size as size_t: max_index is >= 0 here, but
+    // max_index == INT32_MAX would overflow the signed `max_index + 1`
+    // (undefined behavior) before the comparison/resize below.
+    const size_t needed = static_cast<size_t>(max_index) + 1;
+    if (needed > output_list->tensors().size()) {
+      output_list->tensors().resize(needed);
     }
 
     // Scatter the values.

--- a/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
@@ -568,6 +568,28 @@ class ListOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
           )
       )
 
+  def testScatterIntoExistingListFailsWhenIndexBeyondMaxNumElements(self):
+    # Follow-up to the negative-index fix: scattering past the list's declared
+    # max_num_elements must raise instead of unbounded-growing the backing
+    # std::vector by an attacker-controlled index (a memory-exhaustion DoS,
+    # and at INT32_MAX a signed `max_index + 1` overflow). Mirrors
+    # TensorListPushBack, which already enforces this cap.
+    l = list_ops.empty_tensor_list(
+        element_dtype=dtypes.float32, element_shape=[], max_num_elements=3
+    )
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError,
+        "is beyond the list's max_num_elements",
+    ):
+      self.evaluate(
+          list_ops.tensor_list_scatter(
+              tensor=[2.0, 3.0],
+              indices=[0, 5],
+              element_shape=[],
+              input_handle=l,
+          )
+      )
+
   def testScatterFailsWithInvalidNumElements(self):
     c0 = constant_op.constant([1.0, 2.0])
     with self.assertRaisesRegex(


### PR DESCRIPTION
### Follow-up to #121412

#121412 (merged, `b14991de0e`) closed the negative-index out-of-bounds write in
`TensorListScatterIntoExistingList`. While reviewing the merged code I noticed the resize path just
below the new check still has two smaller issues, both driven by the attacker-controlled index **value**
(not the sign the merged PR already handles):

```cpp
max_index = *minmax.second;              // >= 0 after #121412
...
if (max_index + 1 > output_list->tensors().size()) {   // (1) int32 overflow at INT32_MAX
  output_list->tensors().resize(max_index + 1);        // (2) no max_num_elements cap
}
```

1. **`max_index + 1` overflows int32** when `max_index == INT32_MAX` — undefined behavior before the value
   is ever widened for the comparison / `resize()` argument.
2. **The list's declared `max_num_elements` is not honored.** `TensorListPushBack` already enforces
   `size() < max_num_elements`, but scatter-into-existing does not, so a scatter silently grows the backing
   `std::vector<Tensor>` past the cap — and with no cap at all, a single large index drives an unbounded
   allocation.

Observed on a released build (`tensorflow-cpu==2.21.0`, x86-64):

```python
import tensorflow as tf
from tensorflow.python.ops import list_ops
from tensorflow.python.framework import dtypes

# (2) cap ignored: a max_num_elements=3 list grows to length 6
l = list_ops.empty_tensor_list(element_dtype=dtypes.float32, element_shape=[], max_num_elements=3)
out = list_ops.tensor_list_scatter(tensor=[2., 3.], indices=[0, 5], element_shape=[], input_handle=l)
print(int(tf.raw_ops.TensorListLength(input_handle=out)))     # -> 6

# unbounded resize: a single large index exhausts memory (process killed)
l2 = tf.raw_ops.EmptyTensorList(element_shape=[2], max_num_elements=-1, element_dtype=tf.float32)
tf.raw_ops.TensorListScatterIntoExistingList(
    input_handle=l2, tensor=tf.constant([[1., 2.], [3., 4.]], tf.float32),
    indices=tf.constant([100000000, 0], tf.int32))            # OOM-kill; INT32_MAX also overflows (1)
```

### Change

- Enforce `max_index < max_num_elements` (when the list has a cap), mirroring `TensorListPushBack`.
- Compute the required size as `size_t` so the INT32_MAX case is well defined.
- Add a regression test (`testScatterIntoExistingListFailsWhenIndexBeyondMaxNumElements`).

### Note on the behavior change

Enforcing the cap makes a previously-accepted call (scatter past `max_num_elements`) raise
`InvalidArgument`. I believe that's the correct behavior — it matches `TensorListPushBack` and prevents an
unbounded grow — but if you'd prefer to keep scatter's grow-past-cap semantics, I'm happy to reduce this to
just the `size_t` overflow fix. Severity here is low (DoS / UB), not the memory-safety issue #121412 fixed.
