### PR TITLE
Compute experimental.numpy.arange at full float precision

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -296,6 +296,16 @@ def arange(start, stop=None, step=1, dtype=None):
     return array([], dtype=dtype)
   # TODO(srbs): There are some bugs when start or stop is float type and dtype
   # is integer type.
+  if dtypes.as_dtype(dtype).is_floating:
+    # Build the range at the resolved precision so the values follow NumPy;
+    # handing the Python scalars to tf.range directly computes them as
+    # float32 even when the output dtype is float64.
+    limit = None if stop is None else ops.convert_to_tensor(stop, dtype=dtype)
+    return math_ops.range(
+        ops.convert_to_tensor(start, dtype=dtype),
+        limit=limit,
+        delta=ops.convert_to_tensor(step, dtype=dtype),
+    )
   return math_ops.cast(
       math_ops.range(start, limit=stop, delta=step), dtype=dtype
   )

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -380,6 +380,18 @@ class ArrayCreationTest(test.TestCase):
           np_array_ops.ascontiguousarray(a, dtype=dtype),
           np.ascontiguousarray(a, dtype=dtype))
 
+  def testARangeFloatStep(self):
+    for args, kwargs in [
+        ((0., 1.), dict(step=0.3)),
+        ((0., 5.), dict(step=1.5)),
+        ((2., -3.), dict(step=-0.75)),
+    ]:
+      self.assertAllEqual(
+          np_array_ops.arange(*args, **kwargs), np.arange(*args, **kwargs))
+    self.assertAllEqual(
+        np_array_ops.arange(2., -3., step=-0.75, dtype=np.float32),
+        np.arange(2., -3., step=-0.75, dtype=np.float32))
+
   def testARange(self):
     int_values = np.arange(-3, 3).tolist()
     float_values = np.arange(-3.5, 3.5).tolist()


### PR DESCRIPTION
## Summary
experimental.numpy.arange handed Python scalars to tf.range, which computes at float32 even when the resolved output dtype is float64, so results like arange(0., 1., step=0.3) carried float32 rounding after being cast up and did not match NumPy. The range is now built from tensors of the resolved dtype for floating outputs; integer paths are unchanged.

## Testing
Reproduced on a release build: tnp.arange(0., 1., step=0.3) returned [0, 0.30000001...] while NumPy returns [0, 0.3, ...]. Added ArrayCreationTest.testARangeFloatStep asserting exact equality with NumPy for positive, negative and explicit-dtype steps; the full np_array_ops_test suite passes.

## Checklist
- bug reproduced before the fix
- root cause identified
- minimal fix implemented
- tests passed