### PR TITLE
Widen the accumulator for integer reduce_mean under XLA

### DIFF
--- a/tensorflow/compiler/tests/reduce_ops_test.py
+++ b/tensorflow/compiler/tests/reduce_ops_test.py
@@ -160,6 +160,25 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
     self._testReduction(math_ops.reduce_mean, np.mean, np.complex64,
                         self.NONEMPTY_COMPLEX_DATA, index_dtype)
 
+  def testReduceMeanIntegerOverflow(self, index_dtype):
+    # Regression test for GitHub issue 125978. Mean accumulated in the element
+    # type, so a sum that overflowed wrapped before the division was applied
+    # and the mean of two copies of the largest value came back as -1 for
+    # int32, disagreeing with the eager kernel. The 8 and 16 bit types were
+    # already widened, so only the 32 bit ones were affected.
+    for dtype in (np.int32, np.uint32):
+      if dtype not in self.all_types:
+        continue
+      max_value = np.iinfo(dtype).max
+      test_input = np.array([[max_value, max_value]], dtype=dtype)
+      with self.session() as sess:
+        with self.test_scope():
+          a = array_ops.placeholder(dtype)
+          index = array_ops.placeholder(index_dtype)
+          out = math_ops.reduce_mean(a, index)
+        result = sess.run(out, {a: test_input, index: [1]})
+      self.assertAllEqual([max_value], result)
+
   def testReduceAll(self, index_dtype):
     self._testReduction(math_ops.reduce_all, np.all, np.bool_, self.BOOL_DATA,
                         index_dtype)

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
@@ -123,11 +123,25 @@ class MaxOp : public XlaReductionOp {
 REGISTER_XLA_OP(Name("Max").CompileTimeConstantInput("reduction_indices"),
                 MaxOp);
 
+// Mean divides the accumulated sum by the number of reduced elements, so an
+// accumulator that wraps does not merely produce a wrapped sum the way Sum
+// does, it produces a quotient that is wrong in both sign and magnitude. That
+// is why Mean needs a wider accumulator than the other reductions:
+// `SumAccumulationType` already widens the 8 and 16 bit integer types to avoid
+// overflow, but leaves the 32 bit ones alone, so reducing int32 or uint32 gave
+// a negative mean for strictly positive inputs and disagreed with the eager
+// kernel. The 64 bit types have nothing wider to accumulate in and keep
+// wrapping, which is what the eager kernel does for them as well.
+DataType MeanAccumulationType(const DataType& dtype) {
+  if (dtype == DT_INT32) return DT_INT64;
+  if (dtype == DT_UINT32) return DT_UINT64;
+  return XlaHelpers::SumAccumulationType(dtype);
+}
+
 class MeanOp : public XlaReductionOp {
  public:
   explicit MeanOp(OpKernelConstruction* ctx)
-      : XlaReductionOp(ctx,
-                       XlaHelpers::SumAccumulationType(ctx->input_type(0))) {}
+      : XlaReductionOp(ctx, MeanAccumulationType(ctx->input_type(0))) {}
 
   xla::XlaOp InitialValue(xla::XlaBuilder* builder) override {
     return xla::Zero(builder, xla_reduction_type_);


### PR DESCRIPTION
Fixes #125978

`tf.reduce_mean` on `int32` and `uint32` disagrees with eager execution under `tf.function(jit_compile=True)` when the sum of the reduced elements overflows the element type, returning a negative mean for strictly positive inputs:

```python
a = tf.constant([[2**31 - 1, 2**31 - 1]], dtype=tf.int32)
tf.reduce_mean(a, axis=1)
# eager                    -> [2147483647]
# tf.function(jit_compile) -> [-1]
```

### Cause

`MeanOp` in `tensorflow/compiler/tf2xla/kernels/reduction_ops.cc` accumulates in `XlaHelpers::SumAccumulationType(input_type)` and then divides. That helper widens only the narrow integer types:

```cpp
// Upcast small integer types to 32 bit to avoid overflow.
if (dtype == DT_INT8 || dtype == DT_INT16) return DT_INT32;
if (dtype == DT_UINT8 || dtype == DT_UINT16) return DT_UINT32;
return dtype;
```

`int32` and `uint32` fall through unwidened, so the sum wraps before the division is applied. This accounts for the reported behavior exactly: `int8` and `int16` widen to `int32` and agree with eager, `uint8` and `uint16` widen to `uint32` and agree, `int64` and `uint64` have nothing wider and wrap in eager too so they also agree, and `int32` and `uint32` are the only two that diverge.

It is also why `reduce_sum` agrees while `reduce_mean` does not. Sum returns the wrapped sum either way, since the result is converted back to the input type at the end. Only Mean divides, which turns a wrapped accumulator into a quotient that is wrong in both sign and magnitude.

### Fix

`Mean` now selects its own accumulation type, widening the 32 bit integer types and deferring to `SumAccumulationType` for everything else:

```cpp
DataType MeanAccumulationType(const DataType& dtype) {
  if (dtype == DT_INT32) return DT_INT64;
  if (dtype == DT_UINT32) return DT_UINT64;
  return XlaHelpers::SumAccumulationType(dtype);
}
```

`SumAccumulationType` itself is deliberately left alone. It feeds roughly sixteen other call sites, including `Sum`, `Prod`, `L2Loss`, softmax, LRN, batch norm, pooling and the scan ops, and none of those need a wider accumulator to match eager. Confining the change to `Mean` fixes the divergence without altering the accumulation width of every other reduction.

`XlaReductionOp` already converts the input to the reduction type before reducing, so no other change is needed for the wider accumulator to take effect.

`int64` and `uint64` continue to wrap, which matches the eager kernel: for those types the reporter's own control shows both paths returning `-1`, so there is no divergence to fix and nothing wider to accumulate in.

### Tests

`testReduceMeanIntegerOverflow` in `tensorflow/compiler/tests/reduce_ops_test.py` reduces two copies of the largest representable value for `int32` and `uint32` and checks the result equals that value, guarded on the dtype being supported by the backend. It follows the existing class-level index dtype parameterization.

Verified against the released 2.21.0 wheel that the assertion the test makes fails on the current kernels:

```
int32:  expected [2147483647]  got [-1]
uint32: expected [4294967295]  got [2147483647]
```

### Notes for reviewers

- I could not build TensorFlow locally, so the C++ change has not been compiled and the new test has not been executed. The reproducer, the dtype matrix and the gating evidence above were verified against the released 2.21.0 wheel on macOS arm64 CPU.
- The tradeoff is that integer `Mean` now accumulates in 64 bit for 32 bit inputs. The existing comment in `SumAccumulationType` indicates the widening is there to avoid overflow in the first place, so this extends the stated intent rather than introducing a new policy, but I am happy to reconsider if the cost is a concern for large integer reductions.
- Worth noting for anyone looking at the MLIR path: the reduction lowering there uses a different helper, `GetAccumulationType` in `tensorflow/compiler/mlir/tf2xla/transforms/legalize_tf.cc`, which widens no integer types at all. The observed results identify the kernel above as the one that is live for this case, since the MLIR path would have returned -1 for `int8` rather than the 127 that is actually produced.
