### PR TITLE
fix: validate minimum input rank in convolution_internal to prevent crash on invalid shapes

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
@@ -247,6 +247,12 @@ class AtrousDepthwiseConv2DTest(test.TestCase):
                 y2 = nn_impl.depthwise_conv2d(x, f_up, strides, padding)
                 self.assertAllClose(y1, y2, rtol=1e-3, atol=1e-3)
 
+  def testInvalidInputRank(self):
+    value = array_ops.zeros([10], dtype=dtypes.float32)
+    filters = array_ops.zeros([5, 5, 1, 8], dtype=dtypes.float32)
+    with self.assertRaisesRegex(ValueError, "rank at least 3"):
+      nn_ops.atrous_conv2d(value, filters, rate=1, padding="VALID")
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/nn_ops/atrous_convolution_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/atrous_convolution_test.py
@@ -272,6 +272,12 @@ class AtrousConvolutionTest(test.TestCase):
                 dilation_rate=[rate_height, rate_width],
                 padding=padding)
 
+  def testInvalidInputRank(self):
+    value = array_ops.zeros([10], dtype=dtypes.float32)
+    filters = array_ops.zeros([5, 5, 1, 8], dtype=dtypes.float32)
+    with self.assertRaisesRegex(ValueError, "rank at least 3"):
+      nn_ops.convolution(value, filters, padding="VALID")
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1263,15 +1263,20 @@ def convolution_internal(
         f"filters.shape={filters.shape} of rank {filters_rank} and "
         f"num_spatial_dims={num_spatial_dims}")
 
-  if inputs_rank:
-    num_batch_dims = inputs_rank - num_spatial_dims - 1  # Channel dimension.
-  else:
-    num_batch_dims = 1  # By default, assume single batch dimension.
-
   if num_spatial_dims not in {1, 2, 3}:
     raise ValueError(
         "`num_spatial_dims` must be 1, 2, or 3. "
         f"Received: num_spatial_dims={num_spatial_dims}.")
+
+  if inputs_rank is not None:
+    num_batch_dims = inputs_rank - num_spatial_dims - 1  # Channel dimension.
+    if num_batch_dims < 0:
+      raise ValueError(
+          f"`input` must have rank at least {num_spatial_dims + 1} "
+          f"({num_spatial_dims} spatial dimensions + 1 channel dimension). "
+          f"Received: input.shape={input.shape} of rank {inputs_rank}")
+  else:
+    num_batch_dims = 1  # By default, assume single batch dimension.
 
   if data_format is None or data_format in _CHANNELS_LAST_FORMATS:
     channel_index = num_batch_dims + num_spatial_dims


### PR DESCRIPTION
When calling `tf.nn.atrous_conv2d` or `tf.nn.convolution` with an invalid input tensor rank (for example, a rank-1 or rank-2 tensor when performing 2D convolution with rank-4 filters), execution on CPU triggers a fatal check failure abort:

```
Check failed: index >= 0 && index < num_total_dims Invalid index from the dimension: 3, 0, C
*** Check failure stack trace: ***
Aborted (core dumped)
```

### Root cause

In `tensorflow/python/ops/nn_ops.py:convolution_internal`, `num_spatial_dims` is computed from `filters.shape.rank - 2` (e.g. `4 - 2 = 2` for 2D convolution). The number of batch dimensions was calculated as `num_batch_dims = inputs_rank - num_spatial_dims - 1`.

When `inputs_rank < num_spatial_dims + 1` (e.g. `inputs_rank = 1` for a 1D input to 2D convolution), `num_batch_dims` became negative (`1 - 2 - 1 = -2`), leading to an invalid `channel_index = num_batch_dims + num_spatial_dims = 0`. This caused `_get_sequence` to construct malformed stride/dilation sequences and passed invalid shapes to the C++ kernel where an internal dimension check failure terminated the process on CPU. Additionally, when `inputs_rank == 0` (scalar), `if inputs_rank:` evaluated to `False` and incorrectly fell back to `num_batch_dims = 1`.

### Fix

In `convolution_internal`, when `inputs_rank is not None`, validate that `num_batch_dims = inputs_rank - num_spatial_dims - 1 >= 0`. If `inputs_rank < num_spatial_dims + 1`, raise a descriptive `ValueError` indicating that the input must have rank at least `num_spatial_dims + 1` (spatial dimensions + channel dimension), preventing malformed parameters from reaching the underlying kernels.

### Testing

- Added `testInvalidInputRank` in `tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py`.
- Added `testInvalidInputRank` in `tensorflow/python/kernel_tests/nn_ops/atrous_convolution_test.py`.
- Verified syntax with `python3 -m py_compile`.

Fixes #125510.