### PR TITLE
Fix pooling op names in shared depth-pooling error messages

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
@@ -340,7 +340,7 @@ void MklPoolParameters::Init(OpKernelContext* context,
     OP_REQUIRES(context,
                 (depth_window == 1 || (window_rows == 1 && window_cols == 1)),
                 absl::UnimplementedError(
-                    "MaxPooling supports exactly one of pooling across depth "
+                    "Pooling supports exactly one of pooling across depth "
                     "or pooling across width/height."));
   } else {
     // Pool3D
@@ -369,8 +369,8 @@ void MklPoolParameters::Init(OpKernelContext* context,
                 (depth_window == 1 ||
                  (window_rows == 1 && window_cols == 1 && window_planes == 1)),
                 absl::UnimplementedError(
-                    "AvgPooling3D supports exactly one of pooling across depth "
-                    "or pooling across depth/width/height."));
+                    "Pooling3D supports exactly one of pooling across depth "
+                    "or pooling across planes/width/height."));
   }
 
   if (depth_window == 1) {  // We are pooling in the D (Pool3D only), H and W.

--- a/tensorflow/core/kernels/pooling_ops_common.cc
+++ b/tensorflow/core/kernels/pooling_ops_common.cc
@@ -156,7 +156,7 @@ PoolParameters::PoolParameters(OpKernelContext* context,
   OP_REQUIRES(context,
               (depth_window == 1 || (window_rows == 1 && window_cols == 1)),
               absl::UnimplementedError(
-                  "MaxPooling supports exactly one of pooling across depth "
+                  "Pooling supports exactly one of pooling across depth "
                   "or pooling across width/height."));
   if (padding == Padding::EXPLICIT) {
     OP_REQUIRES_OK(context, CheckValidPadding(padding, explicit_paddings,

--- a/tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py
@@ -935,6 +935,21 @@ class PoolingTest(test.TestCase, parameterized.TestCase):
               t, ksize=[1, 1, 1, 2], strides=[1, 1, 1, 2],
               padding="SAME").eval()
 
+  @test_util.disable_xla("b/123338077")  # Passes with XLA
+  def testDepthwiseAvgPoolInvalidConfigErrorMessage(self):
+    # The pooling parameter validation is shared between MaxPool and
+    # AvgPool, but its error message used to claim MaxPooling even when
+    # AvgPool was the op being run. The negative lookbehind rejects that
+    # old message. See https://github.com/tensorflow/tensorflow/issues/113187.
+    with self.cached_session(use_gpu=False):
+      t = constant_op.constant(1.0, shape=[1, 4, 4, 4])
+      with self.assertRaisesRegex(
+          errors_impl.UnimplementedError,
+          r"(?<!Max)Pooling supports exactly one of pooling across depth"):
+        self.evaluate(
+            nn_ops.avg_pool(
+                t, ksize=[1, 3, 3, 2], strides=[1, 2, 2, 2], padding="SAME"))
+
   # The following are tests that verify that the CPU and GPU implementations
   # produce the same results.
   def _CompareMaxPoolingFwd(self, input_shape, ksize, strides, padding):

--- a/tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py
@@ -939,13 +939,14 @@ class PoolingTest(test.TestCase, parameterized.TestCase):
   def testDepthwiseAvgPoolInvalidConfigErrorMessage(self):
     # The pooling parameter validation is shared between MaxPool and
     # AvgPool, but its error message used to claim MaxPooling even when
-    # AvgPool was the op being run. The negative lookbehind rejects that
-    # old message. See https://github.com/tensorflow/tensorflow/issues/113187.
+    # AvgPool was the op being run. The word boundary rejects any
+    # op-prefixed variant of that old message.
+    # See https://github.com/tensorflow/tensorflow/issues/113187.
     with self.cached_session(use_gpu=False):
       t = constant_op.constant(1.0, shape=[1, 4, 4, 4])
       with self.assertRaisesRegex(
           errors_impl.UnimplementedError,
-          r"(?<!Max)Pooling supports exactly one of pooling across depth"):
+          r"\bPooling supports exactly one of pooling across depth"):
         self.evaluate(
             nn_ops.avg_pool(
                 t, ksize=[1, 3, 3, 2], strides=[1, 2, 2, 2], padding="SAME"))


### PR DESCRIPTION
Fixes #113187.

## Background

The reported scenario passes NHWC-style `ksize=[1, 3, 3, 1]` to `tf.nn.avg_pool` with `data_format="NCHW"`, where ksize is interpreted in `[N, C, H, W]` order. That requests pooling across channels (3) and height (3) simultaneously, which TensorFlow's pooling implementation does not support by design: it allows exactly one of depth pooling or spatial pooling. The correct NCHW call is `ksize=[1, 1, 3, 3]`. The rejection itself is therefore working as intended (the PaddlePaddle comparison in the issue is not equivalent, since `kernel_size=[3, 3]` there is spatial-only and cannot express depth pooling).

## What this PR fixes

The one accurate observation in the report: the error message names the wrong op. The validation lives in shared max/avg pooling parameter code, with the op name hardcoded:

- `PoolParameters` (`pooling_ops_common.cc`) and the oneDNN 2D branch (`mkl_pooling_ops_common.cc`) say "MaxPooling supports exactly one of pooling across depth or pooling across width/height", so `tf.nn.avg_pool` reports an error about MaxPooling. Reproducible on any platform with plain NHWC input: `tf.nn.avg_pool2d(x, ksize=[1, 3, 3, 2], ...)` raises `UnimplementedError: MaxPooling supports ...`.
- The oneDNN 3D branch has the mirror-image problem: it says "AvgPooling3D" for both MaxPool3D and AvgPool3D, and its wording ("pooling across depth or pooling across depth/width/height") names depth on both sides of the choice.

This PR makes the messages op-neutral ("Pooling" / "Pooling3D") and describes the 3D spatial alternative as "planes/width/height", matching the kernel's terminology for the spatial D dimension.

## Test

`testDepthwiseAvgPoolInvalidConfigErrorMessage` in `pooling_ops_test.py` runs AvgPool with a combined depth and spatial window and asserts the message via `(?<!Max)Pooling supports exactly one of pooling across depth`, so it fails against the old message and passes with the new one (verified: fails on the current wheel with the old MaxPooling text, and the full `pooling_ops_test.py` suite has no other failures). It follows the pattern of the neighboring `testDepthwiseMaxPoolInvalidConfigs`, including `@test_util.disable_xla` since XLA supports these configurations. No test anywhere asserts the old exact strings; the existing assertions use the stable "exactly one of pooling across depth" substring, which is unchanged.
