### PR TITLE
Fix out-of-bounds write in GPU bincount kernels with negative input

### DIFF
--- a/tensorflow/core/kernels/bincount_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bincount_op_gpu.cu.cc
@@ -118,7 +118,7 @@ __global__ void BincountReduceKernel(const Tidx* in, T* out, const int nthreads,
                                      const Tidx num_bins) {
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin < num_bins) {
+    if (bin >= 0 && bin < num_bins) {
       out[bin] = T(1);
     }
   }
@@ -149,7 +149,7 @@ __global__ void BincountColReduceKernel(const Tidx* in, const T* weights,
   const int nthreads = num_rows * num_cols;
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin < num_bins) {
+    if (bin >= 0 && bin < num_bins) {
       int row = index / num_cols;
       int offset = row * num_bins + bin;
       if (binary_count) {
@@ -179,7 +179,7 @@ __global__ void BincountColReduceSharedKernel(const Tidx* in, const T* weights,
   const int nthreads = num_rows * num_cols;
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin < num_bins) {
+    if (bin >= 0 && bin < num_bins) {
       int row = index / num_cols;
       int offset = row * num_bins + bin;
       if (binary_count) {

--- a/tensorflow/core/kernels/bincount_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bincount_op_gpu.cu.cc
@@ -17,6 +17,8 @@ limitations under the License.
 
 #define EIGEN_USE_GPU
 
+#include <type_traits>
+
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -118,7 +120,8 @@ __global__ void BincountReduceKernel(const Tidx* in, T* out, const int nthreads,
                                      const Tidx num_bins) {
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin >= 0 && bin < num_bins) {
+    if (static_cast<std::make_unsigned_t<Tidx>>(bin) <
+        static_cast<std::make_unsigned_t<Tidx>>(num_bins)) {
       out[bin] = T(1);
     }
   }
@@ -149,7 +152,8 @@ __global__ void BincountColReduceKernel(const Tidx* in, const T* weights,
   const int nthreads = num_rows * num_cols;
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin >= 0 && bin < num_bins) {
+    if (static_cast<std::make_unsigned_t<Tidx>>(bin) <
+        static_cast<std::make_unsigned_t<Tidx>>(num_bins)) {
       int row = index / num_cols;
       int offset = row * num_bins + bin;
       if (binary_count) {
@@ -179,7 +183,8 @@ __global__ void BincountColReduceSharedKernel(const Tidx* in, const T* weights,
   const int nthreads = num_rows * num_cols;
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin >= 0 && bin < num_bins) {
+    if (static_cast<std::make_unsigned_t<Tidx>>(bin) <
+        static_cast<std::make_unsigned_t<Tidx>>(num_bins)) {
       int row = index / num_cols;
       int offset = row * num_bins + bin;
       if (binary_count) {

--- a/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
@@ -273,6 +273,60 @@ class BincountOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
               gen_math_ops.dense_bincount(
                   input=inp, weights=np_weight, size=size, binary_output=True)))
 
+  @test_util.run_gpu_only
+  def test_bincount_all_binary_with_negative_input_on_gpu(self):
+    # Regression test for https://github.com/tensorflow/tensorflow/issues/103995
+    # BincountReduceKernel only checked `bin < num_bins`, so a negative
+    # input value indexed before the start of the output buffer on GPU
+    # (an out-of-bounds write) instead of being skipped like the CPU
+    # kernel does.
+    size = 7
+    inp = np.array(
+        [-1737321568, 32584, 7, 4, 3, 7, 7, 2, 5, 4, 1, 7, 5, 1],
+        dtype=np.int32)
+    expected_out = np.zeros((size,))
+    for v in inp:
+      if 0 <= v < size:
+        expected_out[v] = 1
+    with ops.device("/GPU:0"):
+      out = self.evaluate(
+          gen_math_ops.dense_bincount(
+              input=inp, weights=[], size=size, binary_output=True))
+    self.assertAllEqual(expected_out, out)
+
+  def _test_bincount_col_binary_with_negative_input(self, num_rows, num_cols,
+                                                      size, dtype):
+    # Regression test for the same out-of-bounds write as above, but in
+    # BincountColReduceKernel / BincountColReduceSharedKernel, which had
+    # the identical missing lower-bound check.
+    np.random.seed(42)
+    inp = np.random.randint(0, size, (num_rows, num_cols), dtype=dtype)
+    inp[0, 0] = -1737321568
+    inp[num_rows - 1, num_cols - 1] = -1
+    expected_out = np.zeros((num_rows, size))
+    for row in range(num_rows):
+      for v in inp[row]:
+        if 0 <= v < size:
+          expected_out[row, v] = 1
+    with ops.device("/GPU:0"):
+      out = self.evaluate(
+          gen_math_ops.dense_bincount(
+              input=inp, weights=[], size=size, binary_output=True))
+    self.assertAllEqual(expected_out, out)
+
+  @test_util.run_gpu_only
+  def test_col_reduce_shared_memory_with_negative_input(self):
+    # num_rows * size small enough to select BincountColReduceSharedKernel,
+    # matching test_col_reduce_shared_memory below.
+    self._test_bincount_col_binary_with_negative_input(128, 27, 10, np.int32)
+
+  @test_util.run_gpu_only
+  def test_col_reduce_global_memory_with_negative_input(self):
+    # num_rows * size large enough to select BincountColReduceKernel,
+    # matching test_col_reduce_global_memory below.
+    self._test_bincount_col_binary_with_negative_input(
+        128, 27, 1024, np.int32)
+
   def _test_bincount_col_count(self, num_rows, num_cols, size, dtype):
     np.random.seed(42)
     inp = np.random.randint(0, size, (num_rows, num_cols), dtype=dtype)

--- a/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
@@ -314,18 +314,27 @@ class BincountOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
               input=inp, weights=[], size=size, binary_output=True))
     self.assertAllEqual(expected_out, out)
 
+  @parameterized.parameters([{
+      "dtype": np.int32,
+  }, {
+      "dtype": np.int64,
+  }])
   @test_util.run_gpu_only
-  def test_col_reduce_shared_memory_with_negative_input(self):
+  def test_col_reduce_shared_memory_with_negative_input(self, dtype):
     # num_rows * size small enough to select BincountColReduceSharedKernel,
     # matching test_col_reduce_shared_memory below.
-    self._test_bincount_col_binary_with_negative_input(128, 27, 10, np.int32)
+    self._test_bincount_col_binary_with_negative_input(128, 27, 10, dtype)
 
+  @parameterized.parameters([{
+      "dtype": np.int32,
+  }, {
+      "dtype": np.int64,
+  }])
   @test_util.run_gpu_only
-  def test_col_reduce_global_memory_with_negative_input(self):
+  def test_col_reduce_global_memory_with_negative_input(self, dtype):
     # num_rows * size large enough to select BincountColReduceKernel,
     # matching test_col_reduce_global_memory below.
-    self._test_bincount_col_binary_with_negative_input(
-        128, 27, 1024, np.int32)
+    self._test_bincount_col_binary_with_negative_input(128, 27, 1024, dtype)
 
   def _test_bincount_col_count(self, num_rows, num_cols, size, dtype):
     np.random.seed(42)


### PR DESCRIPTION
## Summary

`BincountReduceKernel`, `BincountColReduceKernel`, and `BincountColReduceSharedKernel` in `tensorflow/core/kernels/bincount_op_gpu.cu.cc` only checked `bin < num_bins` before writing to the output buffer, so a negative bin value satisfies the check and indexes before the start of the output buffer, causing an out-of-bounds write on GPU. The CPU kernel already skips out-of-range bins in both directions (see `bincount_op.cc`), so this brings the GPU kernels in line with it by also checking `bin >= 0`.

Fixes #103995

## Repro (from the issue, Compute-Sanitizer)

```
========= Invalid __global__ write of size 4 bytes
=========     at void tensorflow::functor::BincountReduceKernel<int, float>(const T1 *, T2 *, int, T1)+0x110
=========     by thread (0,0,0) in block (0,0,0)
=========     Address 0x7f931dca9480 is out of bounds
```

## Test plan

- Added `test_bincount_all_binary_with_negative_input_on_gpu` covering `BincountReduceKernel` with the issue's reproduction input.
- Added `_test_bincount_col_binary_with_negative_input` (parameterized over shared-memory vs. global-memory kernel selection, matching the existing `test_col_reduce_shared_memory` / `test_col_reduce_global_memory` sizing) covering `BincountColReduceKernel` and `BincountColReduceSharedKernel`, which had the identical missing lower-bound check.
- All new tests are `@test_util.run_gpu_only` regression tests asserting negative bins are skipped rather than written out of bounds.