### PR TITLE
check sparse indices row count matches values in RaggedCross

### DIFF
--- a/tensorflow/core/kernels/ragged_cross_op.cc
+++ b/tensorflow/core/kernels/ragged_cross_op.cc
@@ -410,6 +410,13 @@ class RaggedCrossOp : public OpKernel {
         return absl::InvalidArgumentError(
             "tf.ragged.cross only supports inputs with rank=2.");
       }
+      if (sparse_indices_list[i].dim_size(0) !=
+          sparse_values_list[i].dim_size(0)) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Expected size of sparse values to be ",
+            sparse_indices_list[i].dim_size(0), " got ",
+            sparse_values_list[i].dim_size(0), " at position ", i));
+      }
     }
     for (int i = 0; i < dense_list.size(); ++i) {
       if (!TensorShapeUtils::IsMatrix(dense_list[i].shape())) {

--- a/tensorflow/python/ops/ragged/ragged_cross_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_cross_op_test.py
@@ -446,6 +446,27 @@ class RaggedCrossOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
           out_values_type=dtypes.string,
           out_row_splits_type=dtypes.int64))
 
+  def testSparseIndicesRowCountMustMatchValues(self):
+    # A sparse input whose indices matrix has fewer rows than its values
+    # vector has elements drives an out-of-bounds read in the
+    # SparseFeatureReader loop, which is bounded by the values length.
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError),
+        'Expected size of sparse values to be'):
+      self.evaluate(gen_ragged_array_ops.RaggedCross(
+          ragged_values=[],
+          ragged_row_splits=[],
+          sparse_indices=[[[0, 0]]],
+          sparse_values=[['a', 'b', 'c']],
+          sparse_shape=[[2, 5]],
+          dense_inputs=[],
+          input_order='S',
+          hashed_output=False,
+          num_buckets=5,
+          hash_key=2,
+          out_values_type=dtypes.string,
+          out_row_splits_type=dtypes.int64))
+
   def testRaggedValuesAndSplitsMustMatch(self):
     with self.assertRaisesRegex(
         (ValueError, errors.InvalidArgumentError),


### PR DESCRIPTION
SparseFeatureReader in ragged_cross_op.cc bounds its scan loop by the sparse feature's values length but uses that index to read the indices matrix, so a RaggedCross input whose indices tensor has fewer rows than its values vector reads past the end of the indices buffer. ValidateInput never checks the two lengths agree, though the sibling SparseCrossOp already enforces exactly this in its own ValidateInput. Add the same check so mismatched sparse inputs are rejected before the reader runs.