### PR TITLE
Add an OSS-Fuzz target for the TensorFlow Lite interpreter

### DIFF
--- a/tensorflow/lite/fuzzing/BUILD
+++ b/tensorflow/lite/fuzzing/BUILD
@@ -1,0 +1,22 @@
+# Fuzzing harnesses for the TensorFlow Lite runtime.
+
+load(
+    "//tensorflow/security/fuzzing:tf_fuzzing.bzl",
+    "tf_cc_fuzz_test",
+)
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = ["//visibility:private"],
+    licenses = ["notice"],
+)
+
+tf_cc_fuzz_test(
+    name = "interpreter_fuzz",
+    srcs = ["interpreter_fuzz.cc"],
+    deps = [
+        "//tensorflow/lite:framework",
+        "//tensorflow/lite/core:framework",
+        "//tensorflow/lite/kernels:builtin_ops",
+    ],
+)

--- a/tensorflow/lite/fuzzing/interpreter_fuzz.cc
+++ b/tensorflow/lite/fuzzing/interpreter_fuzz.cc
@@ -81,10 +81,12 @@ void FuzzInterpreter(const std::string& model_bytes) {
         tensor->type == kTfLiteVariant) {
       return;
     }
-    total_bytes += tensor->bytes;
-    if (total_bytes > kMaxArenaBytes) {
+    // Check before accumulating so the sum itself cannot wrap.
+    if (tensor->bytes > kMaxArenaBytes ||
+        total_bytes > kMaxArenaBytes - tensor->bytes) {
       return;
     }
+    total_bytes += tensor->bytes;
     std::memset(tensor->data.raw, 1, tensor->bytes);
   }
 

--- a/tensorflow/lite/fuzzing/interpreter_fuzz.cc
+++ b/tensorflow/lite/fuzzing/interpreter_fuzz.cc
@@ -1,0 +1,97 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Fuzzes the TensorFlow Lite interpreter end to end: an arbitrary buffer is
+// verified as a flatbuffer model, an interpreter is built for it, tensors are
+// allocated, inputs are filled deterministically, and the graph is invoked.
+//
+// This exercises the builtin kernel implementations, the arena planner and the
+// shape-propagation paths, none of which previously had OSS-Fuzz coverage.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "fuzztest/fuzztest.h"
+#include "tensorflow/lite/core/interpreter.h"
+#include "tensorflow/lite/core/interpreter_builder.h"
+#include "tensorflow/lite/core/model_builder.h"
+#include "tensorflow/lite/kernels/register.h"
+
+namespace tflite {
+namespace fuzzing {
+namespace {
+
+// Keep the fuzzer inside the OSS-Fuzz memory budget. Models and arenas larger
+// than this are not interesting: they exercise the allocator, not the kernels.
+constexpr size_t kMaxModelBytes = 1 << 20;   // 1 MiB
+constexpr size_t kMaxArenaBytes = 1 << 26;   // 64 MiB
+
+void FuzzInterpreter(const std::string& model_bytes) {
+  if (model_bytes.size() < 8 || model_bytes.size() > kMaxModelBytes) {
+    return;
+  }
+
+  // VerifyAndBuildFromBuffer applies tflite::VerifyModelBuffer first, so
+  // structurally invalid buffers are rejected cheaply.
+  std::unique_ptr<FlatBufferModel> model =
+      FlatBufferModel::VerifyAndBuildFromBuffer(model_bytes.data(),
+                                                model_bytes.size());
+  if (model == nullptr) {
+    return;
+  }
+
+  // Delegates are excluded so the fuzzer exercises the reference and optimized
+  // CPU kernels rather than a delegate's own implementation.
+  ops::builtin::BuiltinOpResolverWithoutDefaultDelegates resolver;
+  std::unique_ptr<Interpreter> interpreter;
+  if (InterpreterBuilder(*model, resolver)(&interpreter) != kTfLiteOk ||
+      interpreter == nullptr) {
+    return;
+  }
+
+  if (interpreter->AllocateTensors() != kTfLiteOk) {
+    return;
+  }
+
+  size_t total_bytes = 0;
+  for (const int tensor_index : interpreter->inputs()) {
+    TfLiteTensor* tensor = interpreter->tensor(tensor_index);
+    if (tensor == nullptr || tensor->data.raw == nullptr) {
+      continue;
+    }
+    // String tensors own a dynamic buffer with its own layout; writing raw
+    // bytes into it would corrupt the interpreter rather than the kernel under
+    // test.
+    if (tensor->type == kTfLiteString || tensor->type == kTfLiteResource ||
+        tensor->type == kTfLiteVariant) {
+      return;
+    }
+    total_bytes += tensor->bytes;
+    if (total_bytes > kMaxArenaBytes) {
+      return;
+    }
+    std::memset(tensor->data.raw, 1, tensor->bytes);
+  }
+
+  interpreter->Invoke();
+}
+FUZZ_TEST(TfLiteFuzz, FuzzInterpreter);
+
+}  // namespace
+}  // namespace fuzzing
+}  // namespace tflite


### PR DESCRIPTION
TensorFlow Lite currently has **no OSS-Fuzz coverage**.

`projects/tensorflow` builds 29 fuzz targets (`tf_cc_fuzz_test` rules under
`tensorflow/security/fuzzing/cc`, `tensorflow/core/framework`,
`tensorflow/core/common_runtime` and `tensorflow/cc/saved_model`). They cover TF
core ops, framework types, path/string helpers and the GraphDef/SavedModel
loaders. Nothing under `tensorflow/lite/` is fuzzed — the builtin kernels, the
arena planner and the shape-propagation paths have no coverage at all.

This adds one end-to-end harness: an arbitrary buffer is verified as a
flatbuffer model, an interpreter is built for it, tensors are allocated, inputs
are filled deterministically, and the graph is invoked. That reaches the builtin
kernel implementations through the same path a real caller uses, so a single
target covers a large fraction of `tensorflow/lite/kernels`.

### Design notes

- **`VerifyAndBuildFromBuffer`** runs `tflite::VerifyModelBuffer` first, so
  structurally invalid buffers are rejected cheaply instead of being handed to
  the interpreter. This keeps the fuzzer spending its time in kernels rather
  than in flatbuffer rejection.
- **`BuiltinOpResolverWithoutDefaultDelegates`** so the fuzzer exercises the
  reference and optimized CPU kernels rather than whichever delegate happens to
  be linked in.
- **Bounded** model size (1 MiB) and total input-arena size (64 MiB), to stay
  inside the OSS-Fuzz memory budget. Larger models exercise the allocator, not
  the kernels, and just produce OOM reports.
- **String / resource / variant inputs are skipped.** Those tensors own a
  dynamic buffer with its own internal layout; writing raw bytes into them would
  corrupt interpreter state rather than test a kernel, producing false reports.

### Notes for reviewers

I do not have a Bazel build environment large enough to compile TensorFlow, so
this has not been compile-tested — please run it through CI. The BUILD rule
follows the same `tf_cc_fuzz_test` pattern as
`tensorflow/cc/saved_model/BUILD`'s `saved_model_fuzz`, and all three deps
(`//tensorflow/lite:framework`, `//tensorflow/lite/core:framework`,
`//tensorflow/lite/kernels:builtin_ops`) are publicly visible in OSS.

Happy to adjust the size bounds, the resolver choice, or split the harness if
you would prefer several narrower targets (for example one per kernel family).
