### PR TITLE
Raise a clear error for oversized dimensions in ensure_shape

### DIFF
--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1022,6 +1022,15 @@ class EnsureShapeTest(test.TestCase):
       def_function.function(
           lambda: check_ops.ensure_shape(x, shape))()
 
+  def testSymbolicTensorInsideTfFunction(self):
+    @def_function.function
+    def f(val):
+      shape_tensor = constant_op.constant([2], dtype=dtypes.int32)
+      return check_ops.ensure_shape(val, shape_tensor)
+
+    x = constant_op.constant([1.0, 2.0])
+    self.assertAllEqual(f(x), [1.0, 2.0])
+
 
 class EnsureShapeBenchmark(test.Benchmark):
 

--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -1012,6 +1012,16 @@ class EnsureShapeTest(test.TestCase):
     expected = [[1.0], [1.0]]
     self.assertAllEqual(gradient_values, expected)
 
+  def testRaisesErrorWhenDimensionSizeTooLarge(self):
+    x = constant_op.constant([1., 2.])
+    shape = constant_op.constant(
+        [18446743219011059112, 1], dtype=dtypes.uint64)
+    with self.assertRaisesRegex(ValueError, 'Dimension size must be at most'):
+      self.evaluate(check_ops.ensure_shape(x, shape))
+    with self.assertRaisesRegex(ValueError, 'Dimension size must be at most'):
+      def_function.function(
+          lambda: check_ops.ensure_shape(x, shape))()
+
 
 class EnsureShapeBenchmark(test.Benchmark):
 

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -2366,8 +2366,13 @@ def ensure_shape(x, shape, name=None):
       # Resolve tensor inputs through their values so that dimension sizes
       # outside the signed 64-bit range are caught below instead of causing
       # an obscure failure inside op construction.
+      shape_value = tensor_util.constant_value(shape)
+      if shape_value is None:
+        raise ValueError(
+            'The shape argument to ensure_shape must be statically known, '
+            f'but got a dynamic tensor: {shape}')
       shape = tensor_shape.TensorShape(
-          [int(dim) for dim in tuple(shape.numpy())])
+          [int(dim) for dim in tuple(shape_value)])
     else:
       shape = tensor_shape.TensorShape(shape)
 

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -2362,7 +2362,23 @@ def ensure_shape(x, shape, name=None):
     of `x`.
   """
   if not isinstance(shape, tensor_shape.TensorShape):
-    shape = tensor_shape.TensorShape(shape)
+    if tensor_util.is_tf_type(shape):
+      # Resolve tensor inputs through their values so that dimension sizes
+      # outside the signed 64-bit range are caught below instead of causing
+      # an obscure failure inside op construction.
+      shape = tensor_shape.TensorShape(
+          [int(dim) for dim in tuple(shape.numpy())])
+    else:
+      shape = tensor_shape.TensorShape(shape)
+
+  # Dimension sizes are stored as int64 attributes; reject larger values here
+  # so callers get a clear error instead of an obscure failure deep inside op
+  # construction.
+  if shape.rank is not None:
+    for dim in shape.as_list():
+      if dim is not None and dim > dtypes.int64.max:
+        raise ValueError(
+            f'Dimension size must be at most {dtypes.int64.max}; got {dim}.')
 
   return array_ops.ensure_shape(x, shape, name=name)
 


### PR DESCRIPTION
## Summary
Passing a uint64 Tensor whose dimension sizes exceed int64 to tf.ensure_shape crashed with SystemError in eager mode and TypeError under tf.function, because the values only failed when converted into the op shape attribute. Tensor shapes are now resolved through their values up front, and a dimension size larger than int64 raises ValueError.

## Testing
Reproduced with tf.ensure_shape(x, tf.constant([18446743219011059112, 1], tf.uint64)) on a release build: SystemError eager and TypeError under tf.function; both now raise ValueError. Added EnsureShapeTest.testRaisesErrorWhenDimensionSizeTooLarge covering both modes; valid uint64, int32 tensor, list and None shapes unchanged. Full check_ops_test suite passes.

## Checklist
- bug reproduced before the fix
- root cause identified
- minimal fix implemented
- tests passed