### PR TITLE
Make TfLiteGpuDelegateV2Delete and TFLGpuDelegateDelete accept nullptr

### DIFF
--- a/tensorflow/lite/delegates/gpu/BUILD
+++ b/tensorflow/lite/delegates/gpu/BUILD
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework", "ios_unit_test")
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_dylib")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
@@ -25,7 +25,12 @@ load(
     "tf_gpu_tests_tags",
 )
 load("//tensorflow/lite:build_def.bzl", "CXX17_BAZEL_ONLY_COPTS", "tflite_pagesize_linkopts")
-load("//tensorflow/lite:special_rules.bzl", "tflite_extra_gles_deps", "tflite_portable_test_suite")
+load(
+    "//tensorflow/lite:special_rules.bzl",
+    "tflite_extra_gles_deps",
+    "tflite_ios_lab_runner",
+    "tflite_portable_test_suite",
+)
 load("//tensorflow/lite/delegates/gpu:build_defs.bzl", "gpu_delegate_linkopts")
 
 package(
@@ -202,6 +207,27 @@ objc_library(
 )
 
 objc_library(
+    name = "metal_delegate_test_lib",
+    testonly = 1,
+    srcs = ["metal_delegate_test.mm"],
+    copts = CXX17_BAZEL_ONLY_COPTS,
+    sdk_frameworks = ["XCTest"],
+    deps = [":metal_delegate"],
+)
+
+ios_unit_test(
+    name = "metal_delegate_test",
+    testonly = 1,
+    minimum_os_version = "12.0",
+    runner = tflite_ios_lab_runner("IOS_LATEST"),
+    tags = tf_gpu_tests_tags() + [
+        "notap",
+        "tflite_not_portable_android",
+    ],
+    deps = [":metal_delegate_test_lib"],
+)
+
+objc_library(
     name = "metal_delegate_internal",
     hdrs = ["metal_delegate_internal.h"],
     copts = CXX17_BAZEL_ONLY_COPTS,
@@ -358,6 +384,15 @@ cc_library(
             "//tensorflow/lite/delegates/gpu/gl:api2",
         ],
     }) + _DELEGATE_NO_GL_DEPS + ["//tensorflow/lite/delegates/gpu/cl:api"],
+)
+
+cc_test(
+    name = "delegate_test",
+    srcs = ["delegate_test.cc"],
+    deps = [
+        ":delegate",
+        "@com_google_googletest//:gtest_main",
+    ],
 )
 
 cc_library(

--- a/tensorflow/lite/delegates/gpu/BUILD
+++ b/tensorflow/lite/delegates/gpu/BUILD
@@ -389,6 +389,7 @@ cc_library(
 cc_test(
     name = "delegate_test",
     srcs = ["delegate_test.cc"],
+    tags = tf_gpu_tests_tags() + ["tflite_not_portable_ios"],
     deps = [
         ":delegate",
         "@com_google_googletest//:gtest_main",

--- a/tensorflow/lite/delegates/gpu/delegate.cc
+++ b/tensorflow/lite/delegates/gpu/delegate.cc
@@ -1597,6 +1597,7 @@ TfLiteDelegate* TfLiteGpuDelegateV2CreateAsync(
 #endif  // defined(__ANDROID__)
 
 void TfLiteGpuDelegateV2Delete(TfLiteDelegate* delegate) {
+  if (delegate == nullptr) return;
   delete tflite::gpu::GetDelegate(delegate);
 }
 

--- a/tensorflow/lite/delegates/gpu/delegate_test.cc
+++ b/tensorflow/lite/delegates/gpu/delegate_test.cc
@@ -1,0 +1,26 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/delegates/gpu/delegate.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// The external delegate interface requires destroying a null delegate to be
+// allowed and to have no effect. The test passes by not crashing.
+TEST(TfLiteGpuDelegateV2, DeleteWithNull) { TfLiteGpuDelegateV2Delete(nullptr); }
+
+}  // namespace

--- a/tensorflow/lite/delegates/gpu/metal_delegate.mm
+++ b/tensorflow/lite/delegates/gpu/metal_delegate.mm
@@ -722,6 +722,7 @@ TfLiteDelegate* TFLGpuDelegateCreate(const TFLGpuDelegateOptions* options) {
 }
 
 void TFLGpuDelegateDelete(TfLiteDelegate* delegate) {
+  if (delegate == nullptr) return;
   delete ::tflite::gpu::metal::GetMetalDelegate(delegate);
 }
 

--- a/tensorflow/lite/delegates/gpu/metal_delegate_test.mm
+++ b/tensorflow/lite/delegates/gpu/metal_delegate_test.mm
@@ -1,0 +1,31 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/delegates/gpu/metal_delegate.h"
+
+#import <XCTest/XCTest.h>
+
+@interface MetalDelegateTest : XCTestCase
+@end
+
+@implementation MetalDelegateTest
+
+// The external delegate interface requires destroying a null delegate to be
+// allowed and to have no effect. The test passes by not crashing.
+- (void)testDeleteWithNull {
+  TFLGpuDelegateDelete(nullptr);
+}
+
+@end


### PR DESCRIPTION
When I was playing around with my GPU delegate plugin, I found that `tflite_plugin_destroy_delegate(nullptr)` can segfault for both GPU delegates.

`tensorflow/lite/delegates/external/external_delegate_interface.h` says:

https://github.com/tensorflow/tensorflow/blob/eb1d7f7691d90817a1020b0bb9e0f8f680750000/tensorflow/lite/delegates/external/external_delegate_interface.h#L70-L73

And both GPU implementations dereference `delegate->data_` without checking, so if a `nullptr` is passed to `TFLGpuDelegateDelete`:

```cpp
#include "tensorflow/lite/delegates/gpu/metal_delegate.h"
int main() { TFLGpuDelegateDelete(nullptr); }
```

It will segfault.

```
$ ./repro
about to call TFLGpuDelegateDelete(nullptr)
[1]    segmentation fault  ./repro
```

`TfLiteGpuDelegateV2Delete` behaves the same way via `tflite::gpu::GetDelegate`.

This is reachable in normal use: both `TfLiteGpuDelegateV2Create` and `TFLGpuDelegateCreate` end in `... ? ...->tflite_delegate() : nullptr`, and `CreateDelegate` in `core/acceleration/configuration/c/gpu_plugin.cc` returns `nullptr` outright on platforms with neither GPU backend. The `DestroyDelegate` next to it then calls straight into `TfLiteGpuDelegateV2Delete` with no check of its own.

Two other delegates in the tree already do this: `TfLiteXNNPackDelegateDelete` opens with `if (delegate != nullptr)`, and `TfLiteDelegateFactory::DeleteSimpleDelegate` with `if (!delegate) return;`.

This is probably the better way than deleting the line claiming that *Calling this with nullptr as the argument value is allowed and has no effect* from `external_delegate_interface.h`