### PR TITLE
Make `tf.experimental.numpy.fabs` always return a floating point result

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -784,7 +784,9 @@ def absolute(x):
 @tf_export.tf_export('experimental.numpy.fabs', v1=[])
 @np_utils.np_doc('fabs')
 def fabs(x):
-  return abs(x)
+  # Unlike `absolute`, `fabs` always produces a floating point result,
+  # so an integer argument has to be promoted first.
+  return _scalar(math_ops.abs, x, True)
 
 
 @tf_export.tf_export('experimental.numpy.ceil', v1=[])

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -687,6 +687,30 @@ class MathTest(test.TestCase, parameterized.TestCase):
         )
 
 
+  def testFabsAlwaysReturnsFloat(self):
+    # `fabs` differs from `absolute` in that its result is always floating
+    # point, so an integer argument is promoted rather than passed through.
+    int_args = [
+        [1, -2, 3],
+        -5,
+        np.array([1, -2, 3], dtype=np.int32),
+        np.array([1, -2, 3], dtype=np.int64),
+        np.array([], dtype=np.int32),
+        np.array([[1, -2], [3, -4]], dtype=np.int32),
+    ]
+    for arg in int_args:
+      self.match(
+          np_math_ops.fabs(arg), np.fabs(arg), msg='fabs({})'.format(arg)
+      )
+
+    # A floating point argument keeps its own dtype.
+    for dtype in [np.float16, np.float32, np.float64]:
+      arg = np.array([1.5, -2.5], dtype=dtype)
+      self.match(
+          np_math_ops.fabs(arg), np.fabs(arg), msg='fabs({})'.format(arg)
+      )
+
+
 if __name__ == '__main__':
   tensor.enable_tensor_equality()
   ops.enable_eager_execution()


### PR DESCRIPTION
`tnp.fabs` hands back an integer when given an integer, where numpy gives a float:

```python
>>> import numpy as np, tensorflow.experimental.numpy as tnp
>>> a = np.array([1, -2, 3], dtype=np.int32)
>>> tnp.fabs(a).dtype
tf.int32
>>> np.fabs(a).dtype
dtype('float64')
```

Returning a float is the entire difference between `fabs` and `absolute` — it's why both exist — and the docstring that `np_doc('fabs')` generates points at numpy's, which documents the result as always floating point.

The cause is that `fabs` was written as `return abs(x)`, so it picked up `absolute`'s dtype behaviour along with its values:

```python
def absolute(x):
  return abs(x)

def fabs(x):
  return abs(x)
```

`absolute` aliasing `abs` is right, since `np.absolute` does preserve the input dtype. `fabs` doing it is not.

The fix passes `promote_to_float=True` to `_scalar()`, which is how `ceil`, `floor`, `log` and the other always-float unary ops in this file already do it. `_scalar()` only casts a dtype that isn't already inexact, so floating point arguments are untouched and `float16`/`float32` inputs keep their own dtype, matching numpy.

### Checking it

I compared against numpy across int32, int64, Python ints, empty integer arrays, 2-D integer arrays, and float16/32/64. Before the change five of those disagree, all of them integer cases; after it all eight agree on dtype, shape and values, and the float cases are byte-for-byte what they were.

I couldn't build with Bazel here, so I verified by dropping the current `np_math_ops.py` from master into the installed wheel and running the repo's own tests against it, unfixed and fixed. The new test fails before the change with

```
AssertionError: tf.int64 != dtype('float64') : Dtype mismatch.
```

and passes after. Full `np_math_ops_test.py` is 62 tests OK, and `np_math_ops_no_numpy_methods_test`, `np_logic_test` and `np_utils_test` are clean. `np_array_ops_test` has 2 failures and 3 errors, but it has exactly the same five with `np_math_ops.py` reverted to master, so they're pre-existing and nothing to do with this.

The values don't change here, only the dtype, so the test asserts the dtype rather than just comparing numbers — `assert_allclose` would happily pass either way.

One difference I left alone: `np.fabs` rejects complex input with a `TypeError` while `tnp.fabs` returns the magnitude, since complex is already inexact and falls straight through to `math_ops.abs`. That's a behaviour change rather than a dtype correction and it would need its own discussion, so it isn't part of this.