### PR TITLE
Reject negative values in set_inter_op_parallelism_threads

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -2250,7 +2250,7 @@ class Context:
     if self._inter_op_parallelism_threads == num_threads:
       return
 
-    if num_threads < 0:
+    if num_threads is not None and num_threads < 0:
       raise ValueError(
           "Inter op parallelism threads must be >= 0, but got %d" % num_threads
       )

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -2250,6 +2250,11 @@ class Context:
     if self._inter_op_parallelism_threads == num_threads:
       return
 
+    if num_threads < 0:
+      raise ValueError(
+          "Inter op parallelism threads must be >= 0, but got %d" % num_threads
+      )
+
     if self._context_handle is not None:
       raise RuntimeError(
           "Inter op parallelism cannot be modified after initialization."

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -162,6 +162,9 @@ class ConfigTest(test.TestCase, parameterized.TestCase):
 
     config.set_inter_op_parallelism_threads(10)
 
+    # None keeps the default behavior instead of failing the comparison.
+    config.set_inter_op_parallelism_threads(None)
+
   @test_util.run_gpu_only
   @reset_eager
   def testSoftPlacement(self):

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -155,6 +155,13 @@ class ConfigTest(test.TestCase, parameterized.TestCase):
 
     config.set_inter_op_parallelism_threads(10)
 
+  @reset_eager
+  def testInterOpParallelismThreadsNegative(self):
+    with self.assertRaisesRegex(ValueError, 'must be >= 0'):
+      config.set_inter_op_parallelism_threads(-1)
+
+    config.set_inter_op_parallelism_threads(10)
+
   @test_util.run_gpu_only
   @reset_eager
   def testSoftPlacement(self):


### PR DESCRIPTION
## Summary
tf.config.threading.set_inter_op_parallelism_threads accepted negative thread counts and passed them into thread pool creation, which aborts the process on a num_threads >= 1 check (issue 73519). The intra op setter already rejects negative values with ValueError; the same validation is applied to the inter op setter.

## Testing
A release build accepts set_inter_op_parallelism_threads(-1) silently before crashing later at pool creation; after the fix it raises ValueError immediately. Added ConfigTest.testInterOpParallelismThreadsNegative mirroring the existing intra op test; the full config_test suite passes.

## Checklist
- bug reproduced before the fix
- root cause identified
- minimal fix implemented
- tests passed