### PR TITLE
test(process_util): add negative thread test for NumInterOpThreadsFromSessionOptions

### DIFF
--- a/tensorflow/core/common_runtime/process_util_test.cc
+++ b/tensorflow/core/common_runtime/process_util_test.cc
@@ -28,6 +28,12 @@ TEST(ProcessUtilTest, NumThreads) {
   EXPECT_EQ(10, NumInterOpThreadsFromSessionOptions(opts));
 }
 
+TEST(ProcessUtilTest, NumThreadsNegative) {
+  SessionOptions opts;
+  opts.config.set_inter_op_parallelism_threads(-1);
+  EXPECT_GT(NumInterOpThreadsFromSessionOptions(opts), 0);
+}
+
 TEST(ProcessUtilTest, ThreadPool) {
   SessionOptions opts;
   opts.config.set_inter_op_parallelism_threads(10);


### PR DESCRIPTION
Rebased onto latest `master`.

Since commit 1d31888b3e0 landed the core fix and `ThreadPoolNegative` test for #124954, this PR adds `NumThreadsNegative` in `process_util_test.cc` to ensure `NumInterOpThreadsFromSessionOptions` is covered when `inter_op_parallelism_threads < 0`.
