### PR TITLE
Fix experimental.numpy.var crash when ddof is used without dtype

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -753,7 +753,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=None):  # pylint: d
         )
       n = math_ops.cast(n - ddof, input_tensor.dtype)
 
-      return math_ops.cast(math_ops.divide(squared_deviations, n), dtype)
+      return math_ops.divide(squared_deviations, n)
 
   else:
     reduce_fn = math_ops.reduce_variance

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -856,6 +856,9 @@ class ArrayMethodsTest(test.TestCase):
     run_test([[1, 2], [3, 4]], axis=-1)
     run_test([[1, 2], [3, 4]], axis=-2)
     run_test([[1, 2], [3, 4]], axis=(0, 1))
+    run_test([1., 2., 3.], ddof=1)
+    run_test([1., 2., 3.], ddof=1, dtype=np.float64)
+    run_test([[1., 2.], [3., 4.]], axis=-1, ddof=1, keepdims=True)
     run_test(np.arange(8).reshape((2, 2, 2)).tolist(), axis=(0, 2))
     run_test(
         np.arange(8).reshape((2, 2, 2)).tolist(), axis=(0, 2), keepdims=True)


### PR DESCRIPTION
## Summary
tf.experimental.numpy.var raised TypeError (Cannot convert the argument type_value: None to a TensorFlow DType) whenever ddof was nonzero and the optional dtype argument was omitted, because the ddof code path passed dtype=None into math_ops.cast. The caller already casts the reduction result to dtype afterwards, so the broken inner cast is simply removed.

## Testing
Reproduced on a release build with tnp.var(tf.constant([1., 2., 6.]), ddof=1), which raised TypeError; after the fix it returns 7.0 matching NumPy, including explicit dtype, negative axis, keepdims and integer promotion cases. Extended testVar in np_array_ops_test.py with ddof coverage.

## Checklist
- bug reproduced before the fix
- root cause identified
- minimal fix implemented
- tests passed