### PR TITLE
Register missing SoftsignGrad gradient

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,6 +40,12 @@ In `tensorflow/c/experimental/filesystem/filesystem_interface.h`, removed `TF_Tr
         `tf.image.adjust_contrast` can now be differentiated with
         `GradientTape`. Fixes
         [#126083](https://github.com/tensorflow/tensorflow/issues/126083).
+*   `tf.nn.softsign`
+
+    *   Fixes second-order gradients of `tf.nn.softsign`. Differentiating twice
+        previously failed with a lookup error because the `SoftsignGrad`
+        backward op had no registered Python gradient.
+
 
 *   `tf.experimental.numpy`
 

--- a/tensorflow/python/eager/pywrap_gradient_exclusions.cc
+++ b/tensorflow/python/eager/pywrap_gradient_exclusions.cc
@@ -773,6 +773,7 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedOutputIndices(
       {"Softplus"},
       {"SoftplusGrad"},
       {"Softsign"},
+      {"SoftsignGrad"},
       {"SpaceToBatch"},
       {"SpaceToBatchND"},
       {"SpaceToDepth"},

--- a/tensorflow/python/eager/pywrap_gradient_exclusions.cc
+++ b/tensorflow/python/eager/pywrap_gradient_exclusions.cc
@@ -429,7 +429,7 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
 
 absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedOutputIndices(
     const tensorflow::string &op_name) {
-  static std::array<OpIndexInfo, 488> a = {{
+  static std::array<OpIndexInfo, 489> a = {{
       {"Abs"},
       {"AccumulateNV2"},
       {"Acos"},

--- a/tensorflow/python/kernel_tests/nn_ops/softsign_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/softsign_op_test.py
@@ -97,13 +97,14 @@ class SoftsignTest(test.TestCase):
           dy = tape.gradient(y, x)
         return tape.gradient(dy, x)
 
-      x = np.asarray(
-          [[-0.9, -0.7, -0.5, -0.3, -0.1], [0.1, 0.3, 0.5, 0.7, 0.9]],
-          dtype=np.float64,
-          order="F")
-      got = self.evaluate(f(constant_op.constant(x)))
-      want = _softsign_grad_grad(x)
-      self.assertAllClose(got, want)
+      for dtype in (np.float32, np.float64):
+        x = np.asarray(
+            [[-0.9, -0.7, -0.5, -0.3, -0.1], [0.1, 0.3, 0.5, 0.7, 0.9]],
+            dtype=dtype,
+            order="F")
+        got = self.evaluate(f(constant_op.constant(x)))
+        want = _softsign_grad_grad(x.astype(np.float64)).astype(dtype)
+        self.assertAllClose(got, want)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/nn_ops/softsign_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/softsign_op_test.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 
+from tensorflow.python.eager import backprop
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import test_util
@@ -23,6 +24,10 @@ from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import nn_ops
 import tensorflow.python.ops.nn_grad  # pylint: disable=unused-import
 from tensorflow.python.platform import test
+
+
+def _softsign_grad_grad(activation):
+  return -2 * np.sign(activation) / (1 + np.abs(activation))**3
 
 
 class SoftsignTest(test.TestCase):
@@ -81,6 +86,24 @@ class SoftsignTest(test.TestCase):
           TypeError,
           "'features' has DataType int32 not in list of allowed values"):
         nn_ops.softsign(constant_op.constant(7)).eval()
+
+  def testGradGrad(self):
+    with self.cached_session():
+
+      def f(x):
+        with backprop.GradientTape(persistent=True) as tape:
+          tape.watch(x)
+          y = nn_ops.softsign(x)
+          dy = tape.gradient(y, x)
+        return tape.gradient(dy, x)
+
+      x = np.asarray(
+          [[-0.9, -0.7, -0.5, -0.3, -0.1], [0.1, 0.3, 0.5, 0.7, 0.9]],
+          dtype=np.float64,
+          order="F")
+      got = self.evaluate(f(constant_op.constant(x)))
+      want = _softsign_grad_grad(x)
+      self.assertAllClose(got, want)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -495,10 +495,11 @@ def _SoftsignGrad(op: ops.Operation, grad):
 @ops.RegisterGradient("SoftsignGrad")
 def _SoftsignGradGrad(op: ops.Operation, grad):
   x = op.inputs[1]
+  denominator = 1.0 + math_ops.abs(x)
   return (
       gen_nn_ops.softsign_grad(grad, x),
       -2.0 * grad * op.inputs[0] * math_ops.sign(x) /
-      math_ops.pow(1.0 + math_ops.abs(x), 3),
+      (denominator * denominator * denominator),
   )
 
 

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -492,6 +492,16 @@ def _SoftsignGrad(op: ops.Operation, grad):
   return gen_nn_ops.softsign_grad(grad, op.inputs[0])
 
 
+@ops.RegisterGradient("SoftsignGrad")
+def _SoftsignGradGrad(op: ops.Operation, grad):
+  x = op.inputs[1]
+  return (
+      gen_nn_ops.softsign_grad(grad, x),
+      -2.0 * grad * op.inputs[0] * math_ops.sign(x) /
+      math_ops.pow(1.0 + math_ops.abs(x), 3),
+  )
+
+
 @ops.RegisterGradient("ReluGrad")
 def _ReluGradGrad(op: ops.Operation, grad):
   x = op.inputs[1]


### PR DESCRIPTION
## Summary

Differentiating through `tf.nn.softsign` twice fails with

```
LookupError: gradient registry has no entry for: SoftsignGrad
```

because the `SoftsignGrad` backward op has no Python gradient registration, while every sibling activation backward op (`ReluGrad`, `EluGrad`, `SeluGrad`, `SoftplusGrad`) has one in `tensorflow/python/ops/nn_grad.py`.

The kernel (`tensorflow/core/kernels/softsign_op.h`) computes `gradients / (1 + |features|)^2`, so the new registration returns

- `softsign_grad(grad, features)` for the gradients input (reusing the kernel), and
- `-2 * grad * upstream * sign(features) / (1 + |features|)^3` for the features input,

which makes second derivatives of `tf.nn.softsign` work for the first time.

Found by sweeping autodiff second derivatives of public activations against analytic formulas; found while working on this, `LRNGrad` has the same kind of gap and is handled in a separate change (#126083 describes the `tf.image` variants).

## Testing

Reproduction on a pip tf-nightly build (`2.22.0-dev20260808`) with the patched `nn_grad.py` overlaid (the repo master copy was byte identical to the installed one before patching):

```
second derivative at x=0.5 before fix:
LookupError: gradient registry has no entry for: SoftsignGrad
after fix: matches -2*sign(x)/(1+|x|)^3 at
x in {-0.9, -0.5, -0.1, 0.0, 0.1, 0.5, 0.9} to 1e-12
```

Repo test file against the same nightly:

```
$ python tensorflow/python/kernel_tests/nn_ops/softsign_op_test.py
Ran 5 tests in 0.461s

OK (skipped=1)
```

including the new `testGradGrad`; with pristine `nn_grad.py` that test fails with the LookupError above.

Lint:

```
$ pylint --rcfile=tensorflow/tools/ci_build/pylintrc tensorflow/python/ops/nn_grad.py tensorflow/python/kernel_tests/nn_ops/softsign_op_test.py
Your code has been rated at 10.00/10
```

A `RELEASE.md` entry under 2.22.0 bug fixes is included.
