### PR TITLE
Fix DT_STRING crash in ConjugateTranspose

### DIFF
--- a/tensorflow/core/kernels/transpose_functor_cpu.cc
+++ b/tensorflow/core/kernels/transpose_functor_cpu.cc
@@ -39,8 +39,8 @@ void TransposeSimple(const CPUDevice& device, const Tensor& in,
       ComputeStride<int64_t>(in.shape());
   absl::InlinedVector<int64_t, 8UL> out_strides =
       ComputeStride<int64_t>(out->shape());
-  const T* p = reinterpret_cast<const T*>(in.tensor_data().data());
-  T* q = reinterpret_cast<T*>(const_cast<char*>((out->tensor_data().data())));
+  const T* p = reinterpret_cast<const T*>(in.data());
+  T* q = reinterpret_cast<T*>(out->data());
   auto transpose_fn = [=, &in_strides, &out_strides, &perm](int64_t begin,
                                                             int64_t end) {
     for (int64_t o_idx = begin; o_idx < end; ++o_idx) {

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -146,6 +146,18 @@ class BatchMatrixTransposeTest(test_util.TensorFlowTestCase):
           self.assertAllEqual(expected_transposed, transposed)
 
 
+@test_util.run_all_in_graph_and_eager_modes
+class TransposeTest(test_util.TensorFlowTestCase):
+
+  def testScalarStringConjugateTranspose(self):
+    value = constant_op.constant("hello")
+
+    transposed = gen_array_ops.conjugate_transpose(value, perm=[])
+
+    self.assertEqual((), transposed.shape)
+    self.assertAllEqual(b"hello", transposed)
+
+
 class BooleanMaskTest(test_util.TensorFlowTestCase):
 
   def setUp(self):


### PR DESCRIPTION
## Summary

- use the raw tensor buffer in the CPU fallback transpose path so non-memcpy element types are supported
- add coverage for scalar `DT_STRING` inputs to `ConjugateTranspose`

## Root cause

`TransposeSimple` called `Tensor::tensor_data()`, which has a fatal precondition that the dtype supports memcpy. Scalar inputs use this fallback path, so `DT_STRING` caused a process-level CHECK failure. `Tensor::data()` provides access to the underlying typed storage without imposing that invalid precondition.

## Testing

- `git diff --check`
- `python -m py_compile tensorflow/python/kernel_tests/array_ops/array_ops_test.py`
- Bazel test not run locally because Bazel/Bazelisk is unavailable

Fixes #125665