### PR TITLE
Reject a negative num_elements in BarrierTakeMany

### DIFF
--- a/tensorflow/core/kernels/barrier_ops.cc
+++ b/tensorflow/core/kernels/barrier_ops.cc
@@ -587,6 +587,11 @@ class TakeManyOp : public BarrierOpKernel {
         ctx, TensorShapeUtils::IsScalar(Tnum_elements->shape()),
         absl::InvalidArgumentError("num_elements must be a scalar."), callback);
     const int32_t num_elements = Tnum_elements->scalar<int32_t>()();
+    OP_REQUIRES_ASYNC(
+        ctx, num_elements >= 0,
+        absl::InvalidArgumentError(absl::StrCat(
+            "BarrierTakeMany requested ", num_elements, " < 0 elements")),
+        callback);
 
     DataTypeVector expected_inputs = {DT_STRING_REF, DT_INT32};
     // The first output is the insertion index, the second output is the key.

--- a/tensorflow/python/kernel_tests/data_structures/BUILD
+++ b/tensorflow/python/kernel_tests/data_structures/BUILD
@@ -37,6 +37,7 @@ tf_py_strict_test(
         "//tensorflow/python/framework:tensor",
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:data_flow_ops",
+        "//tensorflow/python/ops:data_flow_ops_gen",
         "//tensorflow/python/platform:client_testlib",
         "//third_party/py/numpy",
     ],

--- a/tensorflow/python/kernel_tests/data_structures/barrier_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/barrier_ops_test.py
@@ -24,6 +24,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import data_flow_ops
+from tensorflow.python.ops import gen_data_flow_ops
 from tensorflow.python.platform import test
 
 
@@ -101,6 +102,25 @@ class BarrierTest(test.TestCase):
       with self.assertRaisesOpError(
           ".*Tensors with no elements are not supported.*"):
         insert_0_op.run()
+
+  @test_util.run_deprecated_v1
+  def testTakeManyNegativeNumElements(self):
+    # Test case for GitHub issue 112742. A negative num_elements reached the
+    # underlying queue, which built an output shape with a negative dimension
+    # and aborted the process. The raw op is used here because Barrier.take_many
+    # rejects a negative count while building the graph, before the kernel runs.
+    with self.cached_session() as sess:
+      b = data_flow_ops.Barrier(
+          (dtypes.float32, dtypes.float32), shapes=((), ()), name="B")
+      keys = [b"a", b"b"]
+      insert_0_op = b.insert_many(0, keys, [10.0, 20.0])
+      insert_1_op = b.insert_many(1, keys, [100.0, 200.0])
+      sess.run([insert_0_op, insert_1_op])
+      take_t = gen_data_flow_ops.barrier_take_many(
+          b.barrier_ref, -1, (dtypes.float32, dtypes.float32),
+          allow_small_batch=False)
+      with self.assertRaisesOpError("requested -1 < 0 elements"):
+        sess.run(take_t)
 
   @test_util.run_deprecated_v1
   def testTakeMany(self):


### PR DESCRIPTION
Fixes #112742

`tf.raw_ops.BarrierTakeMany` aborts the process when `num_elements` is negative:

```
F tensor_shape.cc:204] Check failed: (InitDims(dim_sizes)) is OK
  (INVALID_ARGUMENT: Expected shape dimensions to be non-negative, got -1)
Aborted (core dumped)
```

### Cause

`TakeManyOp::ComputeAsync` in `tensorflow/core/kernels/barrier_ops.cc` validates that `num_elements` is a scalar and then passes the value straight to `Barrier::TryTakeMany`. The value reaches `PriorityQueue::TryDequeueMany`, which uses it as a dimension when building the output shape, and a negative dimension is a fatal check rather than an error.

The sibling kernel already guards against this. `DequeueManyOp` in `tensorflow/core/kernels/queue_op.cc` rejects the same input:

```cpp
OP_REQUIRES_ASYNC(
    ctx, num_elements >= 0,
    absl::InvalidArgumentError(absl::StrCat("DequeueManyOp requested ",
                                            num_elements, " < 0 elements")),
    callback);
```

### Fix

`TakeManyOp` performs the same check immediately after reading the scalar, so the op fails with `InvalidArgument` instead of aborting. The message follows the wording of the existing `DequeueManyOp` check.

### Note on the issue title

The title mentions `TF_ENABLE_ONEDNN_OPTS=1`, but oneDNN is not involved. I ran the reporter's reproducer both with `TF_ENABLE_ONEDNN_OPTS=1` and with the variable unset, and both abort identically with exit 134 and the same check failure. The crash depends only on the negative `num_elements`.

### Tests

`testTakeManyNegativeNumElements` in `barrier_ops_test.py` inserts two complete elements and then takes with `num_elements=-1`, expecting `InvalidArgumentError`.

The test calls `gen_data_flow_ops.barrier_take_many` rather than `Barrier.take_many`. With the default `allow_small_batch=False`, the Python wrapper builds the output shape from the requested count and raises `ValueError: Dimension -1 must be >= 0` while constructing the graph, so it never reaches the kernel. Passing `allow_small_batch=True` avoids that but takes a different path in the queue that blocks waiting for elements. Using the raw op reproduces the reported crash directly, and matches what the reporter's script does.

`//tensorflow/python/ops:data_flow_ops_gen` is added to the test target in `tensorflow/python/kernel_tests/data_structures/BUILD` for that import, since the target uses strict dependencies.

Verified against the released 2.21.0 wheel on macOS arm64 CPU: the new test terminates the interpreter with exit 134 and the check failure above, which is why it cannot be written as a plain assertion failure against current TensorFlow, and the neighbouring `testTakeMany` passes unchanged.

### Note for reviewers

I could not build TensorFlow locally, so the C++ change has not been compiled and the new test has not been run against a patched binary. The reproducer, the oneDNN finding, the crash signature and the control case were verified against the released wheel.
