### PR TITLE
Fix min_input rank 1 to rank 0 for MKL quantized conv tests

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
@@ -1233,22 +1233,22 @@ class BiasCacheTest : public OpsTestBase {
     Tensor bias(DT_FLOAT, {kFilterCount});
     test::FillValues<float>(&bias, {1});
 
-    Tensor min_input(DT_FLOAT, {1});
+    Tensor min_input(DT_FLOAT, {});
     test::FillValues<float>(&min_input, {1});
 
-    Tensor max_input(DT_FLOAT, {1});
+    Tensor max_input(DT_FLOAT, {});
     test::FillValues<float>(&max_input, {1});
 
-    Tensor min_filter(DT_FLOAT, {1});
+    Tensor min_filter(DT_FLOAT, {});
     test::FillValues<float>(&min_filter, {1});
 
-    Tensor max_filter(DT_FLOAT, {1});
+    Tensor max_filter(DT_FLOAT, {});
     test::FillValues<float>(&max_filter, {1});
 
-    Tensor min_output(DT_FLOAT, {1});
+    Tensor min_output(DT_FLOAT, {});
     test::FillValues<float>(&min_output, {1});
 
-    Tensor max_output(DT_FLOAT, {1});
+    Tensor max_output(DT_FLOAT, {});
     test::FillValues<float>(&max_output, {1});
 
     Tensor expected(DT_QUINT8, TensorShape({1, 1, 2, 1}));

--- a/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
@@ -1233,22 +1233,22 @@ class BiasCacheTest : public OpsTestBase {
     Tensor bias(DT_FLOAT, {kFilterCount});
     test::FillValues<float>(&bias, {1});
 
-    Tensor min_input(DT_FLOAT, {});
+    Tensor min_input(DT_FLOAT, TensorShape({}));
     test::FillValues<float>(&min_input, {1});
 
-    Tensor max_input(DT_FLOAT, {});
+    Tensor max_input(DT_FLOAT, TensorShape({}));
     test::FillValues<float>(&max_input, {1});
 
-    Tensor min_filter(DT_FLOAT, {});
+    Tensor min_filter(DT_FLOAT, TensorShape({}));
     test::FillValues<float>(&min_filter, {1});
 
-    Tensor max_filter(DT_FLOAT, {});
+    Tensor max_filter(DT_FLOAT, TensorShape({}));
     test::FillValues<float>(&max_filter, {1});
 
-    Tensor min_output(DT_FLOAT, {});
+    Tensor min_output(DT_FLOAT, TensorShape({}));
     test::FillValues<float>(&min_output, {1});
 
-    Tensor max_output(DT_FLOAT, {});
+    Tensor max_output(DT_FLOAT, TensorShape({}));
     test::FillValues<float>(&max_output, {1});
 
     Tensor expected(DT_QUINT8, TensorShape({1, 1, 2, 1}));

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_perchannel_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_perchannel_test.cc
@@ -129,8 +129,8 @@ class QuantizedConv2DPerChannelTest : public OpsTestBase {
                               image_quantized.flat<quint8>());
     AddInputFromArray<qint8>(filter_quantized.shape(),
                              filter_quantized.flat<qint8>());
-    AddInputFromArray<float>(TensorShape({1}), {image_min});
-    AddInputFromArray<float>(TensorShape({1}), {image_max});
+    AddInputFromArray<float>(TensorShape({}), {image_min});
+    AddInputFromArray<float>(TensorShape({}), {image_max});
     AddInputFromArray<float>(TensorShape({2}), {filter_min, filter_min});
     AddInputFromArray<float>(TensorShape({2}), {filter_max, filter_max});
 


### PR DESCRIPTION


This PR fixes the `min_input` tensor shape in the MKL quantized convolution tests (`mkl_fused_ops_test.cc` and `mkl_quantized_conv_ops_perchannel_test.cc`), changing its rank from 1 to 0 to align with the expected scalar shape.

### Motivation and Context
This is part 3 of decoupling the original monolithic PR #112118 into smaller, atomic pull requests to address reviewer feedback and ensure safe, isolated testing.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
