### PR TITLE
Security: fix heap out-of-bounds read in TFLite SLICE (Prepare skips bounds validation)

### DIFF
--- a/tensorflow/lite/kernels/slice.cc
+++ b/tensorflow/lite/kernels/slice.cc
@@ -145,7 +145,16 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, NumElements(begin), NumElements(size));
   // If the shape of output is fully specified then resize even if
   // the input shape is not staticly defined.
-  if (!HasUnspecifiedDimension(output) && ShapeHasRank(output->dims)) {
+  //
+  // A fully specified output shape does not imply the slice is in bounds when
+  // the input extent is only known at run time. Taking this path leaves the
+  // output static, so Eval() -- which only re-runs ResizeOutputShape() for a
+  // dynamic output -- never reaches CalculateOutputShapeVector(), the one place
+  // `begin` and `size` are checked against the input. Fall through when the
+  // input has an unspecified dimension so the output is marked dynamic and the
+  // bounds are validated against the actual extent on every invocation.
+  if (!HasUnspecifiedDimension(output) && ShapeHasRank(output->dims) &&
+      !HasUnspecifiedDimension(input)) {
     return kTfLiteOk;
   }
   // Postpone allocation of output if any of the indexing tensors is not

--- a/tensorflow/lite/kernels/slice.cc
+++ b/tensorflow/lite/kernels/slice.cc
@@ -153,8 +153,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // `begin` and `size` are checked against the input. Fall through when the
   // input has an unspecified dimension so the output is marked dynamic and the
   // bounds are validated against the actual extent on every invocation.
-  if (!HasUnspecifiedDimension(output) && ShapeHasRank(output->dims) &&
-      !HasUnspecifiedDimension(input)) {
+  if (ShapeHasRank(output->dims) && !HasUnspecifiedDimension(output) &&
+      ShapeHasRank(input->dims) && !HasUnspecifiedDimension(input)) {
     return kTfLiteOk;
   }
   // Postpone allocation of output if any of the indexing tensors is not

--- a/tensorflow/lite/kernels/slice_test.cc
+++ b/tensorflow/lite/kernels/slice_test.cc
@@ -119,7 +119,12 @@ class DynamicInputSliceOpModel : public SingleOpModel {
     output_ = AddOutput(output_data);
     SetBuiltinOp(BuiltinOperator_SLICE, BuiltinOptions_SliceOptions,
                  CreateSliceOptions(builder_).Union());
-    BuildInterpreter({input_data.shape, begin_shape, size_shape});
+    // Delegates are bypassed: a delegate that claims the SLICE node would set
+    // the output allocation type itself, so the assertions below would no
+    // longer describe the built-in CPU kernel.
+    BuildInterpreter({input_data.shape, begin_shape, size_shape},
+                     /*num_threads=*/-1, /*allow_fp32_relax_to_fp16=*/false,
+                     /*apply_delegate=*/false);
   }
 
   void SetInput(std::initializer_list<float> data) {

--- a/tensorflow/lite/kernels/slice_test.cc
+++ b/tensorflow/lite/kernels/slice_test.cc
@@ -102,6 +102,68 @@ class SliceOpModel : public SingleOpModel {
 
 class SliceOpTest : public ::testing::TestWithParam<TestType> {};
 
+// Model with a dynamic input dimension and a statically shaped output. The
+// suite name is deliberately distinct from SliceOpTest, which is a TEST_P
+// fixture -- gtest rejects a suite that mixes TEST and TEST_P.
+class DynamicInputSliceOpModel : public SingleOpModel {
+ public:
+  DynamicInputSliceOpModel(TensorData input_data,
+                           std::initializer_list<int> begin_shape,
+                           std::initializer_list<int32_t> begin_data,
+                           std::initializer_list<int> size_shape,
+                           std::initializer_list<int32_t> size_data,
+                           TensorData output_data) {
+    input_ = AddInput(input_data);
+    begin_ = AddConstInput(TensorType_INT32, begin_data, begin_shape);
+    size_ = AddConstInput(TensorType_INT32, size_data, size_shape);
+    output_ = AddOutput(output_data);
+    SetBuiltinOp(BuiltinOperator_SLICE, BuiltinOptions_SliceOptions,
+                 CreateSliceOptions(builder_).Union());
+    BuildInterpreter({input_data.shape, begin_shape, size_shape});
+  }
+
+  void SetInput(std::initializer_list<float> data) {
+    PopulateTensor<float>(input_, data);
+  }
+  std::vector<float> GetOutput() { return ExtractVector<float>(output_); }
+  std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
+  const TfLiteTensor* GetOutputTensor() {
+    return interpreter_->tensor(output_);
+  }
+
+ private:
+  int input_;
+  int begin_;
+  int size_;
+  int output_;
+};
+
+// A dynamic input dimension must force the output dynamic so the bounds are
+// re-validated in Eval(), even though the declared output shape is static.
+TEST(SliceOpDynamicInputTest, DynamicInputStaticOutputValid) {
+  TensorData input_data(TensorType_FLOAT32, {1, 8});
+  input_data.shape_signature = {1, -1};
+  TensorData output_data(TensorType_FLOAT32, {1, 4});
+
+  DynamicInputSliceOpModel m(input_data, {2}, {0, 2}, {2}, {1, 4}, output_data);
+  m.SetInput({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 4}));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({3.0, 4.0, 5.0, 6.0}));
+  EXPECT_EQ(m.GetOutputTensor()->allocation_type, kTfLiteDynamic);
+}
+
+// The same path must reject a window that does not fit the actual extent.
+TEST(SliceOpDynamicInputTest, DynamicInputStaticOutputOutOfBounds) {
+  TensorData input_data(TensorType_FLOAT32, {1, 4});
+  input_data.shape_signature = {1, -1};
+  TensorData output_data(TensorType_FLOAT32, {1, 8});
+
+  DynamicInputSliceOpModel m(input_data, {2}, {0, 0}, {2}, {1, 8}, output_data);
+  m.SetInput({1.0, 2.0, 3.0, 4.0});
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+}
+
 TEST_P(SliceOpTest, In1D) {
   SliceOpModel<float, int32_t> m({4}, {1}, {1}, {1}, {2}, TensorType_INT32,
                                  TensorType_FLOAT32, GetParam());


### PR DESCRIPTION
> **Security impact:** heap out-of-bounds **read** (CWE-125). `Prepare()` returns
> before the only bounds check runs, and `Eval()` never re-runs it, so `begin`
> and `size` are never validated against the input's actual extent. Verified to
> disclose a co-resident published model's data — see *Demonstrated impact*.
> Affects 2.21.0 and master.

`Prepare()` in `tensorflow/lite/kernels/slice.cc` short-circuits when the output
shape is fully specified:

```c
// If the shape of output is fully specified then resize even if
// the input shape is not staticly defined.
if (!HasUnspecifiedDimension(output) && ShapeHasRank(output->dims)) {
  return kTfLiteOk;
}
```

That path returns **without** calling `SetTensorToDynamic(output)` and **without**
validating anything. `Eval()` only re-runs `ResizeOutputShape()` for a dynamic
output:

```c
if (IsDynamicTensor(output)) {
  TF_LITE_ENSURE_OK(context, ResizeOutputShape(context, input, begin, size, output));
}
```

so `CalculateOutputShapeVector()` — the single place `begin` and `size` are
checked against the input — never runs.

A fully specified *output* shape says nothing about whether the slice fits the
*input* when the input extent is only known at run time. A model declaring
`[1, None]` with a constant slice window is a completely ordinary shape for
sequence models; feeding it a short sequence makes the kernel read past the
input.

### Over-read is severe and the benign path is clean

Model: input `[1, None]`, constant `begin = [0, 1024]`, `size = [1, 4096]`.

| runtime input length | output words | words not from the input |
|---:|---:|---:|
| 8 | 4096 | **4096** |
| 64 | 4096 | 4095 |
| 5000 | 4096 | 8 |
| **5120 (fits)** | 4096 | **0** |

With an 8-element input, none of the 4096 returned words come from it.

### Demonstrated impact: data recovered from a published model

Tested against **`lite-model_ssd_mobilenet_v1_1_metadata_2`** (SSD MobileNet v1),
loaded unmodified from disk and served in the same process. The victim was fed a
synthetic marker input and invoked; the slicing model then ran.

| | result |
|---|---|
| marker words recovered | **67,500 — exactly the victim's input size** |
| across 3 fresh processes | identical each time |
| **benign control** (window fits the input) | **0** |
| **differential** — victim refilled with a different byte | recovered pattern changes with it, same count |

Reaching the victim's memory in that direction required a `begin` the converter
will not emit, so that particular demonstration used a model whose constant was
edited after conversion. The **validation gap itself needs no such thing** — the
over-read above is produced by an ordinary converter-produced model with a short
runtime input. Only synthetic markers were used; no real data was accessed.

### The fix

Fall through when the input has an unspecified dimension, so the output is marked
dynamic and the bounds are validated against the actual extent on every
invocation. Models with fully static shapes keep the existing fast path.

### Tests

No new test: `SliceOpModel`'s constructor takes a plain `initializer_list<int>`
for the input shape, so expressing "dynamic input dimension + fully specified
output" needs the harness extended, which I did not want to do without being able
to build it. Existing `slice_test.cc` cases are unaffected — all use static input
shapes, where the fast path still applies. Happy to add a test if you would like
the harness extended.

Not compile-tested (no Bazel environment) — please run CI.
