### PR TITLE
Validate axis bounds in experimental.numpy argsort, sort, concatenate, and count_nonzero

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1487,10 +1487,12 @@ def count_nonzero(a, axis=None):
   a = np_array_ops.array(a)
   maybe_rank = a.shape.rank
   if axis is not None and maybe_rank is not None:
+    # NumPy accepts axis 0 (and -1) on 0-d inputs.
+    validation_rank = max(maybe_rank, 1)
     axes = axis if isinstance(axis, (tuple, list)) else (axis,)
     for ax in axes:
-      normalized = ax + maybe_rank if ax < 0 else ax
-      if normalized < 0 or normalized >= maybe_rank:
+      normalized = ax + validation_rank if ax < 0 else ax
+      if normalized < 0 or normalized >= validation_rank:
         raise ValueError(
             f'Argument `axis` (received axis={ax}) is out of bounds '
             f'for input {a} of rank {maybe_rank}.'
@@ -1522,8 +1524,11 @@ def argsort(a, axis=-1, kind='quicksort', order=None):  # pylint: disable=missin
 
   maybe_rank = a.shape.rank
   if axis is not None and maybe_rank is not None:
-    normalized = axis + maybe_rank if axis < 0 else axis
-    if normalized < 0 or normalized >= maybe_rank:
+    # NumPy treats 0-d inputs as 1-D of size 1 for axis validation, so
+    # axes -1 and 0 are valid on scalars.
+    validation_rank = max(maybe_rank, 1)
+    normalized = axis + validation_rank if axis < 0 else axis
+    if normalized < 0 or normalized >= validation_rank:
       raise ValueError(
           f'Argument `axis` (received axis={axis}) is out of bounds '
           f'for input {a} of rank {maybe_rank}.'

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1448,6 +1448,15 @@ def concatenate(arys, axis=0):  # pylint: disable=missing-function-docstring
         for array in arys
     ]
     axis = 0
+  else:
+    maybe_rank = arys[0].shape.rank
+    if maybe_rank is not None:
+      normalized = axis + maybe_rank if axis < 0 else axis
+      if normalized < 0 or normalized >= maybe_rank:
+        raise ValueError(
+            f'Argument `axis` (received axis={axis}) is out of bounds '
+            f'for input {arys[0]} of rank {maybe_rank}.'
+        )
   return array_ops.concat(arys, axis)
 
 
@@ -1475,7 +1484,18 @@ def tile(a, reps):  # pylint: disable=missing-function-docstring
 @tf_export.tf_export('experimental.numpy.count_nonzero', v1=[])
 @np_utils.np_doc('count_nonzero')
 def count_nonzero(a, axis=None):
-  return math_ops.count_nonzero(np_array_ops.array(a), axis)
+  a = np_array_ops.array(a)
+  maybe_rank = a.shape.rank
+  if axis is not None and maybe_rank is not None:
+    axes = axis if isinstance(axis, (tuple, list)) else (axis,)
+    for ax in axes:
+      normalized = ax + maybe_rank if ax < 0 else ax
+      if normalized < 0 or normalized >= maybe_rank:
+        raise ValueError(
+            f'Argument `axis` (received axis={ax}) is out of bounds '
+            f'for input {a} of rank {maybe_rank}.'
+        )
+  return math_ops.count_nonzero(a, axis)
 
 
 @tf_export.tf_export('experimental.numpy.argsort', v1=[])
@@ -1499,6 +1519,15 @@ def argsort(a, axis=-1, kind='quicksort', order=None):  # pylint: disable=missin
         'argsort does not support complex64/complex128 dtypes. '
         f'Received dtype: {a.dtype}'
     )
+
+  maybe_rank = a.shape.rank
+  if axis is not None and maybe_rank is not None:
+    normalized = axis + maybe_rank if axis < 0 else axis
+    if normalized < 0 or normalized >= maybe_rank:
+      raise ValueError(
+          f'Argument `axis` (received axis={axis}) is out of bounds '
+          f'for input {a} of rank {maybe_rank}.'
+      )
 
   def _argsort(a, axis, stable):
     if axis is None:
@@ -1532,6 +1561,15 @@ def sort(a, axis=-1, kind='quicksort', order=None):  # pylint: disable=missing-d
     raise ValueError('The `order` argument is not supported. Pass order=None')
 
   a = np_array_ops.array(a)
+
+  maybe_rank = a.shape.rank
+  if axis is not None and maybe_rank is not None:
+    normalized = axis + maybe_rank if axis < 0 else axis
+    if normalized < 0 or normalized >= maybe_rank:
+      raise ValueError(
+          f'Argument `axis` (received axis={axis}) is out of bounds '
+          f'for input {a} of rank {maybe_rank}.'
+      )
 
   if axis is None:
     return sort_ops.sort(array_ops.reshape(a, [-1]), 0)

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -257,6 +257,11 @@ class MathTest(test.TestCase, parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, 'out of bounds'):
       np_math_ops.argsort(np_array_ops.array([[3, 1], [6, 5]]), axis=-3)
 
+    # NumPy treats 0-d inputs as 1-D of size 1, so axes -1 and 0 are
+    # valid on scalars.
+    self.assertAllEqual([0], np_math_ops.argsort(np_array_ops.array(5)))
+    self.assertAllEqual([0], np_math_ops.argsort(np_array_ops.array(5), axis=0))
+
     def testArgsortRaisesErrorForComplexDtypes(self):
       """Test that argsort raises TypeError for complex64 and complex128."""
       complex64_array = np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex64)

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -306,8 +306,8 @@ class MathTest(test.TestCase, parameterized.TestCase):
 
   def testCountNonzero(self):
     a = np_array_ops.array([[0, 1, 2], [3, 0, 0]])
-    self.match(np_math_ops.count_nonzero(a), np.count_nonzero(a))
-    self.match(
+    self.assertAllEqual(np_math_ops.count_nonzero(a), np.count_nonzero(a))
+    self.assertAllEqual(
         np_math_ops.count_nonzero(a, axis=0),
         np.count_nonzero(a, axis=0))
     with self.assertRaisesRegex(ValueError, 'out of bounds'):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -258,9 +258,11 @@ class MathTest(test.TestCase, parameterized.TestCase):
       np_math_ops.argsort(np_array_ops.array([[3, 1], [6, 5]]), axis=-3)
 
     # NumPy treats 0-d inputs as 1-D of size 1, so axes -1 and 0 are
-    # valid on scalars.
+    # valid on scalars, while other axes are out of bounds.
     self.assertAllEqual([0], np_math_ops.argsort(np_array_ops.array(5)))
     self.assertAllEqual([0], np_math_ops.argsort(np_array_ops.array(5), axis=0))
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.argsort(np_array_ops.array(5), axis=1)
 
     def testArgsortRaisesErrorForComplexDtypes(self):
       """Test that argsort raises TypeError for complex64 and complex128."""
@@ -281,6 +283,10 @@ class MathTest(test.TestCase, parameterized.TestCase):
     self.match(np_math_ops.sort(a), np.sort(a))
     self.match(np_math_ops.sort(a, axis=0), np.sort(a, axis=0))
     self.match(np_math_ops.sort(a, axis=-1), np.sort(a, axis=-1))
+    # NumPy raises for 0-d inputs with a concrete axis (unlike argsort,
+    # which treats scalars as 1-D of size 1).
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.sort(np_array_ops.array(5))
     with self.assertRaisesRegex(ValueError, 'out of bounds'):
       np_math_ops.sort(a, axis=2)
     with self.assertRaisesRegex(ValueError, 'out of bounds'):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -252,6 +252,11 @@ class MathTest(test.TestCase, parameterized.TestCase):
     a = np.zeros(100)
     np.testing.assert_equal(np_math_ops.argsort(a, kind='stable'), r)
 
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.argsort(np_array_ops.array([3, 1, 2]), axis=1)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.argsort(np_array_ops.array([[3, 1], [6, 5]]), axis=-3)
+
     def testArgsortRaisesErrorForComplexDtypes(self):
       """Test that argsort raises TypeError for complex64 and complex128."""
       complex64_array = np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex64)
@@ -265,6 +270,39 @@ class MathTest(test.TestCase, parameterized.TestCase):
           TypeError, 'argsort does not support complex64/complex128 dtypes'
       ):
         np_math_ops.argsort(complex128_array)
+
+  def testSort(self):
+    a = np_array_ops.array([[3, 1, 2], [6, 5, 4]])
+    self.match(np_math_ops.sort(a), np.sort(a))
+    self.match(np_math_ops.sort(a, axis=0), np.sort(a, axis=0))
+    self.match(np_math_ops.sort(a, axis=-1), np.sort(a, axis=-1))
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.sort(a, axis=2)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.sort(a, axis=-3)
+
+  def testConcatenate(self):
+    a = np_array_ops.array([[1, 2], [3, 4]])
+    b = np_array_ops.array([[5, 6], [7, 8]])
+    self.match(np_math_ops.concatenate([a, b]), np.concatenate([a, b]))
+    self.match(
+        np_math_ops.concatenate([a, b], axis=1),
+        np.concatenate([a, b], axis=1))
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.concatenate([a, b], axis=2)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.concatenate([a, b], axis=-3)
+
+  def testCountNonzero(self):
+    a = np_array_ops.array([[0, 1, 2], [3, 0, 0]])
+    self.match(np_math_ops.count_nonzero(a), np.count_nonzero(a))
+    self.match(
+        np_math_ops.count_nonzero(a, axis=0),
+        np.count_nonzero(a, axis=0))
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.count_nonzero(a, axis=2)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_math_ops.count_nonzero(a, axis=-3)
 
   def testArgMaxArgMin(self):
     data = [


### PR DESCRIPTION
Follow-up to the `np.diff`, `np.moveaxis`, and `np.take_along_axis`/`np.repeat`/`np.diagonal` axis-bounds fixes. These `tf.experimental.numpy` ops also passed `axis` straight through to TF kernels, which raise opaque `InvalidArgumentError`s (or fail in other unrelated ways) for out-of-bounds axes instead of NumPy's `AxisError`:

- **`argsort`** — out-of-bounds `axis` reached the sort kernel; a bad axis on a rank-0 input was additionally ignored entirely by the scalar fast path.
- **`sort`** — same pass-through to `sort_ops.sort`.
- **`concatenate`** — out-of-bounds `axis` failed inside the concat kernel.
- **`count_nonzero`** — out-of-bounds `axis` (including entries of a tuple/list axis) failed inside the reduction kernel.

Each op now validates `axis` against the rank when it is statically known, raising the same clear `ValueError` as NumPy's `AxisError`:

```python
if normalized < 0 or normalized >= rank:
  raise ValueError(...)
```

`axis=None` remains valid for `argsort`/`sort` (flattens), and dynamically-ranked inputs keep their previous behavior. `tile` takes no axis, so it needs no validation.

Added `testSort`, `testConcatenate`, and `testCountNonzero`, plus out-of-bounds cases in `testArgsort`.

Validated locally with `py_compile` and `git diff --check`. The numpy_ops bazel tests could not be run locally (no Bazel build available); `tensorflow/python/ops/numpy_ops:np_math_ops_test` covers the new tests.
