### PR TITLE
Fix axis bounds check in np.diff for negative axes

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1164,7 +1164,8 @@ def diff(a, n=1, axis=-1):  # pylint: disable=missing-function-docstring
           'Function `diff` currently requires a known rank for input `a`. '
           f'Received: a={a} (unknown rank)'
       )
-    if (axis + nd if axis < 0 else axis) >= nd:
+    axis_normalized = axis + nd if axis < 0 else axis
+    if axis_normalized < 0 or axis_normalized >= nd:
       raise ValueError(
           f'Argument `axis` (received axis={axis}) is out of bounds '
           f'for input {a} of rank {nd}.'

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -656,6 +656,16 @@ class MathTest(test.TestCase, parameterized.TestCase):
     self.match(
         np_math_ops.diff(np_array_ops.array([True, False, True])),
         np.diff(np.array([True, False, True])))
+    # Dtype and value parity for float inputs and n=0.
+    self.match(
+        np_math_ops.diff(np_array_ops.array([1.5, 2.5, 4.0], np.float32)),
+        np.diff(np.array([1.5, 2.5, 4.0], dtype=np.float32)))
+    self.match(
+        np_math_ops.diff(np_array_ops.array([1, 3, 6]), n=0),
+        np.diff(np.array([1, 3, 6], dtype=np.int32), n=0))
+    # NumPy raises ValueError for 0-d inputs too.
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.diff(np_array_ops.array(5))
     with self.assertRaisesRegex(ValueError, 'out of bounds'):
       np_math_ops.diff(a, axis=2)
     with self.assertRaisesRegex(ValueError, 'out of bounds'):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -651,7 +651,7 @@ class MathTest(test.TestCase, parameterized.TestCase):
     self.match(np_math_ops.diff(a, axis=0), np.diff(a, axis=0))
     self.match(np_math_ops.diff(a, axis=-1), np.diff(a, axis=-1))
     self.match(np_math_ops.diff(a, n=2, axis=1), np.diff(a, n=2, axis=1))
-    self.match(np_math_ops.diff(np_array_ops.array([1, 3, 6])),
+    self.match(np_math_ops.diff(np_array_ops.array([1, 3, 6], dtype=np.int32)),
                np.diff(np.array([1, 3, 6], dtype=np.int32)))
     self.match(
         np_math_ops.diff(np_array_ops.array([True, False, True])),
@@ -661,7 +661,7 @@ class MathTest(test.TestCase, parameterized.TestCase):
         np_math_ops.diff(np_array_ops.array([1.5, 2.5, 4.0], np.float32)),
         np.diff(np.array([1.5, 2.5, 4.0], dtype=np.float32)))
     self.match(
-        np_math_ops.diff(np_array_ops.array([1, 3, 6]), n=0),
+        np_math_ops.diff(np_array_ops.array([1, 3, 6], dtype=np.int32), n=0),
         np.diff(np.array([1, 3, 6], dtype=np.int32), n=0))
     # NumPy raises ValueError for 0-d inputs too.
     with self.assertRaisesRegex(ValueError, 'out of bounds'):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -645,6 +645,22 @@ class MathTest(test.TestCase, parameterized.TestCase):
     with self.assertRaises(ValueError):
       a2.flatten('invalid')
 
+  def testDiff(self):
+    a = np_array_ops.array([[1, 2, 3], [4, 6, 8]])
+    self.match(np_math_ops.diff(a), np.diff(a))
+    self.match(np_math_ops.diff(a, axis=0), np.diff(a, axis=0))
+    self.match(np_math_ops.diff(a, axis=-1), np.diff(a, axis=-1))
+    self.match(np_math_ops.diff(a, n=2, axis=1), np.diff(a, n=2, axis=1))
+    self.match(np_math_ops.diff(np_array_ops.array([1, 3, 6])),
+               np.diff(np.array([1, 3, 6], dtype=np.int32)))
+    self.match(
+        np_math_ops.diff(np_array_ops.array([True, False, True])),
+        np.diff(np.array([True, False, True])))
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.diff(a, axis=2)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.diff(a, axis=-3)
+
   def testIsInf(self):
     x1 = ops.convert_to_tensor(-2147483648)
     x2 = ops.convert_to_tensor(2147483647)


### PR DESCRIPTION
The axis validation in `np.diff` only rejects positive out-of-bounds axes:

```python
if (axis + nd if axis < 0 else axis) >= nd:
```

A negative axis below `-ndim` (e.g. `axis=-3` on a rank-2 array) slips through this check and later crashes with an unrelated `IndexError` when building the slice lists, instead of raising a clear error like NumPy's `AxisError`.

This normalizes the axis before the bounds check so both directions are validated. Added `testDiff` covering the basic cases and both out-of-bounds directions.

Validated locally with `py_compile` and `git diff --check`. The numpy_ops bazel tests could not be run locally (no Bazel build available); `tensorflow/python/ops/numpy_ops:np_math_ops_test` covers `testDiff`.
