### PR TITLE
validate decoded element shape and dtype in TensorList::Decode

### DIFF
--- a/tensorflow/core/kernels/tensor_list.cc
+++ b/tensorflow/core/kernels/tensor_list.cc
@@ -127,6 +127,25 @@ bool TensorList::Decode(const VariantTensorData& data) {
 
   const PartialTensorShape decoded_element_shape(element_shape_proto);
 
+  // Every element stored in a list must match its element_dtype and be
+  // compatible with its element_shape; the mutation paths (TensorListPushBack,
+  // TensorListSetItem) enforce this on insertion. The serialized data is
+  // untrusted, so re-establish the same invariant here. Consumers such as
+  // TensorListStack and TensorListGather skip the per-element shape check when
+  // element_shape is fully defined and then treat each element's count as the
+  // output element count, so a decoded element that does not match would
+  // overrun the output buffer.
+  for (const Tensor& t : decoded_tensors) {
+    if (t.dtype() == DT_INVALID) continue;  // Unset element placeholder.
+    if (decoded_element_dtype != DT_INVALID &&
+        t.dtype() != decoded_element_dtype) {
+      return false;
+    }
+    if (!decoded_element_shape.IsCompatibleWith(t.shape())) {
+      return false;
+    }
+  }
+
   element_dtype = decoded_element_dtype;
   max_num_elements = decoded_max_num_elements;
   tensors() = std::move(decoded_tensors);

--- a/tensorflow/core/kernels/tensor_list_test.cc
+++ b/tensorflow/core/kernels/tensor_list_test.cc
@@ -146,6 +146,42 @@ TEST(TensorListTest, DecodeValidRoundTripCompatibility) {
   EXPECT_EQ(decoded.tensors()[3].scalar<int32_t>()(), 9);
 }
 
+TEST(TensorListTest, DecodeRejectsElementLargerThanFullyDefinedShape) {
+  // element_shape is fully defined as [1], but the stored element holds 4
+  // values. Consumers (e.g. TensorListStack) skip the per-element shape check
+  // when element_shape is fully defined and size the output from element_shape,
+  // so this element would overrun the output buffer.
+  TensorShapeProto shape;
+  shape.add_dim()->set_size(1);
+  VariantTensorData data;
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{}, static_cast<uint64_t>(DT_FLOAT),
+      std::numeric_limits<uint64_t>::max(), shape.SerializeAsString()));
+  *data.add_tensors() = Tensor(DT_FLOAT, TensorShape({4}));
+  EXPECT_FALSE(TensorList().Decode(data));
+}
+
+TEST(TensorListTest, DecodeRejectsElementDtypeMismatch) {
+  TensorShapeProto shape;
+  VariantTensorData data;
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{}, static_cast<uint64_t>(DT_FLOAT),
+      std::numeric_limits<uint64_t>::max(), shape.SerializeAsString()));
+  *data.add_tensors() = ScalarInt32Tensor(1);
+  EXPECT_FALSE(TensorList().Decode(data));
+}
+
+TEST(TensorListTest, DecodeAcceptsElementCompatibleWithPartialShape) {
+  TensorShapeProto shape;
+  shape.add_dim()->set_size(-1);
+  VariantTensorData data;
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{}, static_cast<uint64_t>(DT_FLOAT),
+      std::numeric_limits<uint64_t>::max(), shape.SerializeAsString()));
+  *data.add_tensors() = Tensor(DT_FLOAT, TensorShape({4}));
+  EXPECT_TRUE(TensorList().Decode(data));
+}
+
 TEST(TensorListTest, DecodeRejectsOutOfRangeMaxNumElements) {
   TensorShapeProto shape;
   VariantTensorData data;


### PR DESCRIPTION
1. TensorList::Decode rebuilds element_dtype, element_shape and the tensors() vector from the serialized variant but never checks that each stored tensor matches them, unlike TensorListPushBack/TensorListSetItem (list_kernels.cc:201,209) which enforce the same invariant on insertion.
2. TensorListStack and TensorListGather (list_kernels.h) skip the per-element shape merge when element_shape.IsFullyDefined() and then size the output from element_shape while feeding each element's full NumElements() into ConcatCPU, so a crafted list with a fully-defined element_shape (e.g. [1]) and a larger decoded element (e.g. [4]) writes past the output buffer; a dtype-narrower element reinterprets bytes via shaped<T,2> and reads out of bounds.

Re-establish the dtype/shape invariant inside Decode so every consumer sees a consistent list. Reachable from untrusted data via parse_tensor(out_type=tf.variant) into these ops. Tests added in tensor_list_test.cc.