### PR TITLE
Fix MirrorPad silently corrupting tensors with more than 2**31 elements

### DIFF
--- a/tensorflow/core/kernels/image/mirror_pad_op.cc
+++ b/tensorflow/core/kernels/image/mirror_pad_op.cc
@@ -120,12 +120,12 @@ class MirrorPadOp : public OpKernel {
     Tensor* output = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
 
-#define MIRROR_PAD_CASE(i)                                                \
-  case i: {                                                               \
-    functor::MirrorPad<Device, T, Tpaddings, i>()(                        \
-        context->eigen_device<Device>(), To32Bit(output->tensor<T, i>()), \
-        To32Bit(in0.tensor<T, i>()), paddings, offset_);                  \
-    break;                                                                \
+#define MIRROR_PAD_CASE(i)                                       \
+  case i: {                                                      \
+    functor::MirrorPad<Device, T, Tpaddings, i>()(               \
+        context->eigen_device<Device>(), output->tensor<T, i>(), \
+        in0.tensor<T, i>(), paddings, offset_);                  \
+    break;                                                       \
   }
 
     // Invoke the dims-specific implementation.
@@ -153,12 +153,12 @@ using GpuDevice = Eigen::GpuDevice;
 namespace functor {
 // Forward declarations of the functor specializations defined in the sharded
 // files.
-#define DECLARE_CPU_SPEC(T, Tpaddings, i)                     \
-  template <>                                                 \
-  void MirrorPad<CpuDevice, T, Tpaddings, i>::operator()(     \
-      const CpuDevice&, typename TTypes<T, i, int32>::Tensor, \
-      typename TTypes<T, i, int32>::ConstTensor,              \
-      TTypes<Tpaddings>::ConstMatrix, int);                   \
+#define DECLARE_CPU_SPEC(T, Tpaddings, i)                              \
+  template <>                                                          \
+  void MirrorPad<CpuDevice, T, Tpaddings, i>::operator()(              \
+      const CpuDevice&, typename TTypes<T, i>::Tensor,                 \
+      typename TTypes<T, i>::ConstTensor, TTypes<Tpaddings>::ConstMatrix, \
+      int);                                                            \
   extern template struct MirrorPad<CpuDevice, T, Tpaddings, i>;
 
 #define DECLARE_CPU_SPECS(T)       \
@@ -204,12 +204,12 @@ TF_CALL_tstring(REGISTER_KERNEL);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 // Forward declarations of the functor specializations for GPU.
-#define DECLARE_GPU_SPEC(T, Tpaddings, i)                     \
-  template <>                                                 \
-  void MirrorPad<GpuDevice, T, Tpaddings, i>::operator()(     \
-      const GpuDevice&, typename TTypes<T, i, int32>::Tensor, \
-      typename TTypes<T, i, int32>::ConstTensor,              \
-      TTypes<Tpaddings>::ConstMatrix, int);                   \
+#define DECLARE_GPU_SPEC(T, Tpaddings, i)                              \
+  template <>                                                          \
+  void MirrorPad<GpuDevice, T, Tpaddings, i>::operator()(              \
+      const GpuDevice&, typename TTypes<T, i>::Tensor,                 \
+      typename TTypes<T, i>::ConstTensor, TTypes<Tpaddings>::ConstMatrix, \
+      int);                                                            \
   extern template struct MirrorPad<GpuDevice, T, Tpaddings, i>;
 
 #define DECLARE_GPU_SPECS(T)       \
@@ -342,13 +342,13 @@ class MirrorPadGradOp : public OpKernel {
     Tensor* output = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
 
-#define MIRROR_PAD_GRAD_CASE(k)                                           \
-  case k: {                                                               \
-    functor::MirrorPadGrad<Device, T, Tpaddings, k>()(                    \
-        context->eigen_device<Device>(), To32Bit(output->tensor<T, k>()), \
-        To32Bit(in0.tensor<T, k>()), paddings, offset_,                   \
-        To32Bit(scratch.tensor<T, k>()));                                 \
-    break;                                                                \
+#define MIRROR_PAD_GRAD_CASE(k)                                  \
+  case k: {                                                      \
+    functor::MirrorPadGrad<Device, T, Tpaddings, k>()(           \
+        context->eigen_device<Device>(), output->tensor<T, k>(), \
+        in0.tensor<T, k>(), paddings, offset_,                   \
+        scratch.tensor<T, k>());                                 \
+    break;                                                       \
   }
 
     // Invoke the dims-specific implementation.
@@ -373,13 +373,12 @@ class MirrorPadGradOp : public OpKernel {
 namespace functor {
 // Forward declarations of the functor specializations defined in the sharded
 // files.
-#define DECLARE_CPU_SPEC(T, Tpaddings, k)                     \
-  template <>                                                 \
-  void MirrorPadGrad<CpuDevice, T, Tpaddings, k>::operator()( \
-      const CpuDevice&, typename TTypes<T, k, int32>::Tensor, \
-      typename TTypes<T, k, int32>::ConstTensor,              \
-      TTypes<Tpaddings>::ConstMatrix, int,                    \
-      typename TTypes<T, k, int32>::Tensor);                  \
+#define DECLARE_CPU_SPEC(T, Tpaddings, k)                              \
+  template <>                                                          \
+  void MirrorPadGrad<CpuDevice, T, Tpaddings, k>::operator()(          \
+      const CpuDevice&, typename TTypes<T, k>::Tensor,                 \
+      typename TTypes<T, k>::ConstTensor, TTypes<Tpaddings>::ConstMatrix, \
+      int, typename TTypes<T, k>::Tensor);                             \
   extern template struct MirrorPadGrad<CpuDevice, T, Tpaddings, k>;
 
 #define DECLARE_CPU_SPECS(T)       \
@@ -419,13 +418,12 @@ TF_CALL_NUMBER_TYPES(REGISTER_KERNEL);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 // Forward declarations of the functor specializations for GPU.
-#define DECLARE_GPU_SPEC(T, Tpaddings, k)                     \
-  template <>                                                 \
-  void MirrorPadGrad<GpuDevice, T, Tpaddings, k>::operator()( \
-      const GpuDevice&, typename TTypes<T, k, int32>::Tensor, \
-      typename TTypes<T, k, int32>::ConstTensor,              \
-      TTypes<Tpaddings>::ConstMatrix, int,                    \
-      typename TTypes<T, k, int32>::Tensor);                  \
+#define DECLARE_GPU_SPEC(T, Tpaddings, k)                              \
+  template <>                                                          \
+  void MirrorPadGrad<GpuDevice, T, Tpaddings, k>::operator()(          \
+      const GpuDevice&, typename TTypes<T, k>::Tensor,                 \
+      typename TTypes<T, k>::ConstTensor, TTypes<Tpaddings>::ConstMatrix, \
+      int, typename TTypes<T, k>::Tensor);                             \
   extern template struct MirrorPadGrad<GpuDevice, T, Tpaddings, k>;
 
 #define DECLARE_GPU_SPECS(T)       \

--- a/tensorflow/core/kernels/image/mirror_pad_op.h
+++ b/tensorflow/core/kernels/image/mirror_pad_op.h
@@ -342,17 +342,23 @@ namespace functor {
 // values are replicated (offset == 0) or not replicated (offset == 1).
 template <typename Device, typename T, typename Tpaddings, int Dims>
 struct MirrorPad {
-  void operator()(const Device& device,
-                  typename TTypes<T, Dims, int32_t>::Tensor output,
-                  typename TTypes<T, Dims, int32_t>::ConstTensor input,
+  void operator()(const Device& device, typename TTypes<T, Dims>::Tensor output,
+                  typename TTypes<T, Dims>::ConstTensor input,
                   typename TTypes<Tpaddings>::ConstMatrix padding, int offset) {
-    Eigen::array<Eigen::IndexPair<int32_t>, Dims> padding_dims;
+    Eigen::array<Eigen::IndexPair<Tpaddings>, Dims> padding_dims;
 
     for (int i = 0; i < Dims; ++i) {
-      padding_dims[i] = Eigen::IndexPair<int32_t>(padding(i, 0), padding(i, 1));
+      padding_dims[i] =
+          Eigen::IndexPair<Tpaddings>(padding(i, 0), padding(i, 1));
     }
 
-    output.device(device) = MirrorPadOp(input, padding_dims, offset);
+    // 32-bit indexing silently corrupts the output for tensors with more
+    // than 2**31 - 1 elements, so it is only used where it is safe.
+    MaybeWith32BitIndexing<Device>(
+        [&](auto output_x, auto input_x) {
+          output_x.device(device) = MirrorPadOp(input_x, padding_dims, offset);
+        },
+        output, input);
   }
 
   template <typename PaddingDimensions, typename Derived>
@@ -369,74 +375,81 @@ struct MirrorPad {
 // values are replicated (offset == 0) or not replicated (offset == 1).
 template <typename Device, typename T, typename Tpaddings, int Dims>
 struct MirrorPadGrad {
-  void operator()(const Device& device,
-                  typename TTypes<T, Dims, int32_t>::Tensor output,
-                  typename TTypes<T, Dims, int32_t>::ConstTensor input,
+  void operator()(const Device& device, typename TTypes<T, Dims>::Tensor output,
+                  typename TTypes<T, Dims>::ConstTensor input,
                   typename TTypes<Tpaddings>::ConstMatrix paddings, int offset,
-                  typename TTypes<T, Dims, int32_t>::Tensor scratch) {
-    // Copy the gradient input into the scratch buffer.
-    scratch.device(device) = input;
+                  typename TTypes<T, Dims>::Tensor scratch) {
+    // 32-bit indexing silently corrupts the output for tensors with more
+    // than 2**31 - 1 elements, so it is only used where it is safe.
+    MaybeWith32BitIndexing<Device>(
+        [&](auto output_x, auto input_x, auto scratch_x) {
+          using IndexType = typename decltype(scratch_x)::Index;
 
-    Eigen::array<int32_t, Dims> lhs_offsets;
-    Eigen::array<int32_t, Dims> rhs_offsets;
-    Eigen::array<int32_t, Dims> extents;
-    Eigen::array<bool, Dims> reverses;
+          // Copy the gradient input into the scratch buffer.
+          scratch_x.device(device) = input_x;
 
-    for (int i = 0; i < Dims; ++i) {
-      lhs_offsets[i] = 0;
-      rhs_offsets[i] = 0;
-      extents[i] = scratch.dimension(i);
-      reverses[i] = false;
-    }
+          Eigen::array<IndexType, Dims> lhs_offsets;
+          Eigen::array<IndexType, Dims> rhs_offsets;
+          Eigen::array<IndexType, Dims> extents;
+          Eigen::array<bool, Dims> reverses;
 
-    // At this point, the central part (non-padded area) does not include the
-    // gradients back-propagated through padded areas. Those gradient components
-    // need be added to the central part.
-    //
-    // Note that a gradient input element falls into a padded area iff in at
-    // least one dimension i, the coordinate x(i) is in the range (python-style)
-    // [:paddings(i,0)] or [-paddings(i,1):].
+          for (int i = 0; i < Dims; ++i) {
+            lhs_offsets[i] = 0;
+            rhs_offsets[i] = 0;
+            extents[i] = scratch_x.dimension(i);
+            reverses[i] = false;
+          }
 
-    for (int i = 0; i < Dims; ++i) {
-      reverses[i] = true;
+          // At this point, the central part (non-padded area) does not include
+          // the gradients back-propagated through padded areas. Those gradient
+          // components need be added to the central part.
+          //
+          // Note that a gradient input element falls into a padded area iff in
+          // at least one dimension i, the coordinate x(i) is in the range
+          // (python-style) [:paddings(i,0)] or [-paddings(i,1):].
 
-      // This handles the case when coordinate in dimension i is in the range
-      // [:paddings(i,0)]. This portion is added to the range
-      // [paddings(i,0) + offset:2 * paddings(i,0) + offset].
-      if (paddings(i, 0) > 0) {
-        rhs_offsets[i] = 0;
-        lhs_offsets[i] = paddings(i, 0) + offset;
-        extents[i] = paddings(i, 0);
+          for (int i = 0; i < Dims; ++i) {
+            reverses[i] = true;
 
-        scratch.slice(lhs_offsets, extents).device(device) +=
-            scratch.slice(rhs_offsets, extents).reverse(reverses);
-      }
+            // This handles the case when coordinate in dimension i is in the
+            // range [:paddings(i,0)]. This portion is added to the range
+            // [paddings(i,0) + offset:2 * paddings(i,0) + offset].
+            if (paddings(i, 0) > 0) {
+              rhs_offsets[i] = 0;
+              lhs_offsets[i] = paddings(i, 0) + offset;
+              extents[i] = paddings(i, 0);
 
-      // This handles the case when coordinate in dimension i is in the range
-      // [-paddings(i,1):]. This portion is added to the range
-      // [-2 * paddings(i,1) - offset:-paddings(i,1) - offset].
-      if (paddings(i, 1) > 0) {
-        rhs_offsets[i] = scratch.dimension(i) - paddings(i, 1);
-        lhs_offsets[i] = rhs_offsets[i] - paddings(i, 1) - offset;
-        extents[i] = paddings(i, 1);
+              scratch_x.slice(lhs_offsets, extents).device(device) +=
+                  scratch_x.slice(rhs_offsets, extents).reverse(reverses);
+            }
 
-        scratch.slice(lhs_offsets, extents).device(device) +=
-            scratch.slice(rhs_offsets, extents).reverse(reverses);
-      }
+            // This handles the case when coordinate in dimension i is in the
+            // range [-paddings(i,1):]. This portion is added to the range
+            // [-2 * paddings(i,1) - offset:-paddings(i,1) - offset].
+            if (paddings(i, 1) > 0) {
+              rhs_offsets[i] = scratch_x.dimension(i) - paddings(i, 1);
+              lhs_offsets[i] = rhs_offsets[i] - paddings(i, 1) - offset;
+              extents[i] = paddings(i, 1);
 
-      reverses[i] = false;
-      lhs_offsets[i] = paddings(i, 0);
-      rhs_offsets[i] = paddings(i, 0);
-      extents[i] = output.dimension(i);
+              scratch_x.slice(lhs_offsets, extents).device(device) +=
+                  scratch_x.slice(rhs_offsets, extents).reverse(reverses);
+            }
 
-      // At this point, scratch buffer contains gradient input as if paddings
-      // for dimension k = 0,...,i are zeros. Therefore after the loop
-      // termination, the central part of the scratch buffer contains the folded
-      // gradients.
-    }
+            reverses[i] = false;
+            lhs_offsets[i] = paddings(i, 0);
+            rhs_offsets[i] = paddings(i, 0);
+            extents[i] = output_x.dimension(i);
 
-    // Copy the central part of the scratch buffer to the output.
-    output.device(device) = scratch.slice(rhs_offsets, extents);
+            // At this point, scratch buffer contains gradient input as if
+            // paddings for dimension k = 0,...,i are zeros. Therefore after
+            // the loop termination, the central part of the scratch buffer
+            // contains the folded gradients.
+          }
+
+          // Copy the central part of the scratch buffer to the output.
+          output_x.device(device) = scratch_x.slice(rhs_offsets, extents);
+        },
+        output, input, scratch);
   }
 };
 }  // namespace functor

--- a/tensorflow/python/kernel_tests/array_ops/BUILD
+++ b/tensorflow/python/kernel_tests/array_ops/BUILD
@@ -482,6 +482,19 @@ cuda_py_strict_test(
 )
 
 cuda_py_strict_test(
+    name = "large_mirror_pad_op_test",
+    size = "medium",
+    srcs = ["large_mirror_pad_op_test.py"],
+    deps = [
+        "//tensorflow/python/framework:for_generated_wrappers",
+        "//tensorflow/python/ops:array_ops",
+        "//tensorflow/python/ops:math_ops",
+        "//tensorflow/python/platform:client_testlib",
+        "//third_party/py/numpy",
+    ],
+)
+
+cuda_py_strict_test(
     name = "manip_ops_test",
     size = "medium",
     srcs = ["manip_ops_test.py"],

--- a/tensorflow/python/kernel_tests/array_ops/large_mirror_pad_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/large_mirror_pad_op_test.py
@@ -40,13 +40,17 @@ class LargeMirrorPadOpTest(test.TestCase):
           [num_images, 256, 256, 1])
       padded = array_ops.pad(
           x, [[0, 0], [1, 1], [1, 1], [0, 0]], mode="SYMMETRIC")
+      # Probe images on both sides of the 2**31 element boundary, which
+      # falls inside image 2**31 // (256 * 256) = 32768. Gathering them
+      # into one tensor keeps this to a single evaluation of the padding
+      # even under a graph-mode harness.
+      probes = (0, 16000, 32767, 32768, 32999)
+      probed_images = array_ops.gather(padded, probes)
     self.assertEqual(padded.shape, [num_images, 258, 258, 1])
-    # Probe images on both sides of the 2**31 element boundary, which falls
-    # inside image 2**31 // (256 * 256) = 32768.
-    for i in (0, 16000, 32767, 32768, 32999):
-      image = self.evaluate(padded[i])
+    evaluated_probes = self.evaluate(probed_images)
+    for idx, i in enumerate(probes):
       self.assertAllEqual(
-          image,
+          evaluated_probes[idx],
           np.full([258, 258, 1], i % 251, dtype=np.uint8),
           msg="image %d" % i)
 

--- a/tensorflow/python/kernel_tests/array_ops/large_mirror_pad_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/large_mirror_pad_op_test.py
@@ -1,0 +1,55 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for MirrorPad that run over tensors with more than 2**31 elements."""
+
+import numpy as np
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test
+
+
+class LargeMirrorPadOpTest(test.TestCase):
+  """Tests that belong in pad_op_test.py, but run over large tensors."""
+
+  def testMirrorPadLargeTensor(self):
+    # Regression test for GitHub issue 112304. The MirrorPad kernel used
+    # 32-bit indexing unconditionally, so any tensor with more than
+    # 2**31 - 1 elements was silently corrupted. Image i is constant-valued
+    # (i % 251), so every padded image must also be constant.
+    # CPU-only test, because it needs more memory than most GPUs have.
+    num_images = 33000  # 33000 * 256 * 256 elements, just over 2**31.
+    with ops.device("/cpu:0"):
+      values = math_ops.cast(math_ops.range(num_images) % 251, dtypes.uint8)
+      x = array_ops.broadcast_to(
+          array_ops.reshape(values, [num_images, 1, 1, 1]),
+          [num_images, 256, 256, 1])
+      padded = array_ops.pad(
+          x, [[0, 0], [1, 1], [1, 1], [0, 0]], mode="SYMMETRIC")
+    self.assertEqual(padded.shape, [num_images, 258, 258, 1])
+    # Probe images on both sides of the 2**31 element boundary, which falls
+    # inside image 2**31 // (256 * 256) = 32768.
+    for i in (0, 16000, 32767, 32768, 32999):
+      image = self.evaluate(padded[i])
+      self.assertAllEqual(
+          image,
+          np.full([258, 258, 1], i % 251, dtype=np.uint8),
+          msg="image %d" % i)
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
Fixes #112304.

## Problem

`tf.pad` with `SYMMETRIC` or `REFLECT` mode silently corrupts any tensor with more than 2**31 - 1 elements. The MirrorPad kernel wraps its tensors in `To32Bit` unconditionally:

https://github.com/tensorflow/tensorflow/blob/9a75abe08f1e376ea202d3aec0c1e3d05a25f4d8/tensorflow/core/kernels/image/mirror_pad_op.cc#L123-L129

and the functors are instantiated only with `int32` indexing, so the index arithmetic wraps past 2**31 elements. Reproduced with a `[33000, 256, 256, 1]` uint8 tensor (2.16e9 elements) where image `i` is constant-valued: after SYMMETRIC padding, image 0 is correct and the rest of the output is silently zeroed, with no error raised. `CONSTANT` mode is unaffected because `PadOp` already dispatches through `MaybeWith32BitIndexing`, which is how this was isolated. `MirrorPadGrad` has the identical defect.

## Fix

Use `MaybeWith32BitIndexing<Device>` in both functors, following the established pattern in `pad_op.h` and `slice_op.h`:

- On the CPU, the expression now evaluates with 64-bit indices (the utility passes tensors through unchanged there, same as every other kernel using it).
- On the GPU, the 32-bit fast path is kept whenever every tensor is small enough for it, so there is no performance change for normal-sized tensors.
- The gradient functor types its slice offsets and extents on the map's index type, so the 32-bit and 64-bit paths stay internally consistent, and a dimension larger than 2**31 no longer truncates in `extents`.
- The forward padding pairs now use `Tpaddings` instead of truncating `int64` paddings to `int32`, matching `pad_op.h`.

The custom `Eigen::TensorMirrorPadOp` evaluator in `mirror_pad_op.h` is already index-type generic (its `Index` comes from the expression traits), so no changes to the evaluator itself are needed. No code outside `tensorflow/core/kernels/image/` references these functors.

## Test

`large_mirror_pad_op_test.py` follows the `large_concat_op_test.py` precedent: a CPU-only, `size = "medium"` test over a tensor just above 2**31 elements (uint8 to bound memory at about 4.3GB peak), with each image constant-valued so corruption is detectable by probing a handful of images on both sides of the 2**31 boundary. Verified against the current wheel that the test fails with the reported corruption (probed images all zeros) and that the exact failing probes match the bug signature. A comparable direct test for `MirrorPadGrad` would need roughly 7GB of test memory, so the gradient path is covered by the shared dispatch change plus the existing normal-sized gradient tests in `pad_op_test.py`.
