### PR TITLE
Fix BroadcastTo shape inference to reject known negative dimensions.

### DIFF
--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -511,15 +511,22 @@ REGISTER_OP("BroadcastTo")
       // A known negative value is invalid. Mapping it to "unknown" would merge
       // with the input shape, and Grappler would then drop the op as a no-op.
       const Tensor* shape_t = c->input_tensor(1);
-      if (shape_t != nullptr && (shape_t->dtype() == DT_INT32 ||
-                                 shape_t->dtype() == DT_INT64)) {
-        for (int i = 0; i < shape_t->NumElements(); ++i) {
-          const int64_t dim = (shape_t->dtype() == DT_INT32)
-                                  ? shape_t->flat<int32_t>()(i)
-                                  : shape_t->flat<int64_t>()(i);
-          if (dim < 0) {
-            return absl::InvalidArgumentError(
-                absl::StrCat("Dimension ", dim, " must be >= 0"));
+      if (shape_t != nullptr) {
+        if (shape_t->dtype() == DT_INT32) {
+          auto flat = shape_t->flat<int32_t>();
+          for (int i = 0; i < shape_t->NumElements(); ++i) {
+            if (flat(i) < 0) {
+              return absl::InvalidArgumentError(
+                  absl::StrCat("Dimension ", flat(i), " must be >= 0"));
+            }
+          }
+        } else if (shape_t->dtype() == DT_INT64) {
+          auto flat = shape_t->flat<int64_t>();
+          for (int i = 0; i < shape_t->NumElements(); ++i) {
+            if (flat(i) < 0) {
+              return absl::InvalidArgumentError(
+                  absl::StrCat("Dimension ", flat(i), " must be >= 0"));
+            }
           }
         }
       }

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -507,6 +507,22 @@ REGISTER_OP("BroadcastTo")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle shape_in = c->input(1);
       TF_RETURN_IF_ERROR(c->WithRank(shape_in, 1, &shape_in));
+      // Unlike Reshape, BroadcastTo does not treat -1 as an inferred dimension.
+      // A known negative value is invalid. Mapping it to "unknown" would merge
+      // with the input shape, and Grappler would then drop the op as a no-op.
+      const Tensor* shape_t = c->input_tensor(1);
+      if (shape_t != nullptr && (shape_t->dtype() == DT_INT32 ||
+                                 shape_t->dtype() == DT_INT64)) {
+        for (int i = 0; i < shape_t->NumElements(); ++i) {
+          const int64_t dim = (shape_t->dtype() == DT_INT32)
+                                  ? shape_t->flat<int32_t>()(i)
+                                  : shape_t->flat<int64_t>()(i);
+          if (dim < 0) {
+            return absl::InvalidArgumentError(
+                absl::StrCat("Dimension ", dim, " must be >= 0"));
+          }
+        }
+      }
       ShapeHandle out;
       TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(1, &out));
       if (!c->RankKnown(out)) {

--- a/tensorflow/core/ops/array_ops_test.cc
+++ b/tensorflow/core/ops/array_ops_test.cc
@@ -631,6 +631,33 @@ TEST(ArrayOpsTest, BroadcastTo_ShapeFn) {
               "[3,1,1];[3]");
   INFER_ERROR("Dimensions must be equal, but are 2 and 10 for", op,
               "[2,2,1];[3]");
+
+  // Known negative dims are invalid (unlike Reshape, -1 is not "infer this").
+  Tensor neg_shape_t(DT_INT64, TensorShape{1});
+  test::FillValues<int64_t>(&neg_shape_t, {-1});
+  op.input_tensors[1] = &neg_shape_t;
+  INFER_ERROR("Dimension -1 must be >= 0", op, "[4];[1]");
+
+  Tensor neg_shape_t32(DT_INT32, TensorShape{2});
+  test::FillValues<int32_t>(&neg_shape_t32, {2, -1});
+  op.input_tensors[1] = &neg_shape_t32;
+  INFER_ERROR("Dimension -1 must be >= 0", op, "[1];[2]");
+
+  Tensor neg2_shape_t(DT_INT64, TensorShape{1});
+  test::FillValues<int64_t>(&neg2_shape_t, {-2});
+  op.input_tensors[1] = &neg2_shape_t;
+  INFER_ERROR("Dimension -2 must be >= 0", op, "[4];[1]");
+
+  // 0 is a valid dimension; only negatives are rejected.
+  Tensor zero_shape_t(DT_INT64, TensorShape{1});
+  test::FillValues<int64_t>(&zero_shape_t, {0});
+  op.input_tensors[1] = &zero_shape_t;
+  INFER_OK(op, "[1];[1]", "[0]");
+
+  // Unknown shape-tensor values are still allowed; the kernel validates later.
+  op.input_tensors[1] = nullptr;
+  INFER_OK(op, "[1];[1]", "[?]");
+  INFER_OK(op, "[4];[1]", "[d0_0]");
 }
 
 TEST(ArrayOpsTest, BroadcastGradientArgs_ShapeFn) {

--- a/tensorflow/python/kernel_tests/array_ops/broadcast_to_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/broadcast_to_ops_test.py
@@ -16,6 +16,7 @@
 import numpy as np
 
 from tensorflow.python.eager import context
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
@@ -219,6 +220,30 @@ class BroadcastToTest(test_util.TensorFlowTestCase):
       x = constant_op.constant(value=[], shape=(3, 0, 5), dtype=np.int32)
       v = array_ops.broadcast_to(x, output_shape)
       self.evaluate(v)
+
+  def testBroadcastToNegativeDimension(self):
+    # -1 is valid for Reshape ("infer this dim") but not for BroadcastTo.
+    x = constant_op.constant([1.0, 2.0, 3.0, 4.0])
+    for shape in ([-1], constant_op.constant([-1], dtype=dtypes.int32),
+                  constant_op.constant([-1], dtype=dtypes.int64)):
+      with self.assertRaisesRegex((ValueError, errors.InvalidArgumentError),
+                                  r"Dimension -1 must be >= 0"):
+        result = array_ops.broadcast_to(x, shape)
+        self.evaluate(result)
+
+  @test_util.run_v2_only
+  def testBroadcastToNegativeDimensionInFunction(self):
+    # Grappler used to drop BroadcastTo(x, [-1]) as a no-op after shape
+    # inference treated -1 as unknown and merged it with x's shape.
+    x = constant_op.constant([1.0, 2.0, 3.0, 4.0])
+
+    @def_function.function
+    def f():
+      return array_ops.broadcast_to(x, [-1])
+
+    with self.assertRaisesRegex((ValueError, errors.InvalidArgumentError),
+                                r"Dimension -1 must be >= 0"):
+      self.evaluate(f())
 
 if __name__ == "__main__":
   test_lib.main()


### PR DESCRIPTION
## Summary
Fixes #125545.

`tf.broadcast_to` with `shape=[-1]` already errors in eager (`Dimension -1 must be >= 0`). `jit_compile=True` also errors (today via an overflow). Autoclustering (`tf.function` with `tf_xla_auto_jit=2`) silently returns the input.

The silent path is not autoclustering-specific: default `tf.function` does the same. Shape inference treated constant `-1` as unknown (Reshape convention), merged it with the input shape, and Grappler dropped BroadcastTo as a no-op.

BroadcastTo does not support `-1` as “infer this dim”. This change rejects any **known** negative dimension in BroadcastTo shape inference (not only `-1`), so eager, `tf.function`, autoclustering, and `jit_compile` all raise `Dimension N must be >= 0`. Unknown/dynamic shape tensors are unchanged.

## Test plan
- Shape inference: reject `-1`/`-2` (int32 and int64); still accept `0` and unknown shape tensors
- Python: eager and `tf.function` raise on `broadcast_to(x, [-1])`