### PR TITLE
Fix elu second derivative for tiny negative inputs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,6 +43,14 @@ In `tensorflow/c/experimental/filesystem/filesystem_interface.h`, removed `TF_Tr
         (including the defaults) now raises an error unless automatic type
         promotion is enabled, which keeps the cost of promotion opt-in.
 
+*   `tf.nn.elu`
+
+    *   Fixes the second derivative computed by automatic differentiation for
+        small negative inputs. There `elu(x)` rounds to `0.0`, which made the
+        backward pass of the gradient take the positive branch and return `0`
+        instead of a value close to `1`. Fixes
+        [#124830](https://github.com/tensorflow/tensorflow/issues/124830).
+
 *   oneDNN (MKL) convolution and transpose kernels
 
     *   Raises `InvalidArgumentError` instead of aborting the process for a

--- a/tensorflow/python/kernel_tests/nn_ops/relu_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/relu_op_test.py
@@ -489,6 +489,14 @@ class EluTest(test.TestCase):
         err = np.abs(got - want)
         self.assertLess(err, 1e-4)
 
+      # exp(x) is 1 for tiny negative x, so elu(x) rounds to 0 and the
+      # second derivative must still take the exp branch.
+      tiny = constant_op.constant(-1e-300, dtype=dtypes.float64)
+      got = self.evaluate(f(tiny))
+      want = _elu_grad_grad(-1e-300)
+      err = np.abs(got - want)
+      self.assertLess(err, 1e-4)
+
   def testGradGradFloat32(self):
     with self.cached_session():
 

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -419,7 +419,7 @@ def _EluGradGrad(op: ops.Operation, grad):
   elu_x = op.inputs[1]
   return (gen_nn_ops.elu_grad(grad, elu_x),
           array_ops.where(
-              elu_x < 0, grad * op.inputs[0], array_ops.zeros_like(elu_x)))
+              elu_x <= 0, grad * op.inputs[0], array_ops.zeros_like(elu_x)))
 
 
 @ops.RegisterGradient("SeluGrad")


### PR DESCRIPTION
Fixes #124830

## Summary

`tf.nn.elu` returned a second derivative of `0` instead of a value close to `1` for tiny negative inputs such as `-1e-300`.

`_EluGradGrad` in `tensorflow/python/ops/nn_grad.py` masks its `where()` on the sign of its second input, which is `elu(x)`, not `x`. For small negative `x`, `exp(x) - 1` rounds to `+0.0` in floating point, so the strict `< 0` comparison is false and the positive branch is taken even though `x` is negative. Comparing against `<= 0` fixes it: `elu(x)` can only be exactly zero for `x <= 0`, every input where the old code did not sit on that boundary behaves identically, and peer frameworks take the exp branch at the boundary too.

First-order gradients are unaffected: the `EluGrad` kernel returns the same value on both sides when `elu(x)` is exactly zero.

Selu has a similar-looking problem but its kernel also needs a scale_alpha correction there (see #124831 and #124834), so it is deliberately left out of this change.

A `RELEASE.md` entry under 2.22.0 bug fixes is included.

## Testing

Reproduction on a pip tf-nightly build (`2.22.0-dev20260808`) with the patched `nn_grad.py` overlaid:

```
x=-1e-300 second_derivative=0.0   <- before the fix
x=-1e-300 second_derivative=1.0   <- after the fix, matches exp(-1e-300)
x=-0.5   second_derivative=0.6065306597126334  (unchanged)
x=0.5    second_derivative=0.0                        (unchanged)
```

Repo test file run against the same nightly build:

```
$ python tensorflow/python/kernel_tests/nn_ops/relu_op_test.py
Ran 57 tests in 1.577s

OK (skipped=13)
```

The new `testGradGrad` case fails on the unpatched nightly:

```
Ran 1 test in 0.113s

FAILED (failures=1)
```

Lint:

```
$ pylint --rcfile=tensorflow/tools/ci_build/pylintrc tensorflow/python/ops/nn_grad.py tensorflow/python/kernel_tests/nn_ops/relu_op_test.py
Your code has been rated at 10.00/10
```

Bazel was not available on the machine used to prepare this change; the nightly-overlay method above stands in for it, and the repo copy of `nn_grad.py` was byte identical to the installed nightly's copy before patching.
