### PR TITLE
Validate strides/rates in Dilation2D and widen effective-filter arithmetic

### DIFF
--- a/tensorflow/core/kernels/dilation_ops.cc
+++ b/tensorflow/core/kernels/dilation_ops.cc
@@ -53,6 +53,9 @@ void ParseAttributes(OpKernelConstruction* context,
   OP_REQUIRES(context, (*strides)[0] == 1 && (*strides)[3] == 1,
               absl::UnimplementedError(
                   "Stride is only supported across spatial dimensions."));
+  OP_REQUIRES(
+      context, (*strides)[1] >= 1 && (*strides)[2] >= 1,
+      absl::OutOfRangeError("Strides in the spatial dimensions must be >= 1."));
 
   OP_REQUIRES_OK(context, context->GetAttr("rates", rates));
   OP_REQUIRES(context, rates->size() == 4,
@@ -61,6 +64,9 @@ void ParseAttributes(OpKernelConstruction* context,
   OP_REQUIRES(context, (*rates)[0] == 1 && (*rates)[3] == 1,
               absl::UnimplementedError(
                   "Rate is only supported across spatial dimensions."));
+  OP_REQUIRES(
+      context, (*rates)[1] >= 1 && (*rates)[2] >= 1,
+      absl::OutOfRangeError("Rates in the spatial dimensions must be >= 1."));
 
   OP_REQUIRES_OK(context, context->GetAttr("padding", padding));
 }
@@ -103,10 +109,12 @@ void ParseSizes(OpKernelContext* context, const std::vector<int32_t>& strides,
 
   // Effective filter size, after introducing rate - 1 zeros between each
   // non-zero filter element.
-  const int filter_rows_eff =
-      filter_rows + (filter_rows - 1) * (*rate_rows - 1);
-  const int filter_cols_eff =
-      filter_cols + (filter_cols - 1) * (*rate_cols - 1);
+  const int64_t filter_rows_eff =
+      static_cast<int64_t>(filter_rows) +
+      static_cast<int64_t>(filter_rows - 1) * (*rate_rows - 1);
+  const int64_t filter_cols_eff =
+      static_cast<int64_t>(filter_cols) +
+      static_cast<int64_t>(filter_cols - 1) * (*rate_cols - 1);
 
   OP_REQUIRES_OK(context, GetWindowedOutputSize(
                               input_rows, filter_rows_eff, /*dilation_rate=*/1,

--- a/tensorflow/core/kernels/dilation_ops.cc
+++ b/tensorflow/core/kernels/dilation_ops.cc
@@ -55,7 +55,8 @@ void ParseAttributes(OpKernelConstruction* context,
                   "Stride is only supported across spatial dimensions."));
   OP_REQUIRES(
       context, (*strides)[1] >= 1 && (*strides)[2] >= 1,
-      absl::OutOfRangeError("Strides in the spatial dimensions must be >= 1."));
+      absl::InvalidArgumentError(
+          "Strides in the spatial dimensions must be >= 1."));
 
   OP_REQUIRES_OK(context, context->GetAttr("rates", rates));
   OP_REQUIRES(context, rates->size() == 4,
@@ -66,7 +67,8 @@ void ParseAttributes(OpKernelConstruction* context,
                   "Rate is only supported across spatial dimensions."));
   OP_REQUIRES(
       context, (*rates)[1] >= 1 && (*rates)[2] >= 1,
-      absl::OutOfRangeError("Rates in the spatial dimensions must be >= 1."));
+      absl::InvalidArgumentError(
+          "Rates in the spatial dimensions must be >= 1."));
 
   OP_REQUIRES_OK(context, context->GetAttr("padding", padding));
 }


### PR DESCRIPTION
`ParseAttributes` in `dilation_ops.cc` validates that `strides` and `rates` have
four entries and that entries 0 and 3 are 1, but never checks that the **spatial
entries are positive**. Zero and negative values reach the kernel.

`ParseSizes` then computes the effective filter size in `int`:

```c
const int filter_rows_eff = filter_rows + (filter_rows - 1) * (*rate_rows - 1);
```

A negative rate makes this negative directly; a large negative one overflows.
`GetWindowedOutputSizeVerbose` rejects `stride <= 0` and a negative *output*
size, but not a negative *filter* size — with `dilation_rate == 1` the effective
filter size passes straight through, so
`output_size = (input - negative + stride) / stride` comes out larger than the
input and positive, and the guard passes.

### Observed (2.22.0-dev, input `2x4x4x2`, filter `2x2x2`, strides 1)

| `rates` | result |
|---|---|
| `[1,0,0,1]` | accepted, output `2x4x4x2` |
| `[1,-1,-1,1]` | accepted, output `2x5x5x2` |
| `[1,-100,-100,1]` | accepted, output `2x104x104x2` — larger than the input |
| `[1,INT32_MIN,INT32_MIN,1]` | **process abort** |

```
F tensor_shape.cc:204] Check failed: InitDims(dim_sizes) is OK
  (INVALID_ARGUMENT: Encountered overflow when multiplying 4294967304 with 2147483652)
    @ tensorflow::TensorShapeBase<>::TensorShapeBase()
    @ tensorflow::DilationOp<>::Compute()
```

The `CHECK` is inside `TensorShape`'s constructor, so a caller cannot catch it.

### Relationship to 210e2943a0f7

This mirrors ["Fix integer overflow DoS in ExtractImagePatches and
ExtractVolumePatches"](https://github.com/tensorflow/tensorflow/commit/210e2943a0f7bb6df2f2cd0dc35457e7092bafae),
which routed attribute parsing through `ParseAttributeVec4` (enforcing
`(*attr)[1] >= 1 && (*attr)[2] >= 1`) and widened the shape arithmetic to
`int64_t`. `Dilation2D` is the structural sibling — same sliding-window family,
same `strides`/`rates` attributes, same effective-filter computation — and
received neither change. With the same inputs above, `ExtractImagePatches`
already returns `OutOfRangeError` for every non-positive rate.

### Scope

`ParseAttributes` is shared by `Dilation2D`, `Dilation2DBackpropInput` and
`Dilation2DBackpropFilter`, so all three are covered. Valid rates/strides
(`>= 1`) are unaffected.

Note: the behaviour above was verified against a released build; I do not have a
Bazel build environment to compile-test the patch itself, so please run it
through CI.
