### PR TITLE
tf2xla: add XLA CPU kernel for UnravelIndex

### DIFF
--- a/tensorflow/compiler/jit/mark_for_compilation_pass.cc
+++ b/tensorflow/compiler/jit/mark_for_compilation_pass.cc
@@ -2313,6 +2313,7 @@ absl::flat_hash_set<std::string> GetKnownXLAAllowlistOp() {
       "UniformRequantize",
       "Unique",
       "UniqueV2",
+      "UnravelIndex",
       "UpperBound",
       "UnsortedSegmentMax",
       "UnsortedSegmentMin",

--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -861,6 +861,23 @@ tf_xla_py_strict_test(
 )
 
 tf_xla_py_strict_test(
+    name = "unravel_index_op_test",
+    size = "small",
+    srcs = ["unravel_index_op_test.py"],
+    tags = [
+        "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
+        "notap",
+    ],
+    deps = [
+        ":xla_test",
+        "//tensorflow/python/framework:dtypes",
+        "//tensorflow/python/ops:array_ops",
+        "//tensorflow/python/platform:test",
+        "//third_party/py/numpy",
+    ],
+)
+
+tf_xla_py_strict_test(
     name = "dynamic_stitch_test",
     size = "small",
     srcs = ["dynamic_stitch_test.py"],

--- a/tensorflow/compiler/tests/unravel_index_op_test.py
+++ b/tensorflow/compiler/tests/unravel_index_op_test.py
@@ -1,0 +1,60 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for UnravelIndex, previously unsupported under XLA (b/no XLA_CPU_JIT kernel)."""
+
+import numpy as np
+
+from tensorflow.compiler.tests import xla_test
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.platform import googletest
+
+
+class UnravelIndexOpTest(xla_test.XLATestCase):
+
+  def testVectorIndices(self):
+    for dtype in [dtypes.int32, dtypes.int64]:
+      with self.session():
+        with self.test_scope():
+          indices = array_ops.placeholder(dtype, shape=[4])
+          dims = array_ops.constant([2, 2], dtype=dtype)
+          o = array_ops.unravel_index(indices, dims)
+        result = o.eval(feed_dict={indices: [0, 1, 2, 3]})
+        self.assertAllEqual(
+            np.unravel_index([0, 1, 2, 3], (2, 2)), result)
+
+  def testScalarIndex(self):
+    for dtype in [dtypes.int32, dtypes.int64]:
+      with self.session():
+        with self.test_scope():
+          index = array_ops.placeholder(dtype, shape=[])
+          dims = array_ops.constant([3, 4, 5], dtype=dtype)
+          o = array_ops.unravel_index(index, dims)
+        result = o.eval(feed_dict={index: 37})
+        self.assertAllEqual(np.unravel_index(37, (3, 4, 5)), result)
+
+  def testHigherRank(self):
+    with self.session():
+      with self.test_scope():
+        indices = array_ops.constant([22, 41, 37])
+        dims = array_ops.constant([7, 6])
+        o = array_ops.unravel_index(indices, dims)
+      result = o.eval()
+      self.assertAllEqual(
+          np.unravel_index([22, 41, 37], (7, 6)), result)
+
+
+if __name__ == '__main__':
+  googletest.main()

--- a/tensorflow/compiler/tf2xla/kernels/BUILD
+++ b/tensorflow/compiler/tf2xla/kernels/BUILD
@@ -174,6 +174,7 @@ cc_library(
         ":uniform_quantized_ops",
         ":unique_op",
         ":unpack_op",
+        ":unravel_index_op",
         ":variable_ops",
         ":where_op",
         ":while_op",
@@ -3255,6 +3256,24 @@ tf_kernel_library(
         "//tensorflow/compiler/tf2xla/ops:xla_ops",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
+        "@xla//xla/hlo/builder:xla_builder",
+    ],
+)
+
+tf_kernel_library(
+    name = "unravel_index_op",
+    srcs = ["unravel_index_op.cc"],
+    deps = [
+        "//tensorflow/compiler/tf2xla:xla_compilation_device",
+        "//tensorflow/compiler/tf2xla:xla_compiler",
+        "//tensorflow/compiler/tf2xla:xla_context",
+        "//tensorflow/compiler/tf2xla:xla_helpers",
+        "//tensorflow/compiler/tf2xla:xla_op_registry",
+        "//tensorflow/compiler/tf2xla:xla_resource",
+        "//tensorflow/compiler/tf2xla/ops:xla_ops",
+        "//tensorflow/core:framework",
+        "//tensorflow/core/platform:errors",
+        "@xla//xla:xla_data_proto_cc",
         "@xla//xla/hlo/builder:xla_builder",
     ],
 )

--- a/tensorflow/compiler/tf2xla/kernels/unravel_index_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/unravel_index_op.cc
@@ -1,0 +1,139 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// XLA-specific UnravelIndex Op.
+//
+// This mirrors the CPU kernel in
+// tensorflow/core/kernels/unravel_index_op.cc: given a flat `indices` tensor
+// (scalar or vector) and a 1-D `dims` tensor, computes the row-major
+// multi-dimensional coordinates for each flat index.
+//
+// `dims` is required to be a compile-time constant (the same requirement
+// Reshape's `shape` input and similar tf2xla kernels already place on their
+// shape-describing input), which lets the per-dimension strides be computed
+// on the host and lowered to a small constant + elementwise div/mod
+// computation instead of needing a dynamic loop.
+//
+// Unlike the CPU kernel, this lowering does not reproduce the CPU kernel's
+// runtime "index is out of bound as with dims" check: `indices` is a
+// general XlaOp that is not necessarily known at compile time, and emitting
+// a device-side bounds check that raises is not something this op's XLA
+// lowering does elsewhere in this file's sibling kernels (e.g. Gather also
+// does not). Out-of-range indices produce an unspecified (wrapped) result
+// rather than an error, which should be called out in the op's docs if this
+// lands, the same way other index-consuming XLA kernels' behavior on
+// invalid input is documented as unspecified rather than validated.
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "tensorflow/compiler/tf2xla/xla_op_kernel.h"
+#include "tensorflow/compiler/tf2xla/xla_op_registry.h"
+#include "xla/hlo/builder/xla_builder.h"
+#include "xla/xla_data.pb.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/op_requires.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/platform/errors.h"
+
+namespace tensorflow {
+namespace {
+
+class UnravelIndexOp : public XlaOpKernel {
+ public:
+  explicit UnravelIndexOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {}
+
+  void Compile(XlaOpKernelContext* ctx) override {
+    const TensorShape indices_shape = ctx->InputShape(0);
+    OP_REQUIRES(ctx,
+                TensorShapeUtils::IsVector(indices_shape) ||
+                    TensorShapeUtils::IsScalar(indices_shape),
+                errors::InvalidArgument(
+                    "The indices can only be scalar or vector, got \"",
+                    indices_shape.DebugString(), "\""));
+
+    const TensorShape dims_shape = ctx->InputShape(1);
+    OP_REQUIRES(ctx, TensorShapeUtils::IsVector(dims_shape),
+                errors::InvalidArgument("The dims can only be 1-D, got \"",
+                                        dims_shape.DebugString(), "\""));
+
+    std::vector<int64_t> dims;
+    OP_REQUIRES_OK(ctx, ctx->ConstantInputAsIntVector(1, &dims));
+    const int64_t rank = dims.size();
+
+    int64_t product = 1;
+    for (int64_t i = 0; i < rank; ++i) {
+      OP_REQUIRES(ctx, dims[i] > 0,
+                  errors::InvalidArgument(
+                      "Input dims cannot be zero or negative, got dim = ",
+                      dims[i], " at index ", i));
+      OP_REQUIRES(ctx, product <= std::numeric_limits<int64_t>::max() / dims[i],
+                  errors::InvalidArgument(
+                      "Input dims product is causing integer overflow"));
+      product *= dims[i];
+    }
+
+    // trailing[i] = product(dims[i+1:]), i.e. the stride to divide a flat
+    // index by to get the coordinate along dimension i (before taking it
+    // mod dims[i]). trailing[rank - 1] is 1.
+    std::vector<int64_t> trailing(rank, 1);
+    for (int64_t i = rank - 2; i >= 0; --i) {
+      trailing[i] = trailing[i + 1] * dims[i + 1];
+    }
+
+    xla::XlaBuilder* b = ctx->builder();
+    const xla::PrimitiveType index_type = ctx->input_xla_type(0);
+    xla::XlaOp indices = ctx->Input(0);
+
+    xla::XlaOp trailing_const = xla::ConvertElementType(
+        xla::ConstantR1<int64_t>(b, trailing), index_type);
+    xla::XlaOp dims_const = xla::ConvertElementType(
+        xla::ConstantR1<int64_t>(b, dims), index_type);
+
+    xla::XlaOp output;
+    if (TensorShapeUtils::IsScalar(indices_shape)) {
+      // Output shape [rank]: broadcast the scalar index to [rank], then
+      // (index / trailing[i]) % dims[i] elementwise against the [rank]
+      // constants built above.
+      xla::XlaOp indices_bcast = xla::Broadcast(indices, {rank});
+      output = xla::Rem(xla::Div(indices_bcast, trailing_const), dims_const);
+    } else {
+      // Output shape [rank, num_indices]: broadcast indices (shape
+      // [num_indices]) by prepending the rank dimension, and broadcast the
+      // [rank] stride/dims constants along a new trailing indices
+      // dimension via BroadcastInDim, then combine elementwise.
+      const int64_t num_indices = indices_shape.num_elements();
+      OP_REQUIRES(ctx, num_indices > 0,
+                  errors::InvalidArgument("received empty tensor indices: ",
+                                          indices_shape.DebugString()));
+      xla::XlaOp indices_bcast = xla::Broadcast(indices, {rank});
+      xla::XlaOp trailing_bcast = xla::BroadcastInDim(
+          trailing_const, {rank, num_indices}, {0});
+      xla::XlaOp dims_bcast =
+          xla::BroadcastInDim(dims_const, {rank, num_indices}, {0});
+      output =
+          xla::Rem(xla::Div(indices_bcast, trailing_bcast), dims_bcast);
+    }
+
+    ctx->SetOutput(0, output);
+  }
+};
+
+REGISTER_XLA_OP(Name("UnravelIndex").CompileTimeConstantInput("dims"),
+                UnravelIndexOp);
+
+}  // namespace
+}  // namespace tensorflow


### PR DESCRIPTION
Fixes part of #126007.

There was no XLA kernel registered for `UnravelIndex` at all, so `tf.unravel_index()` fails with "No registered 'UnravelIndex' OpKernel for XLA_CPU_JIT devices" under `tf.function(jit_compile=True)`, even though the same call works fine in eager execution and under autoclustering.

This lowers it the same way the CPU kernel computes it (`tensorflow/core/kernels/unravel_index_op.cc`): `dims` is required to be a compile time constant, the same requirement `Reshape` already places on its `shape` input, so the per dimension strides can be computed on the host and the whole op becomes a small constant plus an elementwise div and mod, no dynamic loop needed.

This does not reproduce the CPU kernel's runtime out of range check on `indices`, since `indices` is a general `XlaOp` and not necessarily known at compile time. That mirrors how other index consuming XLA kernels in this same directory, `Gather` for example, do not raise on invalid input either, so it is a known and called out limitation in the code comment rather than a silently dropped check.

Added `unravel_index_op_test.py` covering the scalar index case, the vector index case, and a higher rank case, checked against `numpy.unravel_index`.

Found this via fuzzing TF/XLA divergences between eager, `jit_compile=True` and autoclustering, reported as tensorflow/tensorflow#126007 alongside two other ops with the same missing kernel gap (`tf.print`, `tf.linalg.eig`) that are out of scope for this PR, general eigenvalue decomposition and XLA host callback support are both much bigger pieces of work than this one.

One honest caveat: I was not able to get a full local `bazel test` run to finish for this target before opening this, a from scratch build on the machine I used progressed from about action 8300 to 8450 of 9524 over half an hour, almost entirely spent on large pre existing MLIR/XLA source files unrelated to this change, and I did not want to sit on the fix waiting on that. I did check every XLA builder call this uses (`ConstantR1`, `Broadcast`, `BroadcastInDim`, `Div`, `Rem`, `ConvertElementType`) against the actual signatures in `xla/hlo/builder/xla_builder.h` in the fetched build tree, and worked the div/mod math through by hand against a few `numpy.unravel_index` examples before writing the test, but happy to fix anything CI turns up that I could not catch this way.
