### PR TITLE
fix: validate filter and out_backprop dimensions in Conv2DBackpropInput to prevent crash on invalid rank

### DIFF
--- a/tensorflow/core/kernels/conv_grad_input_ops.h
+++ b/tensorflow/core/kernels/conv_grad_input_ops.h
@@ -356,7 +356,11 @@ class Conv2DBackpropInputOp : public OpKernel {
     OP_REQUIRES(
         context, out_backprop.dims() == 4,
         absl::InvalidArgumentError(absl::StrCat(
-            "input_sizes must be 4-dimensional, got: ", out_backprop.dims())));
+            "out_backprop must be 4-dimensional, got: ", out_backprop.dims())));
+    OP_REQUIRES(
+        context, filter.dims() == 4,
+        absl::InvalidArgumentError(absl::StrCat(
+            "filter must be 4-dimensional, got: ", filter.dims())));
 
     TensorShape input_shape;
     OP_REQUIRES_OK(context,
@@ -468,7 +472,11 @@ class Conv2DCustomBackpropInputOp : public OpKernel {
     OP_REQUIRES(
         context, out_backprop.dims() == 4,
         absl::InvalidArgumentError(absl::StrCat(
-            "input_sizes must be 4-dimensional, got: ", out_backprop.dims())));
+            "out_backprop must be 4-dimensional, got: ", out_backprop.dims())));
+    OP_REQUIRES(
+        context, filter.dims() == 4,
+        absl::InvalidArgumentError(absl::StrCat(
+            "filter must be 4-dimensional, got: ", filter.dims())));
 
     TensorShape input_shape;
     OP_REQUIRES_OK(context,

--- a/tensorflow/core/kernels/conv_grad_shape_utils.cc
+++ b/tensorflow/core/kernels/conv_grad_shape_utils.cc
@@ -174,6 +174,17 @@ absl::Status Conv2DBackpropComputeInputShape(
     const Tensor& input_sizes, const TensorShape& filter_shape,
     const TensorShape& out_backprop_shape, const TensorFormat& data_format,
     TensorShape* input_shape) {
+  if (filter_shape.dims() != 4) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Conv2DBackpropInput: filter must be 4-dimensional, not ",
+        filter_shape.dims()));
+  }
+  if (out_backprop_shape.dims() != 4) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Conv2DBackpropInput: out_backprop must be 4-dimensional, not ",
+        out_backprop_shape.dims()));
+  }
+
   if (!TensorShapeUtils::IsVector(input_sizes.shape())) {
     return absl::InvalidArgumentError(absl::StrCat(
         "Conv2DBackpropInput: input_sizes input must be 1-dim, not ",

--- a/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
@@ -332,5 +332,27 @@ class Conv2DTransposeTest(test.TestCase):
             filters=[[[[1]]]])
         self.evaluate(op)
 
+  def testConv2DTransposeInvalidFilterRank(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = nn_ops.conv2d_transpose(
+            input=constant_op.constant(1.0, shape=[1, 3, 3, 8]),
+            filters=8,
+            output_shape=(2, 2),
+            strides=(2, 2),
+            padding="SAME")
+        self.evaluate(op)
+
+  def testConv2DTransposeInvalidOutputShapeRank(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = nn_ops.conv2d_transpose(
+            input=constant_op.constant(1.0, shape=[1, 4, 4, 3]),
+            filters=constant_op.constant(1.0, shape=[3, 3, 3, 3]),
+            output_shape=(2, 4, 2),
+            strides=[1, 2, 2, 1],
+            padding="SAME")
+        self.evaluate(op)
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2754,6 +2754,11 @@ def conv2d_transpose_v2(
       data_format = "NHWC"
     channel_index = 1 if data_format.startswith("NC") else 3
 
+    filters = ops.convert_to_tensor(filters, name="filters")
+    if filters.shape.rank is not None and filters.shape.rank != 4:
+      raise ValueError(f"`filters` must be 4-dimensional. "
+                       f"Received: filters with shape {filters.shape}")
+
     strides = _get_sequence(strides, 2, channel_index, "strides")
     dilations = _get_sequence(dilations, 2, channel_index, "dilations")
     padding, explicit_paddings = convert_padding(padding)


### PR DESCRIPTION
Fixes #125506

### Summary of Changes

1. **Root Cause**:
   - In `tensorflow/core/kernels/conv_grad_input_ops.h`, `Conv2DBackpropInputOp::Compute` and `Conv2DCustomBackpropInputOp::Compute` checked `out_backprop.dims() == 4` (with a typo mentioning `input_sizes`), but did not validate `filter.dims() == 4`.
   - When a scalar or invalid rank filter (such as `filters=8`) was passed to `tf.nn.conv2d_transpose` or `tf.raw_ops.Conv2DBackpropInput`, querying `filter_shape.dim_size(2)` or `filter_shape.dim_size(3)` in `Conv2DBackpropComputeInputShape` (`tensorflow/core/kernels/conv_grad_shape_utils.cc`) and `Compute` triggered a fatal check failure abort (`Check failed: d < dims() (2 vs. 0)`).
   - Furthermore, `Conv2DBackpropComputeInputShape` lacked validation that `filter_shape` and `out_backprop_shape` were 4-dimensional when `input_sizes` contained 2 spatial dimensions before indexing `filter_shape.dim_size(2)`.

2. **Fix**:
   - Added explicit `OP_REQUIRES(context, filter.dims() == 4, ...)` validation in `Conv2DBackpropInputOp::Compute` and `Conv2DCustomBackpropInputOp::Compute` (`conv_grad_input_ops.h`).
   - Corrected the diagnostic string on `out_backprop` dimension validation to state `out_backprop must be 4-dimensional`.
   - Added shape dimension validation in `Conv2DBackpropComputeInputShape` (`conv_grad_shape_utils.cc`) ensuring `filter_shape` and `out_backprop_shape` have rank 4 before indexing depth dimensions when `input_sizes.dim_size(0) == 2`.
   - Added rank validation on `filters` in `conv2d_transpose_v2` (`tensorflow/python/ops/nn_ops.py`), raising a clear `ValueError` when non-4D filters are passed.
   - Added unit tests `testConv2DTransposeInvalidFilterRank` and `testConv2DTransposeInvalidOutputShapeRank` in `tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py`.

### Validation

- Verified rank validation logic and error raising in unit tests.