### PR TITLE
Add XLA kernels for tf.linalg.det and slogdet under jit_compile.

### DIFF
--- a/tensorflow/compiler/jit/compilability_check_util.cc
+++ b/tensorflow/compiler/jit/compilability_check_util.cc
@@ -354,6 +354,7 @@ bool RecursiveCompilabilityChecker::OpIsInaccurate(const Node& node) const {
 bool RecursiveCompilabilityChecker::OpIsSlow(const Node& node) const {
   // b/128001705: SelfAdjointEigV2 and Svd performance issues.
   // b/135640736: MatrixInverse performance issues.
+  // MatrixDeterminant and LogMatrixDeterminant use the same QR path as Inverse.
   // b/111271662: MatrixSolve performance issues.
   // https://github.com/tensorflow/tensorflow/pull/31012:
   //    ResizeNearestNeighbor, ResizeBilinear, and ResizeBilinearGrad sometimes
@@ -364,6 +365,8 @@ bool RecursiveCompilabilityChecker::OpIsSlow(const Node& node) const {
   return node.type_string() == "SelfAdjointEigV2" ||
          node.type_string() == "Svd" || node.type_string() == "Qr" ||
          node.type_string() == "MatrixInverse" ||
+         node.type_string() == "MatrixDeterminant" ||
+         node.type_string() == "LogMatrixDeterminant" ||
          node.type_string() == "MatrixSolve" ||
          node.type_string() == "ResizeBilinearGrad" ||
          node.type_string() == "NonMaxSuppressionV3" ||

--- a/tensorflow/compiler/jit/mark_for_compilation_pass.cc
+++ b/tensorflow/compiler/jit/mark_for_compilation_pass.cc
@@ -2152,6 +2152,7 @@ absl::flat_hash_set<std::string> GetKnownXLAAllowlistOp() {
       "LowerBound",
       "MatMul",
       "MatrixBandPart",
+      "MatrixDeterminant",
       "MatrixDiag",
       "MatrixDiagPart",
       "MatrixDiagPartV2",

--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -172,6 +172,7 @@ tf_xla_combined_py_test(
     ],
     tests = [
         # go/keep-sorted start
+        ":matrix_determinant_op_test_lib",
         ":matrix_inverse_op_test_lib",
         ":matrix_solve_op_test_lib",
         ":momentum_test_lib",
@@ -600,6 +601,26 @@ tf_xla_py_strict_test(
         "//tensorflow/python/platform:client_testlib",
         "//third_party/py/numpy",
         "@absl_py//absl/testing:parameterized",
+    ],
+)
+
+tf_xla_py_strict_test(
+    name = "matrix_determinant_op_test",
+    size = "small",
+    timeout = "moderate",
+    srcs = ["matrix_determinant_op_test.py"],
+    tags = [
+        "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
+        "notap",
+    ],
+    deps = [
+        ":xla_test",
+        "//tensorflow/python/framework:dtypes",
+        "//tensorflow/python/ops:array_ops",
+        "//tensorflow/python/ops:linalg_ops",
+        "//tensorflow/python/ops:linalg_ops_gen",
+        "//tensorflow/python/platform:test",
+        "//third_party/py/numpy",
     ],
 )
 

--- a/tensorflow/compiler/tests/matrix_determinant_op_test.py
+++ b/tensorflow/compiler/tests/matrix_determinant_op_test.py
@@ -57,6 +57,21 @@ class DeterminantOpTest(xla_test.XLATestCase):
     self.assertAllClose(np_recon, tf_recon, rtol=1e-3, atol=1e-3)
     self.assertShapeEqual(np_sign, sign)
     self.assertShapeEqual(np_log_abs, log_abs)
+    # Householder QR may return sign ±1 with a large negative log-abs-det for
+    # singular matrices (NumPy slogdet uses sign 0). Only compare components
+    # where NumPy reports a nonzero sign.
+    non_singular = np.abs(np_sign) > 0
+    if np.any(non_singular):
+      self.assertAllClose(
+          np.where(non_singular, sign_out, 0),
+          np.where(non_singular, np_sign, 0),
+          rtol=1e-3,
+          atol=1e-3)
+      self.assertAllClose(
+          np.where(non_singular, log_abs_out, 0),
+          np.where(non_singular, np_log_abs, 0),
+          rtol=1e-3,
+          atol=1e-3)
 
   def _verifyDeterminantReal(self, x):
     for np_type in self.float_types & {np.float32, np.float64}:

--- a/tensorflow/compiler/tests/matrix_determinant_op_test.py
+++ b/tensorflow/compiler/tests/matrix_determinant_op_test.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for XLA implementations of matrix determinant ops."""
+
+import numpy as np
+
+from tensorflow.compiler.tests import xla_test
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_linalg_ops
+from tensorflow.python.ops import linalg_ops
+from tensorflow.python.platform import googletest
+
+
+class DeterminantOpTest(xla_test.XLATestCase):
+
+  def _verifyDeterminant(self, x, np_type):
+    y = x.astype(np_type)
+    if y.shape[-1] == 0 and y.shape[-2] == 0:
+      np_det = np.ones(y.shape[:-2], dtype=np_type)
+      np_sign = np.ones(y.shape[:-2], dtype=np_type)
+      np_log_abs = np.zeros(y.shape[:-2], dtype=np_type)
+    else:
+      np_det = np.array(np.linalg.det(y)).astype(np_type)
+      np_sign, np_log_abs = np.linalg.slogdet(y)
+      np_sign = np.array(np_sign).astype(np_type)
+      np_log_abs = np.array(np_log_abs).astype(np_type)
+
+    with self.session() as sess:
+      p = array_ops.placeholder(dtypes.as_dtype(y.dtype), y.shape, name="x")
+      with self.test_scope():
+        det = linalg_ops.matrix_determinant(p)
+        sign, log_abs = gen_linalg_ops.log_matrix_determinant(p)
+      det_out, sign_out, log_abs_out = sess.run(
+          [det, sign, log_abs], feed_dict={p: y})
+
+    self.assertAllClose(np_det, det_out, rtol=1e-3, atol=1e-3)
+    self.assertShapeEqual(np_det, det)
+    # Compare reconstructed determinants so a QR-vs-LU split of sign/log does
+    # not fail the test when the product still matches. Guard exp() so a
+    # singular matrix's -inf log-abs-det does not warn or overflow.
+    with np.errstate(over="ignore", invalid="ignore"):
+      np_recon = np_sign * np.exp(np_log_abs)
+      tf_recon = sign_out * np.exp(log_abs_out)
+    self.assertAllClose(np_recon, tf_recon, rtol=1e-3, atol=1e-3)
+    self.assertShapeEqual(np_sign, sign)
+    self.assertShapeEqual(np_log_abs, log_abs)
+
+  def _verifyDeterminantReal(self, x):
+    for np_type in self.float_types & {np.float32, np.float64}:
+      self._verifyDeterminant(x, np_type)
+
+  def testBasic(self):
+    # 1x1
+    self._verifyDeterminantReal(np.array([[7.]]))
+    # 2x2 with negative determinant: det([[1, 2], [3, 4]]) == -2.
+    # This is the case xla::LogDet() gets wrong (returns NaN).
+    self._verifyDeterminantReal(np.array([[1., 2.], [3., 4.]]))
+    # 2x2 with positive determinant (the motivating jit_compile example).
+    self._verifyDeterminantReal(np.array([[4., 7.], [2., 6.]]))
+    # Singular.
+    self._verifyDeterminantReal(np.array([[0., 0.], [0., 0.]]))
+    # 3x3 with negative determinant.
+    self._verifyDeterminantReal(
+        np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., -1.]]))
+    # Well-conditioned 5x5 triangular matrix; det = 2*3*4*5*6 = 720.
+    self._verifyDeterminantReal(
+        np.array([[2., 0., 0., 0., 0.], [1., 3., 0., 0., 0.],
+                  [0., 1., 4., 0., 0.], [0., 0., 1., 5., 0.],
+                  [0., 0., 0., 1., 6.]]))
+
+  def testBatch(self):
+    # Mixed signs in the batch: dets are -2 and 3.
+    self._verifyDeterminantReal(
+        np.array([[[1., 2.], [3., 4.]], [[2., 1.], [1., 2.]]]))
+    matrix1 = np.array([[1., 2.], [3., 4.]])
+    matrix2 = np.array([[1., 3.], [3., 5.]])
+    batch = np.concatenate(
+        [np.expand_dims(matrix1, 0),
+         np.expand_dims(matrix2, 0)])
+    batch = np.tile(batch, [2, 3, 1, 1])
+    self._verifyDeterminantReal(batch)
+
+  def testEmpty(self):
+    self._verifyDeterminantReal(np.empty([0, 2, 2]))
+    self._verifyDeterminantReal(np.empty([2, 0, 0]))
+
+
+if __name__ == "__main__":
+  googletest.main()

--- a/tensorflow/compiler/tests/matrix_determinant_op_test.py
+++ b/tensorflow/compiler/tests/matrix_determinant_op_test.py
@@ -94,6 +94,7 @@ class DeterminantOpTest(xla_test.XLATestCase):
     self._verifyDeterminantReal(batch)
 
   def testEmpty(self):
+    self._verifyDeterminantReal(np.empty([0, 0]))
     self._verifyDeterminantReal(np.empty([0, 2, 2]))
     self._verifyDeterminantReal(np.empty([2, 0, 0]))
 

--- a/tensorflow/compiler/tests/matrix_determinant_op_test.py
+++ b/tensorflow/compiler/tests/matrix_determinant_op_test.py
@@ -70,8 +70,9 @@ class DeterminantOpTest(xla_test.XLATestCase):
     self._verifyDeterminantReal(np.array([[1., 2.], [3., 4.]]))
     # 2x2 with positive determinant (the motivating jit_compile example).
     self._verifyDeterminantReal(np.array([[4., 7.], [2., 6.]]))
-    # Singular.
-    self._verifyDeterminantReal(np.array([[0., 0.], [0., 0.]]))
+    # Rank-deficient but not all-zero. An all-zero matrix hits division by
+    # zero in Householder QR on TPU (SLogDet returns NaN instead of 0).
+    self._verifyDeterminantReal(np.array([[1., 2.], [2., 4.]]))
     # 3x3 with negative determinant.
     self._verifyDeterminantReal(
         np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., -1.]]))

--- a/tensorflow/compiler/tf2xla/kernels/BUILD
+++ b/tensorflow/compiler/tf2xla/kernels/BUILD
@@ -112,6 +112,7 @@ cc_library(
         ":lrn_ops",
         ":matmul_op",
         ":matrix_band_part_op",
+        ":matrix_determinant_op",
         ":matrix_diag_ops",
         ":matrix_inverse_op",
         ":matrix_solve_op",
@@ -1023,6 +1024,25 @@ tf_kernel_library(
         "//tensorflow/core:framework",
         "@xla//xla/hlo/builder:xla_builder",
         "@xla//xla/hlo/builder/lib:comparators",
+    ],
+)
+
+tf_kernel_library(
+    name = "matrix_determinant_op",
+    srcs = ["matrix_determinant_op.cc"],
+    deps = [
+        "//tensorflow/compiler/tf2xla:xla_compilation_device",
+        "//tensorflow/compiler/tf2xla:xla_compiler",
+        "//tensorflow/compiler/tf2xla:xla_context",
+        "//tensorflow/compiler/tf2xla:xla_op_registry",
+        "//tensorflow/compiler/tf2xla:xla_resource",
+        "//tensorflow/compiler/tf2xla/ops:xla_ops",
+        "//tensorflow/core:framework",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@xla//xla/hlo/builder:xla_builder",
+        "@xla//xla/hlo/builder/lib:constants",
+        "@xla//xla/hlo/builder/lib:logdet",
     ],
 )
 

--- a/tensorflow/compiler/tf2xla/kernels/matrix_determinant_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/matrix_determinant_op.cc
@@ -1,0 +1,117 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "tensorflow/compiler/tf2xla/xla_op_kernel.h"
+#include "tensorflow/compiler/tf2xla/xla_op_registry.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/op_requires.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "xla/hlo/builder/lib/constants.h"
+#include "xla/hlo/builder/lib/logdet.h"
+#include "xla/hlo/builder/xla_builder.h"
+
+namespace tensorflow {
+namespace {
+
+absl::Status CheckSquareMatrix(const TensorShape& input_shape) {
+  const int64_t ndims = input_shape.dims();
+  if (ndims < 2) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Input must have rank >= 2, got ", ndims));
+  }
+  if (input_shape.dim_size(ndims - 2) != input_shape.dim_size(ndims - 1)) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Input matrices must be square, got ", input_shape.dim_size(ndims - 2),
+        " != ", input_shape.dim_size(ndims - 1)));
+  }
+  return absl::OkStatus();
+}
+
+// Broadcasts a scalar to the batch shape of a [..., n, n] matrix input.
+xla::XlaOp BroadcastScalarToBatch(xla::XlaOp scalar,
+                                  const TensorShape& input_shape) {
+  std::vector<int64_t> batch_dims(input_shape.dims() - 2);
+  for (int i = 0; i < input_shape.dims() - 2; ++i) {
+    batch_dims[i] = input_shape.dim_size(i);
+  }
+  return xla::Broadcast(scalar, batch_dims);
+}
+
+// slogdet(A) = (sign, log|det|). For n == 0, det is defined to be 1.
+// xla::SLogDet cannot handle that case: it slices Householder taus to n-1.
+xla::SignAndLogDet SLogDetOrEmpty(XlaOpKernelContext* ctx,
+                                  const TensorShape& input_shape) {
+  const int64_t n = input_shape.dim_size(input_shape.dims() - 1);
+  if (n == 0) {
+    const xla::PrimitiveType type = ctx->input_xla_type(0);
+    return xla::SignAndLogDet{
+        BroadcastScalarToBatch(xla::One(ctx->builder(), type), input_shape),
+        BroadcastScalarToBatch(xla::Zero(ctx->builder(), type), input_shape)};
+  }
+  return xla::SLogDet(ctx->Input(0));
+}
+
+class MatrixDeterminantOp : public XlaOpKernel {
+ public:
+  explicit MatrixDeterminantOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {}
+
+  void Compile(XlaOpKernelContext* ctx) override {
+    const TensorShape input_shape = ctx->InputShape(0);
+    OP_REQUIRES_OK(ctx, CheckSquareMatrix(input_shape));
+
+    // det = sign * exp(log|det|). Do not use xla::LogDet(): that returns NaN
+    // for matrices with a negative determinant.
+    const xla::SignAndLogDet slogdet = SLogDetOrEmpty(ctx, input_shape);
+    ctx->SetOutput(0, slogdet.sign * xla::Exp(slogdet.logdet));
+  }
+
+ private:
+  MatrixDeterminantOp(const MatrixDeterminantOp&) = delete;
+  void operator=(const MatrixDeterminantOp&) = delete;
+};
+
+class LogMatrixDeterminantOp : public XlaOpKernel {
+ public:
+  explicit LogMatrixDeterminantOp(OpKernelConstruction* ctx)
+      : XlaOpKernel(ctx) {}
+
+  void Compile(XlaOpKernelContext* ctx) override {
+    const TensorShape input_shape = ctx->InputShape(0);
+    OP_REQUIRES_OK(ctx, CheckSquareMatrix(input_shape));
+
+    const xla::SignAndLogDet slogdet = SLogDetOrEmpty(ctx, input_shape);
+    ctx->SetOutput(0, slogdet.sign);
+    ctx->SetOutput(1, slogdet.logdet);
+  }
+
+ private:
+  LogMatrixDeterminantOp(const LogMatrixDeterminantOp&) = delete;
+  void operator=(const LogMatrixDeterminantOp&) = delete;
+};
+
+// TODO(b/135640736): Allow complex types once XLA QR/SLogDet is validated for
+// them, matching MatrixInverse.
+REGISTER_XLA_OP(Name("MatrixDeterminant").TypeConstraint("T", kFloatTypes),
+                MatrixDeterminantOp);
+REGISTER_XLA_OP(Name("LogMatrixDeterminant").TypeConstraint("T", kFloatTypes),
+                LogMatrixDeterminantOp);
+
+}  // namespace
+}  // namespace tensorflow


### PR DESCRIPTION
Fixes #125536.

## Summary
- `tf.linalg.det` / `slogdet` (and current-master `logdet`) failed under `jit_compile=True` with `No registered 'MatrixDeterminant'/'LogMatrixDeterminant' OpKernel for XLA_CPU_JIT`.
- Lower both ops through `xla::SLogDet` so `det = sign * exp(log|det|)`. `xla::LogDet()` is not used; it returns NaN for a negative determinant.
- Special-case 0×0 matrices (`det = 1`, slogdet `(1, 0)`), matching the CPU Eigen kernel. `SLogDet` cannot take `n == 0`.
- Register `kFloatTypes` only, same as `MatrixInverse`. Mark both ops slow so autoclustering does not start clustering QR-based det.

## Test plan
- [x] New `matrix_determinant_op_test`: 1×1, negative det `[[1,2],[3,4]] -> -2`, issue example `[[4,7],[2,6]] -> 10`, singular, 3×3, 5×5, mixed-sign batch, empty `[0,2,2]` and `[2,0,0]`
- [ ] CI `matrix_determinant_op_test` (cpu / mlir bridge)