### PR TITLE
Fix the CMake build of the Metal delegate

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -424,14 +424,14 @@ if(TFLITE_ENABLE_GPU)
     enable_language(OBJCXX)
     list(APPEND TFLITE_DELEGATES_METAL_SRCS
       ${TFLITE_SOURCE_DIR}/delegates/gpu/metal_delegate.mm
-      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/buffer.cc
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/buffer.mm
       ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/buffer_convert.mm
       ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/common.mm
-      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/compute_task.cc
-      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/inference_context.cc
-      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/metal_arguments.cc
-      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/metal_device.cc
-      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/metal_spatial_tensor.cc
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/compute_task.mm
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/inference_context.mm
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/metal_arguments.mm
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/metal_device.mm
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/metal_spatial_tensor.mm
     )
     add_library(metal_delegate STATIC
       ${TFLITE_DELEGATES_METAL_SRCS}
@@ -464,30 +464,17 @@ if(TFLITE_ENABLE_GPU)
     #
     # supplementary libraries for libmetal_delegate
     #
-    list(APPEND CC_SRCS
-        buffer
-        compute_task
-        inference_context
-        metal_arguments
-        metal_device
-        metal_spatial_tensor
-    )
    SET(METAL_DELEGATE_PATH ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/)
 
-   foreach(lib_name ${CC_SRCS})
-     set_source_files_properties(${METAL_DELEGATE_PATH}${lib_name}.cc  PROPERTIES LANGUAGE OBJCXX)
-     add_library("${lib_name}" STATIC ${METAL_DELEGATE_PATH}${lib_name}.cc)
-     target_include_directories("${lib_name}" PUBLIC
-       ${CMAKE_BINARY_DIR}/abseil-cpp
-       ${CMAKE_BINARY_DIR}/flatbuffers/include
-     )
-     set_target_properties(${lib_name} PROPERTIES LINKER_LANGUAGE OBJCXX)
-     target_link_libraries(${lib_name})
-   endforeach()
-
    list(APPEND MM_SRCS
+     buffer
      buffer_convert
      common
+     compute_task
+     inference_context
+     metal_arguments
+     metal_device
+     metal_spatial_tensor
    )
    foreach(lib_name ${MM_SRCS})
      add_library("${lib_name}" STATIC ${METAL_DELEGATE_PATH}${lib_name}.mm)

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -466,29 +466,6 @@ if(TFLITE_ENABLE_GPU)
         DEPENDS ${METAL_GENERATED_DIR}/inference_context_generated.h
     )
     add_dependencies(metal_delegate inference_context_cc_fbs)
-    #
-    # supplementary libraries for libmetal_delegate
-    #
-   SET(METAL_DELEGATE_PATH ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/)
-
-   list(APPEND MM_SRCS
-     buffer
-     buffer_convert
-     common
-     compute_task
-     inference_context
-     metal_arguments
-     metal_device
-     metal_spatial_tensor
-   )
-   foreach(lib_name ${MM_SRCS})
-     add_library("${lib_name}" STATIC ${METAL_DELEGATE_PATH}${lib_name}.mm)
-     target_include_directories("${lib_name}" PUBLIC
-       ${CMAKE_BINARY_DIR}/abseil-cpp
-       ${CMAKE_BINARY_DIR}/flatbuffers/include
-     )
-     target_link_libraries(${lib_name})
-   endforeach()
 endif()
   list(APPEND TFLITE_TARGET_PUBLIC_OPTIONS "-DCL_DELEGATE_NO_GL" "-DEGL_NO_X11")
   list(APPEND TFLITE_TARGET_DEPENDENCIES

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -440,6 +440,7 @@ if(TFLITE_ENABLE_GPU)
       ${CMAKE_BINARY_DIR}/abseil-cpp
       ${CMAKE_BINARY_DIR}/flatbuffers/include
       PRIVATE ${TENSORFLOW_SOURCE_DIR}
+      PRIVATE ${PROJECT_BINARY_DIR}
     )
     #
     # generate flatbuffers header for inference_context
@@ -449,16 +450,20 @@ if(TFLITE_ENABLE_GPU)
     else()
       set(FLATC flatc)
     endif()
+    set(METAL_GENERATED_DIR ${PROJECT_BINARY_DIR}/tensorflow/lite/delegates/gpu/metal)
     add_custom_command(
-        OUTPUT ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/inference_context_generated.h
+        OUTPUT ${METAL_GENERATED_DIR}/inference_context_generated.h
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${METAL_GENERATED_DIR}
         COMMAND ${FLATC} --scoped-enums
         -I ${TENSORFLOW_SOURCE_DIR}
-        -o ${TFLITE_SOURCE_DIR}/delegates/gpu/metal
+        -o ${METAL_GENERATED_DIR}
         -c ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/inference_context.fbs
+        DEPENDS ${FLATC_TARGET}
+                ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/inference_context.fbs
     )
     add_custom_target(
         inference_context_cc_fbs
-        DEPENDS ${TFLITE_SOURCE_DIR}/delegates/gpu/metal/inference_context_generated.h
+        DEPENDS ${METAL_GENERATED_DIR}/inference_context_generated.h
     )
     add_dependencies(metal_delegate inference_context_cc_fbs)
     #


### PR DESCRIPTION
Hi I was trying to build metal delegates for TensorFlow Lite and I found that `-DTFLITE_ENABLE_METAL=ON` does not configure on master.

And after digging into the sources, it appears that the Metal delegate's sources were renamed from `.cc` to `.mm` in 3f37462, which updated the Bazel `BUILD` file but not `tensorflow/lite/CMakeLists.txt`:

```
CMake Error at CMakeLists.txt:436 (add_library):
  Cannot find source file:
    .../delegates/gpu/metal/buffer.cc
  ... (compute_task, inference_context, metal_arguments,
       metal_device, metal_spatial_tensor)

CMake Error at CMakeLists.txt:436 (add_library):
  No SOURCES given to target: metal_delegate
```

The first commit points CMake at the `.mm` files. The `CC_SRCS` loop also set `LANGUAGE OBJCXX` and `LINKER_LANGUAGE OBJCXX`, which is exactly what that rename removed the need for, so those six entries move into the existing `MM_SRCS` list and the loop goes away.

The second commit fixes the `inference_context` flatbuffers rule sitting right next to it: it had no `DEPENDS`, so nothing ordered it against `flatc` being built, and it wrote its generated header into the source tree rather than the build tree. The XNNPACK rule about 90 lines below already does both correctly, so this just makes the Metal one match.