### PR TITLE
Return a real dtype for complex experimental.numpy.var with ddof

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -735,10 +735,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=None):  # pylint: d
       if input_tensor.dtype in (dtypes.complex64, dtypes.complex128):
         # The variance of a complex tensor is real; keep the real dtype like
         # math_ops.reduce_variance and NumPy do.
-        centered = math_ops.cast(
-            math_ops.real(centered * math_ops.conj(centered)),
-            input_tensor.dtype.real_dtype,
-        )
+        centered = math_ops.real(centered * math_ops.conj(centered))
       else:
         centered = math_ops.square(centered)
       squared_deviations = math_ops.reduce_sum(

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -753,7 +753,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=None):  # pylint: d
         )
       n = math_ops.cast(n - ddof, input_tensor.dtype)
 
-      return math_ops.cast(math_ops.divide(squared_deviations, n), dtype)
+      return math_ops.divide(squared_deviations, n)
 
   else:
     reduce_fn = math_ops.reduce_variance

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -733,9 +733,11 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=None):  # pylint: d
       means = math_ops.reduce_mean(input_tensor, axis=axis, keepdims=True)
       centered = input_tensor - means
       if input_tensor.dtype in (dtypes.complex64, dtypes.complex128):
+        # The variance of a complex tensor is real; keep the real dtype like
+        # math_ops.reduce_variance and NumPy do.
         centered = math_ops.cast(
             math_ops.real(centered * math_ops.conj(centered)),
-            input_tensor.dtype,
+            input_tensor.dtype.real_dtype,
         )
       else:
         centered = math_ops.square(centered)
@@ -751,7 +753,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=None):  # pylint: d
         n = math_ops.reduce_prod(
             array_ops.gather(array_ops.shape(input_tensor), axis)
         )
-      n = math_ops.cast(n - ddof, input_tensor.dtype)
+      n = math_ops.cast(n - ddof, squared_deviations.dtype)
 
       return math_ops.divide(squared_deviations, n)
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -856,6 +856,9 @@ class ArrayMethodsTest(test.TestCase):
     run_test([[1, 2], [3, 4]], axis=-1)
     run_test([[1, 2], [3, 4]], axis=-2)
     run_test([[1, 2], [3, 4]], axis=(0, 1))
+    run_test([1., 2., 3.], ddof=1)
+    run_test([1., 2., 3.], ddof=1, dtype=np.float64)
+    run_test([[1., 2.], [3., 4.]], axis=-1, ddof=1, keepdims=True)
     run_test(np.arange(8).reshape((2, 2, 2)).tolist(), axis=(0, 2))
     run_test(
         np.arange(8).reshape((2, 2, 2)).tolist(), axis=(0, 2), keepdims=True)

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -859,6 +859,8 @@ class ArrayMethodsTest(test.TestCase):
     run_test([1., 2., 3.], ddof=1)
     run_test([1., 2., 3.], ddof=1, dtype=np.float64)
     run_test([[1., 2.], [3., 4.]], axis=-1, ddof=1, keepdims=True)
+    run_test([1.j, 2., 3.j], ddof=1)
+    run_test([[1.j, 2.], [3.j, 4.]], axis=0, ddof=1)
     run_test(np.arange(8).reshape((2, 2, 2)).tolist(), axis=(0, 2))
     run_test(
         np.arange(8).reshape((2, 2, 2)).tolist(), axis=(0, 2), keepdims=True)


### PR DESCRIPTION
## Summary
For complex input with a nonzero ddof, tf.experimental.numpy.var returned complex128 because the ddof code path cast the squared deviations back to the complex input dtype, while NumPy and tnp.var itself at ddof=0 (via math_ops.reduce_variance) return float32 or float64. The squared deviations and divisor now stay in the real dtype. Note: this branch sits on top of PR 125955, which fixes a TypeError in the same code path; it will reduce to this change once that merges.

## Testing
Reproduced on a release build: tnp.var(complex_input, ddof=1) returned complex128 where NumPy returns float64; after the fix both agree, including axis reductions and complex64 inputs returning float32. Added complex ddof cases to testVar; the full np_array_ops_test suite passes.

## Checklist
- bug reproduced before the fix
- root cause identified
- minimal fix implemented
- tests passed