### PR TITLE
fix int truncation of sparse batch index in SparseCount

### DIFF
--- a/tensorflow/core/kernels/count_ops.cc
+++ b/tensorflow/core/kernels/count_ops.cc
@@ -267,7 +267,7 @@ class SparseCount : public OpKernel {
     }
 
     bool is_1d = shape.NumElements() == 1;
-    int num_batches = is_1d ? 1 : shape_vector(0);
+    int64_t num_batches = is_1d ? 1 : shape_vector(0);
     OP_REQUIRES(context, 0 < num_batches && num_batches < kMaxBatches,
                 absl::InvalidArgumentError(
                     absl::StrCat("Cannot allocate ", num_batches,
@@ -280,7 +280,7 @@ class SparseCount : public OpKernel {
     T max_value = 0;
 
     for (int idx = 0; idx < num_values; ++idx) {
-      int batch = is_1d ? 0 : indices_values(idx, 0);
+      int64_t batch = is_1d ? 0 : indices_values(idx, 0);
       if (batch >= num_batches) {
         OP_REQUIRES(context, batch < num_batches,
                     absl::InvalidArgumentError(absl::StrCat(

--- a/tensorflow/core/kernels/count_ops_test.cc
+++ b/tensorflow/core/kernels/count_ops_test.cc
@@ -230,5 +230,39 @@ TEST_F(SparseCountLimitTest, Basic) {
   EXPECT_EQ(shape(1), int64_t{3});  // max_value + 1
 }
 
+// A dense_shape batch dimension wider than int32 must not be silently truncated
+// to a small num_batches. Before the fix, dense_shape[0] = 2^32 + 5 truncated to
+// 5 while an index of 2^31 (still < dense_shape[0], so it passes index
+// validation) truncated to a negative int32 batch that slipped past the
+// batch < num_batches check and indexed per_batch_counts out of bounds.
+TEST_F(SparseCountLimitTest, DenseShapeBatchDimTooWide) {
+  TF_ASSERT_OK(NodeDefBuilder("sparse_count", "SparseCountSparseOutput")
+                   .Input(FakeInput(DT_INT64))
+                   .Input(FakeInput(DT_INT32))
+                   .Input(FakeInput(DT_INT64))
+                   .Input(FakeInput(DT_INT64))
+                   .Attr("T", DT_INT32)
+                   .Attr("minlength", -1)
+                   .Attr("maxlength", -1)
+                   .Attr("binary_output", false)
+                   .Attr("output_type", DT_INT64)
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  const int64_t kBatchDim = (int64_t{1} << 32) + 5;  // > kMaxBatches
+  const int64_t kBadBatch = int64_t{1} << 31;        // < kBatchDim, wraps < 0
+
+  // Indices: [[2^31, 0]]
+  AddInputFromArray<int64_t>(TensorShape({1, 2}), {kBadBatch, 0});
+  // Values: [1]
+  AddInputFromArray<int32_t>(TensorShape({1}), {1});
+  // Shape: [2^32 + 5, 3]
+  AddInputFromArray<int64_t>(TensorShape({2}), {kBatchDim, 3});
+  // Weights: []
+  AddInputFromArray<int64_t>(TensorShape({0}), {});
+
+  EXPECT_FALSE(RunOpKernel().ok());
+}
+
 }  // namespace
 }  // namespace tensorflow


### PR DESCRIPTION
SparseCount (tf.raw_ops.SparseCountSparseOutput) reads the batch dimension from the untrusted dense_shape into `int num_batches` and each row's batch id from the indices matrix into `int batch`, both narrowing int64 to int. The per-index validation runs at full int64 width, so a dense_shape[0] above INT_MAX truncates to a small positive count that passes the width guard, while an index of 2^31 (still within the shape, so it validates) truncates to a negative batch that slips past the `batch < num_batches` check and indexes per_batch_counts out of bounds. Widen both to int64_t so the width guard and the batch bound apply at full width, which rejects the oversize shape instead.