### PR TITLE
Fix configure.py crash when clang reports no parseable version

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -914,12 +914,12 @@ def retrieve_clang_version(clang_executable):
 
   curr_version_split = curr_version.lower().split('clang version ')
   if len(curr_version_split) <= 1:
-    print('WARNING: current clang installation version unknown.\n')
+    sys.stdout.write('WARNING: current clang installation version unknown.\n')
     return None
 
   tokens = curr_version_split[1].split()
   if not tokens:
-    print('WARNING: current clang installation version unknown.\n')
+    sys.stdout.write('WARNING: current clang installation version unknown.\n')
     return None
 
   curr_version = tokens[0].split('git')

--- a/configure.py
+++ b/configure.py
@@ -914,7 +914,13 @@ def retrieve_clang_version(clang_executable):
 
   curr_version_split = curr_version.lower().split('clang version ')
   if len(curr_version_split) > 1:
-    curr_version = curr_version_split[1].split()[0].split('git')
+    tokens = curr_version_split[1].split()
+    if not tokens:
+      print('WARNING: current clang installation version unknown.\n')
+      return None
+    curr_version = tokens[0].split('git')
+  else:
+    curr_version = [curr_version]
 
   if len(curr_version) > 1:
     print('WARNING: current clang installation is not a release version.\n')

--- a/configure.py
+++ b/configure.py
@@ -937,7 +937,13 @@ def retrieve_clang_version(clang_executable):
 # offset of in the current version of ubp. See
 # https://github.com/protocolbuffers/upb/blob/9effcbcb27f0a665f9f345030188c0b291e32482/upb/upb.c#L183.
 def disable_clang_offsetof_extension(clang_version):
-  if int(clang_version.split('.')[0]) in (16, 17):
+  if not clang_version:
+    return
+  try:
+    clang_major_version = int(clang_version.split('.')[0])
+  except ValueError:
+    return
+  if clang_major_version in (16, 17):
     write_to_bazelrc('build --copt=-Wno-gnu-offsetof-extensions')
 
 

--- a/configure.py
+++ b/configure.py
@@ -913,14 +913,16 @@ def retrieve_clang_version(clang_executable):
                            stderr=stderr)
 
   curr_version_split = curr_version.lower().split('clang version ')
-  if len(curr_version_split) > 1:
-    tokens = curr_version_split[1].split()
-    if not tokens:
-      print('WARNING: current clang installation version unknown.\n')
-      return None
-    curr_version = tokens[0].split('git')
-  else:
-    curr_version = [curr_version]
+  if len(curr_version_split) <= 1:
+    print('WARNING: current clang installation version unknown.\n')
+    return None
+
+  tokens = curr_version_split[1].split()
+  if not tokens:
+    print('WARNING: current clang installation version unknown.\n')
+    return None
+
+  curr_version = tokens[0].split('git')
 
   if len(curr_version) > 1:
     print('WARNING: current clang installation is not a release version.\n')


### PR DESCRIPTION
Fixes #125939

## Summary

`./configure.py` aborted with a traceback when the clang executable does not report a parseable version, which happens with wrappers such as ccache (the reporter's `which clang` resolves to `/usr/lib64/ccache/clang`). Two crashes were reachable:

1. `retrieve_clang_version` returns `None` after printing "WARNING: current clang installation version unknown.", and `disable_clang_offsetof_extension` then crashed on `int(clang_version.split('.')[0])` with `AttributeError: 'NoneType' object has no attribute 'split'`. Non-numeric version strings crashed the same line with `ValueError`.
2. If the wrapper exits without printing anything to stdout, `run_shell` returns an empty string and `retrieve_clang_version` itself crashed with `IndexError: string index out of range` while taking the first character of the output.

The fix guards the consumer so unknown or non-numeric versions skip the `-Wno-gnu-offsetof-extensions` flag exactly like every confirmed version outside 16 and 17, and normalizes the parsing in `retrieve_clang_version` so empty, whitespace-only, unrecognized, adjacent-marker and truncated banners all flow into the existing unknown-version warning instead of raising.

One deliberate behavior change worth flagging: banners without a version token no longer print the misleading "current clang installation is not a release version" warning that master produced by accident (that check used to run over characters of a string instead of tokens), and a token-free banner starting with a digit is now reported as an unknown version instead of as a bogus one-digit version. Version-bearing outputs behave identically to master.

## Testing

Direct call matrix on `disable_clang_offsetof_extension`:

```
None / '' / 'unknown' -> no write, no crash
'16.0.0', '17.1.8'    -> writes build --copt=-Wno-gnu-offsetof-extensions
'22.1.8', '15.x', '18.x' -> no write, byte identical to master output
```

On master, `None` reproduced the exact error from the issue:

```
AttributeError: 'NoneType' object has no attribute 'split'
```

Monkeypatched `run_shell` harness over `retrieve_clang_version` plus the full retrieve-and-consume flow:

```
empty stdout, whitespace only, banner without token, digit-initial token-free
banner, adjacent "clang version " separators, truncated marker:
    all return None with the unknown-version warning, no crash end to end
'clang version 22.1.8'            -> returns 22.1.8
'Ubuntu clang version 18.0.0git'  -> returns 18.0.0 with prerelease warning
```

On master the empty-output input reproduced:

```
IndexError: string index out of range
```

Lint and compile:

```
$ python -m py_compile configure.py          # exit 0
$ pylint --rcfile=tensorflow/tools/ci_build/pylintrc configure.py
Your code has been rated at 10.00/10         # same as the unmodified file
```

No bazel run was needed: `configure.py` sits outside the bazel graph (the root BUILD exports it as a plain data file) and every check above exercises the changed functions directly.
