### PR TITLE
Allow a Tensor buffer_size in Dataset.prefetch

### DIFF
--- a/tensorflow/python/data/kernel_tests/prefetch_test.py
+++ b/tensorflow/python/data/kernel_tests/prefetch_test.py
@@ -25,6 +25,7 @@ from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.ops import options as options_lib
 from tensorflow.python.data.ops import prefetch_op
 from tensorflow.python.framework import combinations
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.ops import script_ops
@@ -38,6 +39,18 @@ class PrefetchTest(test_base.DatasetTestBase, parameterized.TestCase):
                          combinations.combine(buffer_size=[-1, None, 0, 42])))
   def testBufferSize(self, buffer_size):
     dataset = dataset_ops.Dataset.range(10).prefetch(buffer_size=buffer_size)
+    self.assertDatasetProduces(dataset, expected_output=range(10))
+
+  @combinations.generate(test_base.default_test_combinations())
+  def testTensorBufferSize(self):
+    # `buffer_size` is documented as an int64 scalar `tf.Tensor`.
+    dataset = dataset_ops.Dataset.range(10).prefetch(
+        buffer_size=constant_op.constant(2, dtypes.int64))
+    self.assertDatasetProduces(dataset, expected_output=range(10))
+
+    # A tensor holding the AUTOTUNE value keeps autotuning enabled.
+    dataset = dataset_ops.Dataset.range(10).prefetch(
+        buffer_size=constant_op.constant(-1, dtypes.int64))
     self.assertDatasetProduces(dataset, expected_output=range(10))
 
   @combinations.generate(

--- a/tensorflow/python/data/ops/prefetch_op.py
+++ b/tensorflow/python/data/ops/prefetch_op.py
@@ -18,6 +18,7 @@ from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.ops import debug_mode
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import gen_dataset_ops
 
 
@@ -39,6 +40,13 @@ class _PrefetchDataset(dataset_ops.UnaryUnchangedStructureDataset):
     self._buffer_size = ops.convert_to_tensor(
         buffer_size, dtype=dtypes.int64, name="buffer_size")
     self._name = name
+    # `legacy_autotune` must be a Python bool, so decide from the statically
+    # known value of the converted `buffer_size`; it is None for symbolic
+    # tensors, which then use the non-legacy path.
+    buffer_size_constant = tensor_util.constant_value(self._buffer_size)
+    legacy_autotune = (
+        buffer_size_constant is not None
+        and int(buffer_size_constant) == dataset_ops.AUTOTUNE)
     # pylint: disable=protected-access
     # We colocate the prefetch dataset with its input as this collocation only
     # happens automatically in graph mode.
@@ -47,6 +55,6 @@ class _PrefetchDataset(dataset_ops.UnaryUnchangedStructureDataset):
           input_dataset._variant_tensor,
           buffer_size=self._buffer_size,
           slack_period=slack_period,
-          legacy_autotune=(buffer_size == dataset_ops.AUTOTUNE),
+          legacy_autotune=legacy_autotune,
           **self._common_args)
     super().__init__(input_dataset, variant_tensor)


### PR DESCRIPTION
## Summary
Dataset.prefetch rejected a tf.Tensor buffer_size with TypeError (Expected bool for argument legacy_autotune) even though the docs define buffer_size as an int64 scalar tf.Tensor. The legacy_autotune attribute was computed as buffer_size == AUTOTUNE, which yields a Tensor for tensor inputs. The attribute is now derived from the statically known value of the converted tensor, so constant tensors work, a constant AUTOTUNE tensor keeps autotuning, and symbolic tensors use the non-legacy path.

## Testing
Reproduced with Dataset.range(10).prefetch(tf.constant(1, tf.int64)), which raised TypeError on a release build. Added PrefetchTest.testTensorBufferSize covering constant value and constant AUTOTUNE tensors; the full prefetch_test suite passes.

## Checklist
- bug reproduced before the fix
- root cause identified
- minimal fix implemented
- tests passed