### PR TITLE
Remove the non-value-preserving 1/y to Reciprocal grappler rewrite

### DIFF
--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -2042,17 +2042,6 @@ void ConstantFolding::ReplaceBinaryOperationWithBroadcastTo(
   graph_modified_ = true;
 }
 
-void ConstantFolding::ReplaceDivisionOfOnesByReciprocal(NodeDef* node,
-                                                        GraphDef* graph) {
-  node->set_op("Reciprocal");
-  node->mutable_input()->SwapElements(0, 1);
-  const std::string ctrl_dep =
-      AddControlDependency(node->input(1), graph, node_map_.get());
-  node_map_->UpdateInput(node->name(), node->input(1), ctrl_dep);
-  node->set_input(1, ctrl_dep);
-  graph_modified_ = true;
-}
-
 void ConstantFolding::ReplaceSubtractionFromZeroByNegation(NodeDef* node,
                                                            GraphDef* graph) {
   node->set_op("Neg");
@@ -3047,15 +3036,10 @@ absl::Status ConstantFolding::SimplifyArithmeticOperations(
       return absl::OkStatus();
     }
 
-    // Replace 1 / y with Reciprocal op.
-    if (y_matches_output_shape && is_any_div && x_is_one) {
-      TF_RETURN_IF_ERROR(CheckAttrExists(*node, "T"));
-      DataType type = node->attr().at("T").type();
-      if (DataTypeIsFloating(type) || DataTypeIsComplex(type)) {
-        ReplaceDivisionOfOnesByReciprocal(node, optimized_graph);
-        return absl::OkStatus();
-      }
-    }
+    // Note: 1 / y is intentionally not rewritten to Reciprocal(y). The CPU
+    // Reciprocal kernel uses Eigen's fast-math reciprocal for float, which
+    // is not exactly IEEE division, so the rewrite silently changed results
+    // between eager and graph execution on x86 (see issue #102771).
 
     const bool y_is_zero = IsZeros(*y);
     const bool y_is_one = y_is_zero ? false : IsOnes(*y);

--- a/tensorflow/core/grappler/optimizers/constant_folding.h
+++ b/tensorflow/core/grappler/optimizers/constant_folding.h
@@ -131,7 +131,6 @@ class ConstantFolding : public GraphOptimizer {
                                                   NodeDef* node,
                                                   GraphDef* graph);
 
-  void ReplaceDivisionOfOnesByReciprocal(NodeDef* node, GraphDef* graph);
   absl::Status FoldGraph(
       const GraphProperties& properties, GraphDef* output,
       absl::flat_hash_set<std::string>* nodes_to_not_simplify);

--- a/tensorflow/core/grappler/optimizers/constant_folding_test.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding_test.cc
@@ -888,9 +888,11 @@ TEST_F(ConstantFoldingTest, NeutralElement) {
         EXPECT_EQ("x", node.input(0));
         EXPECT_EQ(ctrl_ones_name, node.input(1));
       } else if (name == "div2") {
-        EXPECT_EQ("Reciprocal", node.op());
-        EXPECT_EQ("y", node.input(0));
-        EXPECT_EQ(ctrl_ones_name, node.input(1));
+        // ones / y is not rewritten to Reciprocal(y): the CPU Reciprocal
+        // kernel is not exactly IEEE division for float (see issue #102771).
+        EXPECT_EQ("Div", node.op());
+        EXPECT_EQ(ones_name, node.input(0));
+        EXPECT_EQ("y", node.input(1));
       } else if (name == "floordiv") {
         EXPECT_EQ("FloorDiv", node.op());
         EXPECT_EQ("x", node.input(0));

--- a/tensorflow/python/grappler/constant_folding_test.py
+++ b/tensorflow/python/grappler/constant_folding_test.py
@@ -102,6 +102,25 @@ class ConstantFoldingTest(test.TestCase):
     self.assertEqual(assign_count, 1)
     self.assertLen(graphs[0].node, 11)
 
+  # See GitHub issue #102771.
+  def testDivisionOfOnesNotRewrittenToReciprocal(self):
+    # 1 / x must stay a true division in the optimized graph. The CPU
+    # Reciprocal kernel uses Eigen's fast-math reciprocal for float, which
+    # is not exactly IEEE division, so rewriting 1 / x to Reciprocal(x)
+    # changed results between eager and graph execution on x86.
+
+    @def_function.function
+    def div_by_ones(x):
+      return 1.0 / x
+
+    with context.eager_mode():
+      ones = array_ops.ones([64], dtype=dtypes.float32)
+      with context.collect_graphs(optimized=True) as graphs:
+        result = div_by_ones(ones).numpy()
+    self.assertLen(graphs, 1)
+    self.assertNotIn('Reciprocal', [node.op for node in graphs[0].node])
+    self.assertAllEqual(result, np.ones([64], dtype=np.float32))
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Fixes #102771.

## Root cause

Two pieces combine to produce the eager/graph divergence:

1. Grappler's constant folding rewrites `Div(ones, y)` into `Reciprocal(y)` (`ReplaceDivisionOfOnesByReciprocal` in `constant_folding.cc`), assuming the two are numerically equivalent.
2. They are not equivalent on x86. The CPU `Reciprocal` kernel is Eigen's `scalar_inverse_op`, whose float packet path calls `preciprocal`. Under `EIGEN_FAST_MATH` (on by default) with FMA, the x86 specialization computes `rcp_ps` plus one Newton-Raphson step, which is accurate to about 1 ulp but not exactly IEEE division. The scalar tail path divides exactly. That is precisely the reported pattern for a 10-element float32 tensor on AVX2: one 8-lane packet returns `0.99999994` and the 2 tail elements return `1.0`.

The `Div`/`RealDiv` kernel uses `pdiv`, which is exact, so eager `1.0 / x` gives exact results. `double`, `half`, `bfloat16`, and aarch64 all take the exact generic `pdiv` path, which matches the reporter's observation that Apple M4 is unaffected and explains why only float32 on x86 misbehaves.

## Fix

Remove the rewrite so `1 / y` stays a true division in optimized graphs, restoring eager/graph parity. Users who want the faster approximate reciprocal can still call `tf.math.reciprocal` explicitly, and its kernel is unchanged.

The neighboring `ReduceDivToReciprocalMul` rewrite (division by constant to multiplication by reciprocal) is explicitly documented as a strength reduction and is left unchanged; it does not fire for the reported program since the denominator is not constant.

## Tests

- `constant_folding_test.cc` `NeutralElement`: the `div2` expectation now checks that `Div(ones, y)` is left untouched.
- New `testDivisionOfOnesNotRewrittenToReciprocal` in `tensorflow/python/grappler/constant_folding_test.py` asserts both that no `Reciprocal` node appears in the runtime-optimized graph (via `context.collect_graphs(optimized=True)`, so it gates on every platform) and that `1.0 / ones` is exactly ones (which additionally bites numerically on x86 CI). Verified against the current unfixed wheel that the test fails with `'Reciprocal' unexpectedly found in ['_Arg', 'Reciprocal', '_Retval']`, and that it fails identically (no abort) under `--tf_xla_auto_jit=2`, so it is safe for XLA-enabled harnesses. The remaining tests in the file still pass.

No BUILD changes needed; the test uses only modules the target already depends on.
