### PR TITLE
Fix llvm-raw fetch: sync platforms_config.patch with generated.patch

### DIFF
--- a/third_party/xla/third_party/llvm/platforms_config.patch
+++ b/third_party/xla/third_party/llvm/platforms_config.patch
@@ -15,8 +15,9 @@
 diff --git a/utils/bazel/llvm-project-overlay/llvm/config.bzl b/utils/bazel/llvm-project-overlay/llvm/config.bzl
 --- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
 +++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
-@@ -49,13 +49,12 @@
+@@ -69,14 +69,13 @@
  backtrace_defines = select({
+     "@platforms//os:emscripten": [],
      "@platforms//os:windows": [],
 -    "@llvm//platforms/config:musl": [],
      "//conditions:default": [


### PR DESCRIPTION
## What

One-line fix to `third_party/xla/third_party/llvm/platforms_config.patch`, bringing it back in line with `generated.patch`.

## The failure

`bazel build` fails on a clean checkout, before any target is built, while fetching `llvm-raw`:

```
ERROR: An error occurred during the fetch of repository 'llvm-raw':
Error in patch: Error applying patch third_party/llvm/platforms_config.patch:
in patch applied to utils/bazel/llvm-project-overlay/llvm/config.bzl:
could not apply patch due to CONTENT_DOES_NOT_MATCH_TARGET,
error applying change near line 49
ERROR: Error computing the main repository mapping: no such package
'@@llvm-raw//utils/bazel'
```

Every `bazel` invocation in the repository hits this, so nothing builds at all.

## The cause

The two patches collide. `generated.patch` is applied first and does two things to `config.bzl`:

- inserts 21 lines (`emscripten_defines` and `fenv_defines`) above `backtrace_defines`
- adds `"@platforms//os:emscripten": []` as the first entry inside `backtrace_defines`

After it, `backtrace_defines` is at line 69 and its first select entry is `emscripten`. `platforms_config.patch` still expects the pre-insertion layout at line 49 with `windows` first. Bazel's native patcher matches context exactly, with no fuzz, so it fails.

Reproduced mechanically: applying only `generated.patch`'s `config.bzl` hunks to the pinned LLVM revision (`ab547095ead5464dc024d66264d9b8a987f429f3`) puts `backtrace_defines` at line 69 with `emscripten` first, exactly as the corrected patch expects.

## The fix

`openxla/xla` already carries the corrected patch. This syncs the vendored copy under `third_party/xla` to match it: the hunk header becomes `@@ -69,14 +69,13 @@` and one context line is added. No semantic change to what the patch does to LLVM.

## Verification

```
$ bazel build --nobuild //tensorflow/core/common_runtime/pluggable_device:pluggable_device_plugin_init
INFO: Found 1 target...
INFO: Build completed successfully, 0 total actions
```

Before this change the same command fails during the repository rule, never reaching analysis.

---

CLA: signed.

Drafted with assistance from Claude Opus 5.
