### PR TITLE
Security: fix heap out-of-bounds read in TFLite SLICE (unvalidated negative `begin`)

### DIFF
--- a/tensorflow/lite/kernels/slice.cc
+++ b/tensorflow/lite/kernels/slice.cc
@@ -59,19 +59,25 @@ TfLiteStatus CalculateOutputShapeVector(TfLiteContext* context,
                                         const TfLiteTensor* size,
                                         std::vector<int>* output_shape_vector) {
   for (int idx = 0; idx < NumDimensions(input); ++idx) {
-    T size_value = GetTensorData<T>(size)[idx];
+    // Widen to int64_t so that `begin_value + size_value` below cannot overflow
+    // the index type: for T = int32_t, begin = INT32_MAX and size = 1 would
+    // otherwise wrap to a negative value and pass the bounds check.
+    const int64_t dim_size = SizeOfDimension(input, idx);
+    const int64_t begin_value = GetTensorData<T>(begin)[idx];
+    if (begin_value < 0 || begin_value > dim_size) {
+      TF_LITE_KERNEL_LOG(context, "Invalid begin.");
+      return kTfLiteError;
+    }
+    int64_t size_value = GetTensorData<T>(size)[idx];
     if (size_value < 0) {
       if (size_value != -1) {
         TF_LITE_KERNEL_LOG(context, "Invalid size.");
         return kTfLiteError;
       }
-      size_value = SizeOfDimension(input, idx) - GetTensorData<T>(begin)[idx];
-    } else {
-      if (SizeOfDimension(input, idx) <
-          GetTensorData<T>(begin)[idx] + size_value) {
-        TF_LITE_KERNEL_LOG(context, "Invalid begin and size.");
-        return kTfLiteError;
-      }
+      size_value = dim_size - begin_value;
+    } else if (begin_value + size_value > dim_size) {
+      TF_LITE_KERNEL_LOG(context, "Invalid begin and size.");
+      return kTfLiteError;
     }
     output_shape_vector->push_back(static_cast<int>(size_value));
   }

--- a/tensorflow/lite/kernels/slice.cc
+++ b/tensorflow/lite/kernels/slice.cc
@@ -75,7 +75,7 @@ TfLiteStatus CalculateOutputShapeVector(TfLiteContext* context,
         return kTfLiteError;
       }
       size_value = dim_size - begin_value;
-    } else if (begin_value + size_value > dim_size) {
+    } else if (size_value > dim_size - begin_value) {
       TF_LITE_KERNEL_LOG(context, "Invalid begin and size.");
       return kTfLiteError;
     }

--- a/tensorflow/lite/kernels/slice_test.cc
+++ b/tensorflow/lite/kernels/slice_test.cc
@@ -214,6 +214,35 @@ TEST_P(SliceOpTest, SizeMinus1) {
   EXPECT_THAT(m.GetOutput(), ElementsAreArray({3, 3, 3, 5, 5, 5}));
 }
 
+// `begin` must lie in [0, dim_size]. Previously it was not validated: a
+// negative `begin` combined with `size == -1` produced `size = dim_size -
+// begin`, an output larger than the input, and the kernel then read outside the
+// input tensor and copied that memory into the output.
+TEST(SliceOpValidationTest, NegativeBeginWithSizeMinus1IsRejected) {
+  SliceOpModel<int32_t, int32_t> m({4}, {1}, {-1}, {1}, {-1}, TensorType_INT32,
+                                   TensorType_INT32, TestType::kDynamic);
+  m.SetInput({1, 2, 3, 4});
+  EXPECT_NE(m.Invoke(), kTfLiteOk);
+}
+
+TEST(SliceOpValidationTest, NegativeBeginWithExplicitSizeIsRejected) {
+  SliceOpModel<int32_t, int32_t> m({4}, {1}, {-1}, {1}, {2}, TensorType_INT32,
+                                   TensorType_INT32, TestType::kDynamic);
+  m.SetInput({1, 2, 3, 4});
+  EXPECT_NE(m.Invoke(), kTfLiteOk);
+}
+
+// Regression: begin = INT32_MAX with size = 1 previously wrapped when
+// `begin + size` was computed in the index type, satisfying the bounds check and
+// letting the kernel read far outside the input. It is now rejected.
+TEST(SliceOpValidationTest, BeginPlusSizeOverflowIsRejected) {
+  SliceOpModel<int32_t, int32_t> m({4}, {1}, {2147483647}, {1}, {1},
+                                   TensorType_INT32, TensorType_INT32,
+                                   TestType::kDynamic);
+  m.SetInput({1, 2, 3, 4});
+  EXPECT_NE(m.Invoke(), kTfLiteOk);
+}
+
 TEST_P(SliceOpTest, BeginNonZeroSizeMinus1Axis1) {
   SliceOpModel<int32_t, int32_t> m({3, 3, 2, 1}, {4}, {1, 1, 0, 0}, {4},
                                    {2, -1, 1, 1}, TensorType_INT32,


### PR DESCRIPTION
> **Security impact:** heap out-of-bounds **read** (CWE-125). The out-of-bounds
> values are copied into the op's output tensor, so they are returned to the
> caller. Verified to disclose a co-resident model's data — see *Demonstrated
> impact* below. Affects 2.21.0 and master.

`CalculateOutputShapeVector` (`tensorflow/lite/kernels/slice.cc`) validates `size`
but never validates `begin`.

On the `size == -1` path — the documented "rest of this dimension" idiom — the
kernel computes `size_value = SizeOfDimension(input, idx) - begin`. A negative
`begin` makes that *larger* than the dimension, and nothing re-checks it. On the
other path the guard `dim < begin + size` is *weakened* by a negative `begin`,
so arbitrarily negative offsets are accepted.

A second defect in the same check: `begin + size` was evaluated in the index
type, so `begin = INT32_MAX, size = 1` wrapped past the guard entirely.

`begin` and `size` are runtime tensors — no graph modification is needed. A model
that takes its slice window as input hits this with ordinary input values.

### First invalid access (ASan, master)

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 260 at 0x5150000002bc
    #0 __asan_memcpy
    #1 tflite::optimized_ops::Slice<int>             portable_tensor.h:130
    #2 tflite::ops::builtin::slice::Eval<kOptimized> optimized_ops.h:4776
    #3 tflite::Subgraph::InvokeImpl                  subgraph.cc

0x5150000002bc is located 4 bytes before a 448-byte region
allocated by tflite::SimpleMemoryArena::Commit       simple_memory_arena.cc:444
```

### Leak volume is exactly `|begin|`

Input `[64]` int32; a second tensor in the same graph holds a marker:

| begin | size | output len | marker words returned |
|------:|-----:|-----------:|----------------------:|
| 0 | -1 | 64 | 0 *(correct behaviour)* |
| -1 | -1 | 65 | 1 |
| -4 | -1 | 68 | 4 |
| -16 | -1 | 80 | 16 |
| -64 | 8 | 8 | 8 |

Both the offset and the length are chosen by the caller.

### Demonstrated impact: data recovered from a published model

Tested against **`lite-model_ssd_mobilenet_v1_1_metadata_2`** (SSD MobileNet v1)
and **`lite-model_deeplabv3_1_metadata_2`**, both loaded unmodified from disk and
served in the same process as the slicing model — the ordinary multi-model
serving arrangement. The victim was fed a synthetic marker input and invoked; the
other model then sent `begin = -1048576, size = -1` and nothing else.

| | TF 2.21.0 | master |
|---|---|---|
| SSD MobileNet v1 — marker words recovered | **67,518** | **67,500** |
| DeepLab v3 | 298,340 | 298,967 |

67,500 is exactly the victim's input size, i.e. its entire served input was
returned to the other model. Controls:

- **benign** (`begin = 0`) returns the correct slice and leaks **zero**
- **differential** — refill the victim with a different byte and the recovered
  pattern changes with it, same count, so the bytes are the victim's and not an
  allocator artefact
- identical across three fresh processes

Only synthetic markers were used; no real data was accessed.

### The fix

Validate `begin` against `[0, dim_size]` and widen the bounds arithmetic to
`int64_t`, mirroring what `tensorflow/core/kernels/slice_op.cc` already does for
the same op:

```c
OP_REQUIRES(context, 0 <= b && b <= input.dim_size(i), ...);
OP_REQUIRES(context, 0 <= s && b + s <= input.dim_size(i), ...);
```

Note `int64_t b` / `int64_t s` there — that is also what prevents the overflow.

### Tests

Three regression tests in `slice_test.cc`: negative `begin` with `size == -1`,
negative `begin` with an explicit size, and the `INT32_MAX` overflow case. I
verified the new logic against every existing case in that file (`In1D`, `In2D`,
`SizeMinus1`, `BeginNonZeroSizeMinus1Axis1/2/3`, …) — all produce identical
output shapes.

Reported to Google as issue **552566525**. Not compile-tested (no Bazel
environment) — please run CI.
