### PR TITLE
Register missing AdjustContrastv2 gradient

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,6 +34,13 @@ In `tensorflow/c/experimental/filesystem/filesystem_interface.h`, removed `TF_Tr
     * Exports `__new__` in public API golden files for subclasses of `tuple` (like `tf.io.FixedLenFeature`) to fix false positives during static type checking.>
 * `tf.data`
     * Fixes a bug in `tf.data.Dataset.scan` where the shape of the state returned by `scan_func` was not strictly validated against the initial state.
+*   `tf.image.adjust_contrast`
+
+    *   Registers the missing Python gradient for the `AdjustContrastv2` op,
+        so `tf.image.adjust_contrast` can now be differentiated with
+        `GradientTape`. Fixes
+        [#126083](https://github.com/tensorflow/tensorflow/issues/126083).
+
 *   `tf.experimental.numpy`
 
     *   `tf.experimental.numpy.isclose` and `tf.experimental.numpy.allclose` now

--- a/tensorflow/python/eager/pywrap_gradient_exclusions.cc
+++ b/tensorflow/python/eager/pywrap_gradient_exclusions.cc
@@ -429,13 +429,14 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
 
 absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedOutputIndices(
     const tensorflow::string &op_name) {
-  static std::array<OpIndexInfo, 487> a = {{
+  static std::array<OpIndexInfo, 488> a = {{
       {"Abs"},
       {"AccumulateNV2"},
       {"Acos"},
       {"Add"},
       {"AddN"},
       {"AddV2"},
+      {"AdjustContrastv2"},
       {"AllToAll"},
       {"Angle"},
       {"ApproxTopK", 1, {0}},

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -65,11 +65,12 @@ def _AdjustContrastGrad(op: ops.Operation, grad):
   images = op.inputs[0]
   factor = op.inputs[1]
   factor_t = math_ops.cast(factor, images.dtype)
-  rank = images.shape.rank
-  if rank is not None:
-    spatial_axes = list(range(rank - 3, rank - 1))
+  static_rank = images.shape.rank
+  if static_rank is not None:
+    spatial_axes = list(range(static_rank - 3, static_rank - 1))
   else:
-    spatial_axes = math_ops.range(rank - 3, rank - 1)
+    dynamic_rank = array_ops.rank(images)
+    spatial_axes = math_ops.range(dynamic_rank - 3, dynamic_rank - 1)
   mean = math_ops.reduce_mean(images, axis=spatial_axes, keepdims=True)
   grad_images = grad * factor_t + (1.0 - factor_t) * math_ops.reduce_mean(
       grad,

--- a/tensorflow/python/ops/image_grad.py
+++ b/tensorflow/python/ops/image_grad.py
@@ -47,6 +47,42 @@ def _ResizeNearestNeighborGrad(op: ops.Operation, grad):
   return [grads, None]
 
 
+@ops.RegisterGradient("AdjustContrastv2")
+def _AdjustContrastGrad(op: ops.Operation, grad):
+  """The derivatives for `tf.image.adjust_contrast`.
+
+  The kernel computes `(images - mean) * contrast_factor + mean`, where
+  `mean` is taken per batch and channel over the last three dimensions,
+  which are interpreted as [height, width, channels].
+
+  Args:
+    op: The `AdjustContrastv2` `Operation`.
+    grad: The tensor representing the gradient w.r.t. the output.
+
+  Returns:
+    The gradients w.r.t. the images and the contrast factor.
+  """
+  images = op.inputs[0]
+  factor = op.inputs[1]
+  factor_t = math_ops.cast(factor, images.dtype)
+  rank = images.shape.rank
+  if rank is not None:
+    spatial_axes = list(range(rank - 3, rank - 1))
+  else:
+    spatial_axes = math_ops.range(rank - 3, rank - 1)
+  mean = math_ops.reduce_mean(images, axis=spatial_axes, keepdims=True)
+  grad_images = grad * factor_t + (1.0 - factor_t) * math_ops.reduce_mean(
+      grad,
+      axis=spatial_axes,
+      keepdims=True,
+  )
+  grad_factor = math_ops.reduce_sum(
+      math_ops.cast(grad, dtypes.float32) *
+      (math_ops.cast(images, dtypes.float32) -
+       math_ops.cast(mean, dtypes.float32)))
+  return grad_images, grad_factor
+
+
 @ops.RegisterGradient("ResizeBilinear")
 def _ResizeBilinearGrad(op: ops.Operation, grad):
   """The derivatives for bilinear resizing.

--- a/tensorflow/python/ops/image_grad_test.py
+++ b/tensorflow/python/ops/image_grad_test.py
@@ -23,6 +23,7 @@ ResizeBicubicOpTest = test_base.ResizeBicubicOpTestBase
 ScaleAndTranslateOpTest = test_base.ScaleAndTranslateOpTestBase
 CropAndResizeOpTest = test_base.CropAndResizeOpTestBase
 RGBToHSVOpTest = test_base.RGBToHSVOpTestBase
+AdjustContrastOpTest = test_base.AdjustContrastOpTestBase
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/image_grad_test_base.py
+++ b/tensorflow/python/ops/image_grad_test_base.py
@@ -644,5 +644,37 @@ class RGBToHSVOpTestBase(test.TestCase):
     self.assertAllClose(numerical_dummy, numerical, atol=1e-4)
 
 
+class AdjustContrastOpTestBase(test.TestCase):
+  """Tests the gradient of tf.image.adjust_contrast.
+
+  The op is affine in the images and linear in the scalar factor, so
+  gradient_checker_v2 validates both slots against the real forward kernel,
+  which is what pins down the spatial reduction axes.
+  """
+
+  def testGradRank3(self):
+    self._check_gradient([4, 5, 3])
+
+  def testGradRank4(self):
+    self._check_gradient([2, 4, 5, 3])
+
+  def testGradRank5(self):
+    self._check_gradient([2, 3, 4, 5, 3])
+
+  def _check_gradient(self, shape):
+    x = np.linspace(0.05, 0.95, num=int(np.prod(shape))).reshape(shape)
+    x = x.astype(np.float32)
+    factor = constant_op.constant(1.3, dtype=dtypes.float32)
+
+    def f(image_tensor, factor_tensor):
+      return image_ops.adjust_contrast(image_tensor, factor_tensor)
+
+    with self.cached_session():
+      analytical, numerical = gradient_checker_v2.compute_gradient(
+          f, [constant_op.constant(x), factor])
+    max_error = gradient_checker_v2.max_error(analytical, numerical)
+    self.assertLess(max_error, 1e-4)
+
+
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Fixes #126083 (the `adjust_contrast` part; hue and saturation need piecewise HSV derivations and are left for separate changes)

## Summary

`tf.image.adjust_contrast` could not be used inside a `GradientTape`: differentiating it raised

```
LookupError: gradient registry has no entry for: AdjustContrastv2
```

because the raw op had no Python gradient registration, while its sibling `tf.image.adjust_brightness` works thanks to a composite wrapper.

The kernel computes `(images - mean) * factor + mean`, where `mean` is taken per batch and channel over the last three dimensions, interpreted as [height, width, channels] with any leading dimensions folded into batch. The new registration in `tensorflow/python/ops/image_grad.py` returns

- `factor * grad + (1 - factor) * mean(grad)` over those same axes for the images input,
- `sum(grad * (images - mean))` for the scalar contrast factor,

with the factor reduction formed in float32 so the half-precision path cannot overflow before the upcast.

## Testing

New `AdjustContrastOpTestBase` in `tensorflow/python/ops/image_grad_test_base.py` (wired into `image_grad_test.py`) checks the analytical gradient against finite differences of the real forward kernel via `gradient_checker_v2`, for rank 3, 4 and 5 inputs, which pins down the spatial reduction axes against the actual op rather than an assumption:

```
$ python tensorflow/python/ops/image_grad_test.py AdjustContrastOpTest
Ran 4 tests in 2.486s

OK (skipped=1)
```

That run uses a pip tf-nightly build (`2.22.0-dev20260825`) with the patched `image_grad.py` overlaid; the repo copy was byte identical to the installed one before patching. With pristine `image_grad.py` the rank 3 and rank 4 cases fail with the LookupError quoted above.

Lint:

```
$ pylint --rcfile=tensorflow/tools/ci_build/pylintrc tensorflow/python/ops/image_grad.py tensorflow/python/ops/image_grad_test_base.py tensorflow/python/ops/image_grad_test.py
Your code has been rated at 10.00/10
```

A `RELEASE.md` entry under 2.22.0 bug fixes is included. One compatibility note: downstream code that worked around this gap by registering its own `AdjustContrastv2` Python gradient will now see a duplicate-registration error at import.
