### PR TITLE
Reject scalar inputs to tf.signal.dct and idct

### DIFF
--- a/tensorflow/python/kernel_tests/signal/dct_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/dct_ops_test.py
@@ -219,6 +219,13 @@ class DCTOpsTest(parameterized.TestCase, test.TestCase):
 
   def test_error(self):
     signals = np.random.rand(10)
+    # A scalar has no dimension to transform. Every type, and idct, used to
+    # fail with an IndexError from tensor_shape here.
+    for dct_type in (1, 2, 3, 4):
+      with self.assertRaises(ValueError):
+        dct_ops.dct(np.float32(2.0), type=dct_type)
+      with self.assertRaises(ValueError):
+        dct_ops.idct(np.float32(2.0), type=dct_type)
     # Unsupported type.
     with self.assertRaises(ValueError):
       dct_ops.dct(signals, type=5)

--- a/tensorflow/python/kernel_tests/signal/dct_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/dct_ops_test.py
@@ -21,6 +21,7 @@ from absl.testing import parameterized
 import numpy as np
 
 from tensorflow.python.eager import def_function
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops.signal import dct_ops
@@ -220,12 +221,14 @@ class DCTOpsTest(parameterized.TestCase, test.TestCase):
   def test_error(self):
     signals = np.random.rand(10)
     # A scalar has no dimension to transform. Every type, and idct, used to
-    # fail with an IndexError from tensor_shape here.
+    # fail with an IndexError from tensor_shape here, whether the scalar
+    # arrived as a Python float, a numpy value or a tensor.
     for dct_type in (1, 2, 3, 4):
-      with self.assertRaises(ValueError):
-        dct_ops.dct(np.float32(2.0), type=dct_type)
-      with self.assertRaises(ValueError):
-        dct_ops.idct(np.float32(2.0), type=dct_type)
+      for scalar in (2.0, np.float32(2.0), constant_op.constant(2.0)):
+        with self.assertRaises(ValueError):
+          dct_ops.dct(scalar, type=dct_type)
+        with self.assertRaises(ValueError):
+          dct_ops.idct(scalar, type=dct_type)
     # Unsupported type.
     with self.assertRaises(ValueError):
       dct_ops.dct(signals, type=5)

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -34,7 +34,8 @@ def _validate_dct_arguments(input_tensor, dct_type, n, axis, norm):
   # transform. Without this check the shape lookups, here and in the transform
   # itself, fail with an IndexError from tensor_shape instead of reporting
   # anything the caller can act on.
-  if _np.ndim(input_tensor) == 0:
+  input_tensor = _ops.convert_to_tensor(input_tensor)
+  if input_tensor.shape.ndims == 0:
     raise ValueError("Input must have rank at least 1. Got a scalar.")
   if axis != -1:
     raise NotImplementedError("axis must be -1. Got: %s" % axis)

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -15,6 +15,8 @@
 """Discrete Cosine Transform ops."""
 import math as _math
 
+import numpy as _np
+
 from tensorflow.python.framework import dtypes as _dtypes
 from tensorflow.python.framework import ops as _ops
 from tensorflow.python.framework import smart_cond
@@ -28,6 +30,12 @@ from tensorflow.python.util.tf_export import tf_export
 
 def _validate_dct_arguments(input_tensor, dct_type, n, axis, norm):
   """Checks that DCT/IDCT arguments are compatible and well formed."""
+  # The transform runs over the last dimension, so a scalar has nothing to
+  # transform. Without this check the shape lookups, here and in the transform
+  # itself, fail with an IndexError from tensor_shape instead of reporting
+  # anything the caller can act on.
+  if _np.ndim(input_tensor) == 0:
+    raise ValueError("Input must have rank at least 1. Got a scalar.")
   if axis != -1:
     raise NotImplementedError("axis must be -1. Got: %s" % axis)
   if n is not None and n < 1:

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -15,8 +15,6 @@
 """Discrete Cosine Transform ops."""
 import math as _math
 
-import numpy as _np
-
 from tensorflow.python.framework import dtypes as _dtypes
 from tensorflow.python.framework import ops as _ops
 from tensorflow.python.framework import smart_cond


### PR DESCRIPTION
`tf.signal.dct` and `tf.signal.idct` fail with an `IndexError` from TensorFlow's own shape machinery when given a scalar:

```python
>>> tf.signal.dct(tf.constant(2.0))
IndexError: tuple index out of range
```

with the traceback ending in `tensor_shape.py`, several frames below anything the caller wrote, and naming neither the argument nor the actual problem. All four DCT types do it, and `idct` with them.

The transform runs over the last dimension and nothing checks that there is one, so a rank-0 input reaches `input.shape[-1]` and indexes off the end.

`_validate_dct_arguments` is already where this family of problem is reported, and already raises `ValueError` with a readable message for an unsupported type, a bad `n`, or an unknown normalization. This adds the missing rank check there, ahead of the type-I branch that reads `input_tensor.shape[-1]` and would otherwise hit the same `IndexError` first:

```
ValueError: Input must have rank at least 1. Got a scalar.
```

### Why np.ndim

Validation runs before the input is converted, so `input_tensor` may still be a list, a numpy array or value, or a plain Python number, and `.shape` is not something that can be relied on — the existing type-I check assumes it, which is why `dct([1.0, 2.0, 3.0, 4.0], type=1)` currently raises `AttributeError: 'list' object has no attribute 'shape'`. I have not touched that here, but it is the same underlying assumption and worth a follow-up.

`np.ndim` avoids it: it reports 0 for a Python scalar, a numpy scalar and a rank-0 tensor alike, gives the rank of a symbolic tensor without forcing a conversion, and returns -1 rather than 0 when the rank is unknown, so a partially specified shape is not rejected. It is also how `array_ops.py` and `ragged_factory_ops.py` already test for a scalar argument.

### Testing

Extended `DCTOpsTest.test_error`, which is where the other argument validation is covered, with a scalar for each of the four types through both `dct` and `idct`. Those eight assertions raise `IndexError` without this change and pass with it.

Valid inputs are unaffected: 1-D, 2-D, list input and the `norm="ortho"` round trip all behave as before.

I don't have a Bazel build here, so I ran `dct_ops_test.py` against an installed TF 2.21 wheel carrying the same change. Two tests in that file fail either way and are unrelated to this: `test_error` also asserts that a Type-I DCT rejects `n=1`, and `test_idct_docstring_does_not_claim_n_must_be_none` checks docstring wording, and both of those landed upstream after 2.21, so the wheel predates them. The visible effect of this change in that run is the eight scalar assertions moving from erroring to passing.
