### PR TITLE
Fix remaining AttributeError from Tensor.astype in tf.experimental.numpy

### DIFF
--- a/tensorflow/python/ops/numpy_ops/BUILD
+++ b/tensorflow/python/ops/numpy_ops/BUILD
@@ -267,6 +267,18 @@ cuda_py_strict_test(
 )
 
 cuda_py_strict_test(
+    name = "np_array_ops_no_numpy_methods_test",
+    srcs = ["np_array_ops_no_numpy_methods_test.py"],
+    deps = [
+        ":np_array_ops",
+        "//tensorflow/python/framework:constant_op",
+        "//tensorflow/python/framework:ops",
+        "//tensorflow/python/platform:client_testlib",
+        "//third_party/py/numpy",
+    ],
+)
+
+cuda_py_strict_test(
     name = "np_math_ops_no_numpy_methods_test",
     srcs = ["np_math_ops_no_numpy_methods_test.py"],
     deps = [

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -853,12 +853,15 @@ def around(a, decimals=0):  # pylint: disable=missing-docstring
     # Use float as the working dtype when a.dtype is exact (e.g. integer),
     # because `decimals` can be negative.
     float_dtype = np_utils.result_type(float)
-    a = a.astype(float_dtype)
+    # `Tensor.astype` only exists once `enable_numpy_methods_on_tensor()`
+    # has been called, and is an alias of `math_ops.cast`; calling `cast`
+    # directly keeps `around` working without that opt-in.
+    a = math_ops.cast(a, float_dtype)
     factor = math_ops.cast(factor, float_dtype)
   a = math_ops.multiply(a, factor)
   a = math_ops.round(a)
   a = math_ops.divide(a, factor)
-  return a.astype(dtype)
+  return math_ops.cast(a, dtype)
 
 
 setattr(np_arrays.ndarray, '__round__', around)
@@ -2177,7 +2180,9 @@ def _with_index_update_helper(update_method, a, slice_spec, updates):
   a_dtype = a.dtype
   a, updates = _promote_dtype_binary(a, updates)
   result_t = _slice_helper(a, slice_spec, update_method, updates)
-  return result_t.astype(a_dtype)
+  # See the note in `around`: `astype` depends on an opt-in that this
+  # module-level helper does not require of its callers.
+  return math_ops.cast(result_t, a_dtype)
 
 
 setattr(np_arrays.ndarray, '_numpy_style_getitem', _getitem)

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_no_numpy_methods_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_no_numpy_methods_test.py
@@ -85,23 +85,26 @@ class ArrayWithoutNumpyMethodsOnTensorTest(test.TestCase):
         atol=1e-6,
     )
 
-  def testIndexUpdateHelpersPreserveDtype(self):
-    # The `_with_index_*` helpers are attached to `Tensor` at import time,
-    # rather than by `enable_numpy_methods_on_tensor()`, so they must not
-    # require the opt-in either. They are attached as `functools.partial`
-    # objects, which are not descriptors, so the tensor is passed explicitly
-    # instead of being bound as `self`.
+  def testIndexUpdateHelperPreservesDtype(self):
+    # `_with_index_update_helper` backs the `_with_index_*` methods, which are
+    # attached to `Tensor` at import time rather than by
+    # `enable_numpy_methods_on_tensor()`, so it must not require the opt-in
+    # either. It is called directly here because the methods are attached as
+    # `functools.partial` objects, and whether those bind the tensor as their
+    # first argument differs between Python versions.
     tensor = constant_op.constant([1, 2, 3, 4], dtype='int32')
     updates = constant_op.constant([9, 9], dtype='int32')
     cases = [
-        ('update', tensor._with_index_update, np.array([9, 9, 3, 4])),
-        ('add', tensor._with_index_add, np.array([10, 11, 3, 4])),
+        (np_array_ops._UpdateMethod.UPDATE, np.array([9, 9, 3, 4])),
+        (np_array_ops._UpdateMethod.ADD, np.array([10, 11, 3, 4])),
     ]
-    for name, helper, expected in cases:
-      actual = helper(tensor, slice(0, 2), updates)
-      self.assertEqual(actual.dtype, tensor.dtype, msg=name)
+    for update_method, expected in cases:
+      actual = np_array_ops._with_index_update_helper(
+          update_method, tensor, slice(0, 2), updates
+      )
+      self.assertEqual(actual.dtype, tensor.dtype, msg=str(update_method))
       np.testing.assert_array_equal(
-          np.asarray(actual), expected, err_msg=name
+          np.asarray(actual), expected, err_msg=str(update_method)
       )
 
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_no_numpy_methods_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_no_numpy_methods_test.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tf numpy array methods that must not depend on Tensor methods.
+
+`np_math_ops.enable_numpy_methods_on_tensor()` adds numpy methods such as
+`astype` to `Tensor`. The other numpy_ops test modules call it from their
+`__main__`, so a code path that only works once those methods are installed
+still passes there. This module deliberately does not call it, which is the
+configuration a user gets from a plain `import tensorflow`.
+"""
+
+import numpy as np
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import ops
+from tensorflow.python.ops.numpy_ops import np_array_ops
+from tensorflow.python.platform import test
+
+
+class ArrayWithoutNumpyMethodsOnTensorTest(test.TestCase):
+
+  def testAroundAcceptsFloatInputs(self):
+    # `around` casts back to the argument's dtype on every path, so it is
+    # broken for float arguments too, not only the promoted integer ones.
+    arg = np.array([1.234, 5.678, -2.345], dtype=np.float32)
+    for decimals in (0, 1, 2):
+      actual = np_array_ops.around(arg, decimals)
+      np.testing.assert_allclose(
+          np.asarray(actual),
+          np.around(arg, decimals),
+          rtol=1e-6,
+          atol=1e-6,
+          err_msg='around({}, {})'.format(arg, decimals),
+      )
+
+  def testAroundAcceptsIntegerInputs(self):
+    # An integer argument takes the promoting branch, which computes in a
+    # float dtype and casts back to the integer dtype at the end.
+    for arg in (
+        np.array([11, 25, 37], dtype=np.int32),
+        np.array([11, 25, 37], dtype=np.int64),
+    ):
+      for decimals in (0, 1):
+        actual = np_array_ops.around(arg, decimals)
+        np.testing.assert_array_equal(
+            np.asarray(actual),
+            np.around(arg, decimals),
+            err_msg='around({}, {})'.format(arg, decimals),
+        )
+
+  def testAroundPreservesDtype(self):
+    for dtype in (np.int32, np.int64, np.float32, np.float64):
+      arg = np.array([1, 2, 3], dtype=dtype)
+      self.assertEqual(np_array_ops.around(arg).dtype, dtype)
+
+  def testRoundAcceptsFloatInputs(self):
+    arg = np.array([1.234, 5.678], dtype=np.float32)
+    np.testing.assert_allclose(
+        np.asarray(np_array_ops.round(arg, 1)),
+        np.round(arg, 1),
+        rtol=1e-6,
+        atol=1e-6,
+    )
+
+  def testBuiltinRoundOnTensor(self):
+    # `around` is installed as `Tensor.__round__` at import time, so the
+    # builtin `round()` reaches the same code path.
+    tensor = constant_op.constant([1.234, 5.678], dtype='float32')
+    np.testing.assert_allclose(
+        np.asarray(round(tensor, 1)),
+        np.around(np.array([1.234, 5.678], dtype=np.float32), 1),
+        rtol=1e-6,
+        atol=1e-6,
+    )
+
+  def testIndexUpdateHelpersPreserveDtype(self):
+    # The `_with_index_*` helpers are attached to `Tensor` at import time,
+    # rather than by `enable_numpy_methods_on_tensor()`, so they must not
+    # require the opt-in either. They are attached as `functools.partial`
+    # objects, which are not descriptors, so the tensor is passed explicitly
+    # instead of being bound as `self`.
+    tensor = constant_op.constant([1, 2, 3, 4], dtype='int32')
+    updates = constant_op.constant([9, 9], dtype='int32')
+    cases = [
+        ('update', tensor._with_index_update, np.array([9, 9, 3, 4])),
+        ('add', tensor._with_index_add, np.array([10, 11, 3, 4])),
+    ]
+    for name, helper, expected in cases:
+      actual = helper(tensor, slice(0, 2), updates)
+      self.assertEqual(actual.dtype, tensor.dtype, msg=name)
+      np.testing.assert_array_equal(
+          np.asarray(actual), expected, err_msg=name
+      )
+
+
+if __name__ == '__main__':
+  ops.enable_eager_execution()
+  # Intentionally not calling `np_math_ops.enable_numpy_methods_on_tensor()`.
+  test.main()

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -443,7 +443,9 @@ def heaviside(x1, x2):  # pylint: disable=missing-function-docstring
 
   y = _bin_op(f, x1, x2)
   if not np.issubdtype(y.dtype.as_numpy_dtype, np.inexact):
-    y = y.astype(np_utils.result_type(float))
+    # See the note in `_scalar`: `astype` is unavailable without the
+    # `enable_numpy_methods_on_tensor()` opt-in.
+    y = math_ops.cast(y, np_utils.result_type(float))
   return y
 
 
@@ -1557,7 +1559,9 @@ def average(a, axis=None, weights=None, returned=False):  # pylint: disable=miss
   default_float_type = np_utils.result_type(float)
   if weights is None:  # Treat all weights as 1
     if not np.issubdtype(a.dtype.as_numpy_dtype, np.inexact):
-      a = a.astype(np_utils.result_type(a.dtype, default_float_type))
+      # See the note in `_scalar`: `astype` is unavailable without the
+      # `enable_numpy_methods_on_tensor()` opt-in.
+      a = math_ops.cast(a, np_utils.result_type(a.dtype, default_float_type))
     avg = math_ops.reduce_mean(a, axis=axis)
     if returned:
       if axis is None:

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_no_numpy_methods_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_no_numpy_methods_test.py
@@ -95,6 +95,37 @@ class MathWithoutNumpyMethodsOnTensorTest(test.TestCase):
           err_msg='{}(2)'.format(name),
       )
 
+  def testHeavisideAcceptsIntegerInputs(self):
+    # `heaviside` promotes an exact result to a float dtype, which must not
+    # depend on `enable_numpy_methods_on_tensor()`.
+    x1 = np.array([-1, 0, 1], dtype=np.int32)
+    for x2 in (np.int32(1), np.array([5, 5, 5], dtype=np.int32)):
+      actual = np_math_ops.heaviside(x1, x2)
+      np.testing.assert_allclose(
+          np.asarray(actual),
+          np.heaviside(x1, x2),
+          rtol=1e-6,
+          atol=1e-6,
+          err_msg='heaviside({}, {})'.format(x1, x2),
+      )
+
+  def testAverageAcceptsIntegerInputs(self):
+    # The unweighted branch of `average` promotes an integer argument to a
+    # float dtype before reducing.
+    for arg in (
+        [1, 2, 3],
+        np.array([1, 2, 3], dtype=np.int32),
+        np.array([1, 2, 3], dtype=np.int64),
+    ):
+      actual = np_math_ops.average(arg)
+      np.testing.assert_allclose(
+          np.asarray(actual),
+          np.average(np.asarray(arg)),
+          rtol=1e-6,
+          atol=1e-6,
+          err_msg='average({})'.format(arg),
+      )
+
   def testFloatInputsAreUnchanged(self):
     arg = np.array([1.5, 2.5, 3.5], dtype=np.float32)
     for name, tf_fun, np_fun in _PROMOTING_UNARY_OPS:


### PR DESCRIPTION
`tnp.around` and `tnp.round` raise `AttributeError` for every input dtype unless `experimental_enable_numpy_behavior()` has been called first. `tnp.heaviside` and `tnp.average` do the same for integer input.

```python
>>> import tensorflow.experimental.numpy as tnp

>>> tnp.around([1.5, 2.5])
AttributeError: EagerTensor object has no attribute 'astype'.
        If you are looking for numpy-related methods, please run the following:
        tf.experimental.numpy.experimental_enable_numpy_behavior()

>>> tnp.heaviside([-1, 0, 1], 1)
AttributeError: EagerTensor object has no attribute 'astype'.
```

The builtin `round()` on a `Tensor` fails the same way, because `around` is installed as `Tensor.__round__` at import time.

### Cause

This is the same defect fixed in `_scalar` by #124957. Five `.astype(...)` call sites remain, across four functions:

```python
# np_array_ops.around, twice: once for the integer branch, once on every path
a = a.astype(float_dtype)
return a.astype(dtype)

# np_math_ops.heaviside
y = y.astype(np_utils.result_type(float))

# np_math_ops.average
a = a.astype(np_utils.result_type(a.dtype, default_float_type))

# np_array_ops._with_index_update_helper
return result_t.astype(a_dtype)
```

`Tensor` has no `astype` by default. That method is installed only by `enable_numpy_methods_on_tensor()`, bound straight to `math_ops.cast`:

```python
setattr(tensor_class, 'astype', math_ops.cast)
```

`around` is the worst of the four because its final cast runs on every code path, so no input reaches the end. `_with_index_update_helper` is reached through `_with_index_update` and friends, which are attached to `Tensor` at import time rather than by the opt-in, so it fails for any argument too.

### Fix

Call `math_ops.cast` directly, as #124957 did. Since `Tensor.astype` is the `math_ops.cast` function object installed as a class attribute, normal Python method binding makes `a.astype(dtype)` equivalent to `math_ops.cast(a, dtype)`. This is therefore the identical operation for anyone who has enabled numpy behaviour, and it makes these functions work for everyone who has not. Neither module calls `astype` after this change.

### Why the tests didn't catch it

`np_array_ops_test.py` and `np_math_ops_test.py` call `enable_numpy_methods_on_tensor()` from their `__main__`, which patches `Tensor` process-wide and hides this failure mode.

#124957 added `np_math_ops_no_numpy_methods_test.py` for exactly this reason. `heaviside` and `average` go there. `around`, `round`, the builtin `round()` and the index update helpers get an `np_array_ops` counterpart of that module. Neither makes the opt-in call, so both run in the configuration a plain `import tensorflow` gives you.

On an unpatched tree 6 tests in the new module and 2 in the existing one fail with the `AttributeError` above; with the fix both modules pass. `np_array_ops_test.py` and `np_math_ops_test.py` are unchanged by the fix.

### Scope

This PR intentionally does not change `around` numerics. Once the `AttributeError` is removed, pre-existing discrepancies with NumPy become observable for negative `decimals` and for sufficiently large integer input:

```python
# TensorFlow
tnp.around([11, 25, 37], -1)  # [9, 29, 39]

# NumPy
np.around([11, 25, 37], -1)   # [10, 20, 40]
```

Those need changes to the rounding implementation rather than this mechanical `astype` to `math_ops.cast` replacement, so I am leaving them for a separate PR.