### PR TITLE
Validate axis bounds in np.moveaxis

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1036,7 +1036,6 @@ def moveaxis(a, source, destination):  # pylint: disable=missing-docstring
       return axis + rank if axis < 0 else axis
     rank_t = ops.convert_to_tensor(rank)
     axis_t = ops.convert_to_tensor(axis)
-    axis_t = ops.convert_to_tensor(axis)
     control_flow_assert.Assert(
         math_ops.reduce_all(
             math_ops.logical_and(axis_t >= -rank_t, axis_t < rank_t)

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1022,20 +1022,20 @@ def moveaxis(a, source, destination):  # pylint: disable=missing-docstring
   a_rank = np_utils._maybe_static(array_ops.rank(a))  # pylint: disable=protected-access
 
   def _correct_axis(axis, rank):
-    if isinstance(axis, (int, np.integer)) and isinstance(rank, (int, np.integer)):
+    if (
+        isinstance(axis, (int, np.integer))
+        and isinstance(rank, (int, np.integer))
+    ):
       axis = int(axis)
       rank = int(rank)
-      normalized = axis + rank if axis < 0 else axis
-      if normalized < 0 or normalized >= rank:
+      if not (-rank <= axis < rank):
         raise ValueError(
             f'Argument `axis` (received axis={axis}) is out of bounds '
             f'for input {a} of rank {rank}.'
         )
-      return normalized
-    # Rank is only known at runtime: assert the bounds dynamically so
-    # out-of-bounds axes are rejected consistently with `swapaxes`,
-    # instead of producing a perm with leftover negative entries.
+      return axis + rank if axis < 0 else axis
     rank_t = ops.convert_to_tensor(rank)
+    axis_t = ops.convert_to_tensor(axis)
     axis_t = ops.convert_to_tensor(axis)
     control_flow_assert.Assert(
         math_ops.reduce_all(
@@ -1048,7 +1048,11 @@ def moveaxis(a, source, destination):  # pylint: disable=missing-docstring
   source = tuple(_correct_axis(axis, a_rank) for axis in source)
   destination = tuple(_correct_axis(axis, a_rank) for axis in destination)
 
-  if a.shape.rank is not None:
+  if (
+      isinstance(a_rank, (int, np.integer))
+      and builtins.all(isinstance(x, (int, np.integer)) for x in source)
+      and builtins.all(isinstance(x, (int, np.integer)) for x in destination)
+  ):
     perm = [i for i in range(a_rank) if i not in source]
     for dest, src in sorted(zip(destination, source)):
       assert dest <= len(perm)

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1022,7 +1022,9 @@ def moveaxis(a, source, destination):  # pylint: disable=missing-docstring
   a_rank = np_utils._maybe_static(array_ops.rank(a))  # pylint: disable=protected-access
 
   def _correct_axis(axis, rank):
-    if isinstance(rank, int):
+    if isinstance(axis, (int, np.integer)) and isinstance(rank, (int, np.integer)):
+      axis = int(axis)
+      rank = int(rank)
       normalized = axis + rank if axis < 0 else axis
       if normalized < 0 or normalized >= rank:
         raise ValueError(

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1022,9 +1022,26 @@ def moveaxis(a, source, destination):  # pylint: disable=missing-docstring
   a_rank = np_utils._maybe_static(array_ops.rank(a))  # pylint: disable=protected-access
 
   def _correct_axis(axis, rank):
-    if axis < 0:
-      return axis + rank
-    return axis
+    if isinstance(rank, int):
+      normalized = axis + rank if axis < 0 else axis
+      if normalized < 0 or normalized >= rank:
+        raise ValueError(
+            f'Argument `axis` (received axis={axis}) is out of bounds '
+            f'for input {a} of rank {rank}.'
+        )
+      return normalized
+    # Rank is only known at runtime: assert the bounds dynamically so
+    # out-of-bounds axes are rejected consistently with `swapaxes`,
+    # instead of producing a perm with leftover negative entries.
+    rank_t = ops.convert_to_tensor(rank)
+    axis_t = ops.convert_to_tensor(axis)
+    control_flow_assert.Assert(
+        math_ops.reduce_all(
+            math_ops.logical_and(axis_t >= -rank_t, axis_t < rank_t)
+        ),
+        ['axis', axis_t, 'is out of bounds for array of dimension', rank_t],
+    )
+    return array_ops.where_v2(axis_t < 0, np_utils.add(axis_t, rank_t), axis_t)
 
   source = tuple(_correct_axis(axis, a_rank) for axis in source)
   destination = tuple(_correct_axis(axis, a_rank) for axis in destination)

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -1314,6 +1314,11 @@ class ArrayMethodsTest(test.TestCase):
     _test(a, tuple(range(6)), tuple(reversed(range(6))))
     _test(a, (), ())
 
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.moveaxis(a, -8, 0)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.moveaxis(a, 0, 8)
+
   def testFlip(self):
     np.random.seed(0)
     random_seed.set_seed(0)


### PR DESCRIPTION
`np.moveaxis` promises in its docstring to raise `ValueError` for out-of-bounds `source`/`destination` axes, but never actually validated them:

- Positive out-of-bounds axes hit an unrelated `AssertionError` from `assert dest <= len(perm)`.
- Negative axes below `-rank` (e.g. `source=-8` on a rank-6 array) produced a `perm` with leftover negative entries, which eager silently re-normalizes while XLA compilation fails with opaque errors.

This normalizes and validates axes when the rank is statically known, raising a clear error matching `np.moveaxis`'s `AxisError` in NumPy, and asserts the bounds at runtime for dynamically-known ranks — mirroring the `swapaxes` fix for issue #122054 (PR #122544). Added out-of-bounds regression tests for both directions.

Validated locally with `py_compile` and `git diff --check`. The numpy_ops bazel tests could not be run locally (no Bazel build available); `tensorflow/python/ops/numpy_ops:np_array_ops_test` covers `testMoveaxis`.
