### PR TITLE
Reject scalar inputs to the tf.image RGB/YIQ/YUV conversions

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -184,6 +184,30 @@ def _Assert3DImage(image):
       _Check3DImage(image, require_static=False), image)
 
 
+def _AssertAtLeast1DImage(image):
+  """Assert that `image` has a channel dimension.
+
+  The RGB/YIQ/YUV conversions contract the last dimension of `image` against a
+  3-element kernel. A scalar has no such dimension, and without this check the
+  failure surfaces as an `IndexError` from inside `tensordot`.
+
+  Args:
+    image: >= 1-D Tensor of size [*, 3]
+
+  Raises:
+    ValueError: if the rank of `image` is known and is less than one.
+
+  Returns:
+    `image`, unchanged.
+  """
+  try:
+    image.get_shape().with_rank_at_least(1)
+  except ValueError:
+    raise ValueError("'images' (shape %s) must be at least one-dimensional." %
+                     image.shape)
+  return image
+
+
 def _AssertAtLeast3DImage(image):
   """Assert that we are working with a properly shaped image.
 
@@ -2591,6 +2615,7 @@ def rgb_to_grayscale(images, name=None):
   """
   with ops.name_scope(name, 'rgb_to_grayscale', [images]) as name:
     images = ops.convert_to_tensor(images, name='images')
+    images = _AssertAtLeast1DImage(images)
     # Remember original dtype to so we can convert back if needed
     orig_dtype = images.dtype
     flt_image = convert_image_dtype(images, dtypes.float32)
@@ -4029,6 +4054,7 @@ def rgb_to_yiq(images):
     images: tensor with the same shape as `images`.
   """
   images = ops.convert_to_tensor(images, name='images')
+  images = _AssertAtLeast1DImage(images)
   kernel = ops.convert_to_tensor(
       _rgb_to_yiq_kernel, dtype=images.dtype, name='kernel')
   ndims = images.get_shape().ndims
@@ -4057,6 +4083,7 @@ def yiq_to_rgb(images):
     images: tensor with the same shape as `images`.
   """
   images = ops.convert_to_tensor(images, name='images')
+  images = _AssertAtLeast1DImage(images)
   kernel = ops.convert_to_tensor(
       _yiq_to_rgb_kernel, dtype=images.dtype, name='kernel')
   ndims = images.get_shape().ndims
@@ -4088,6 +4115,7 @@ def rgb_to_yuv(images):
     images: tensor with the same shape as `images`.
   """
   images = ops.convert_to_tensor(images, name='images')
+  images = _AssertAtLeast1DImage(images)
   kernel = ops.convert_to_tensor(
       _rgb_to_yuv_kernel, dtype=images.dtype, name='kernel')
   ndims = images.get_shape().ndims
@@ -4141,6 +4169,7 @@ def yuv_to_rgb(images):
     images: tensor with the same shape as `images`.
   """
   images = ops.convert_to_tensor(images, name='images')
+  images = _AssertAtLeast1DImage(images)
   kernel = ops.convert_to_tensor(
       _yuv_to_rgb_kernel, dtype=images.dtype, name='kernel')
   ndims = images.get_shape().ndims

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -143,6 +143,15 @@ class RGBToYIQTest(test_util.TensorFlowTestCase):
       self.assertAllClose(batch2, inp, rtol=1e-4, atol=1e-4)
 
 
+  def testRejectsScalar(self):
+    # A scalar has no channel dimension to convert. Without a check this fails
+    # with an IndexError from inside tensordot.
+    err_msg = "must be at least one-dimensional"
+    for fn in [image_ops.rgb_to_yiq, image_ops.yiq_to_rgb]:
+      with self.assertRaisesRegex(ValueError, err_msg):
+        fn(constant_op.constant(2.0))
+
+
 class RGBToYUVTest(test_util.TensorFlowTestCase):
 
   @test_util.run_without_tensor_float_32(
@@ -173,6 +182,13 @@ class RGBToYUVTest(test_util.TensorFlowTestCase):
       self.assertAllClose(batch1, join1, rtol=1e-4, atol=1e-4)
       self.assertAllClose(batch2, join2, rtol=1e-4, atol=1e-4)
       self.assertAllClose(batch2, inp, rtol=1e-4, atol=1e-4)
+
+
+  def testRejectsScalar(self):
+    err_msg = "must be at least one-dimensional"
+    for fn in [image_ops.rgb_to_yuv, image_ops.yuv_to_rgb]:
+      with self.assertRaisesRegex(ValueError, err_msg):
+        fn(constant_op.constant(2.0))
 
 
 class GrayscaleToRGBTest(test_util.TensorFlowTestCase):
@@ -268,6 +284,11 @@ class GrayscaleToRGBTest(test_util.TensorFlowTestCase):
       err_msg = "must be at least two-dimensional"
       with self.assertRaisesRegex(ValueError, err_msg):
         image_ops.grayscale_to_rgb(x_tf)
+
+  def testRGBToGrayscaleRejectsScalar(self):
+    err_msg = "must be at least one-dimensional"
+    with self.assertRaisesRegex(ValueError, err_msg):
+      image_ops.rgb_to_grayscale(constant_op.constant(2.0))
 
   def testShapeInference(self):
     # Shape function requires placeholders and a graph.


### PR DESCRIPTION
Five of the colour conversions in `tf.image` fail with an `IndexError` when handed a scalar:

```python
>>> tf.image.rgb_to_grayscale(tf.constant(2.0))
IndexError: list index out of range
```

The same for `rgb_to_yiq`, `yiq_to_rgb`, `rgb_to_yuv` and `yuv_to_rgb`. It's not an informative failure — the error names no argument and points at a list index, and the traceback ends inside `tensordot`, several frames below anything the caller wrote.

They all contract the last dimension of the argument against a 3-element kernel:

```python
ndims = images.get_shape().ndims
return math_ops.tensordot(images, kernel, axes=[[ndims - 1], [0]])
```

With a scalar, `ndims` is 0, so the axis index is `-1` on a rank-0 tensor and `tensordot` indexes past the end of a shape list. `rgb_to_grayscale` reaches the same place via `tensordot(flt_image, rgb_weights, [-1, -1])`.

`grayscale_to_rgb`, immediately below them in the same file, already validates its argument and says something useful:

```
ValueError: A grayscale image (shape ()) must be at least two-dimensional.
```

so this adds the equivalent check for the other five, in the same shape and with a matching message:

```
ValueError: 'images' (shape ()) must be at least one-dimensional.
```

### On the check being static only

`_AssertAtLeast1DImage` only looks at the static shape and returns the tensor unchanged. It deliberately does not follow `_AssertGrayscaleImage` in adding runtime assert ops via `control_flow_ops.with_dependencies`.

Two reasons. These are hot preprocessing ops and I didn't want to put extra ops in everyone's graph to catch a case that is a programming error rather than a data-dependent one. And rank is nearly always known statically even when the dimensions are not, so a static check catches this in practice without touching the dynamic path.

The consequence is that an unknown *rank* is still accepted, which is what `GrayscaleToRGBTest.testShapeInference` already asserts for `rgb_to_grayscale` (it feeds a placeholder with no shape at all and expects no error). That test still passes.

### Testing

`testRejectsScalar` on `RGBToYIQTest` and `RGBToYUVTest`, and `testRGBToGrayscaleRejectsScalar` on `GrayscaleToRGBTest`. All three fail on master with the `IndexError` above.

Running `RGBToYIQTest`, `RGBToYUVTest`, `GrayscaleToRGBTest` and `AdjustGamma` together against an installed TF 2.21 with this change applied: 3 failures before, 0 after, 24 tests, nothing that passed before failing now. I don't have a Bazel build here, so that is a wheel with the same edit rather than a real build of this branch.

I checked that valid inputs are unaffected: 3-D and 4-D images convert as before, and a rank-1 `[r, g, b]` still works, since one dimension is all these need.
