### PR TITLE
Fix integer overflow in WindowDataset target buffer size

### DIFF
--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -1643,8 +1643,10 @@ tf_kernel_library(
         "//tensorflow/core/data:name_utils",
         "//tensorflow/core/framework:dataset_options_proto_cc",
         "//tensorflow/core/framework:types_proto_cc",
+        "//tensorflow/core/util:overflow",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
     ],
 )
@@ -1672,6 +1674,7 @@ tf_cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
+        "//tensorflow/core/platform:status_matchers",
     ],
 )
 

--- a/tensorflow/core/kernels/data/experimental/BUILD
+++ b/tensorflow/core/kernels/data/experimental/BUILD
@@ -846,10 +846,13 @@ tf_kernel_library(
         "//tensorflow/core:lib_internal",
         "//tensorflow/core/framework:attr_value_proto_cc",
         "//tensorflow/core/framework:dataset_options_proto_cc",
+        "//tensorflow/core/util:overflow",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/tensorflow/core/kernels/data/experimental/sliding_window_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/sliding_window_dataset_op.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <deque>
 #include <memory>
 #include <string>
@@ -23,7 +24,9 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "tensorflow/core/framework/attr_value.pb.h"
 #include "tensorflow/core/framework/dataset.h"
 #include "tensorflow/core/framework/dataset_options.pb.h"
@@ -31,6 +34,8 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/util/batch_util.h"
+#include "tensorflow/core/util/overflow.h"
+#include "xla/tsl/platform/statusor.h"
 
 namespace tensorflow {
 namespace data {
@@ -186,7 +191,8 @@ class SlidingWindowDatasetOp : public UnaryDatasetOpKernel {
           batch_elements.reserve(window_size);
 
           // Fill up buffer if not entire data was consumed.
-          size_t target_size = TargetBufferSize(window_size, window_stride);
+          TF_ASSIGN_OR_RETURN(const size_t target_size,
+                              TargetBufferSize(window_size, window_stride));
           for (size_t i = buffer_.size(); i < target_size && input_impl_; ++i) {
             bool end_of_input;
             std::vector<Tensor> element;
@@ -318,8 +324,19 @@ class SlidingWindowDatasetOp : public UnaryDatasetOpKernel {
       }
 
      private:
-      size_t TargetBufferSize(int64_t window_size, int64_t window_stride) {
-        return (window_size - 1) * window_stride + 1;
+      absl::StatusOr<size_t> TargetBufferSize(int64_t window_size,
+                                              int64_t window_stride) {
+        int64_t result = MultiplyWithoutOverflow(window_size - 1, window_stride);
+        if (result >= 0) result = AddWithoutOverflow(result, 1);
+        if (result < 0 || static_cast<uint64_t>(result) >
+                              std::numeric_limits<size_t>::max()) {
+          return absl::InvalidArgumentError(absl::StrFormat(
+              "Window target buffer size overflow: (window_size=%lld - 1) * "
+              "window_stride=%lld + 1 is not representable.",
+              static_cast<long long>(window_size),
+              static_cast<long long>(window_stride)));
+        }
+        return static_cast<size_t>(result);
       }
 
       mutex mu_;

--- a/tensorflow/core/kernels/data/window_dataset_op.cc
+++ b/tensorflow/core/kernels/data/window_dataset_op.cc
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <deque>
 #include <memory>
 #include <string>
@@ -24,8 +25,10 @@ limitations under the License.
 
 #include "absl/log/check.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/statusor.h"
 #include "tensorflow/core/data/name_utils.h"
 #include "tensorflow/core/framework/dataset.h"
 #include "tensorflow/core/framework/dataset_options.pb.h"
@@ -38,6 +41,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/kernels/data/window_dataset.h"
 #include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/util/overflow.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/status.h"
 #include "tensorflow/core/platform/strcat.h"
@@ -124,7 +128,11 @@ class WindowDatasetOp::Dataset : public DatasetBase {
       // of the initial window. If it is negative, we know that the
       // cardinality is 0. Otherwise, it will be the number of valid shifts
       // over the rest_elements.
-      int64_t rest_elements = n - ((window_size_ - 1) * window_stride_ + 1);
+      int64_t target =
+          MultiplyWithoutOverflow(window_size_ - 1, window_stride_);
+      if (target >= 0) target = AddWithoutOverflow(target, 1);
+      // If the target overflows, no finite input can fill a complete window.
+      int64_t rest_elements = target < 0 ? -1 : n - target;
       cardinality = rest_elements < 0 ? 0 : rest_elements / window_shift_ + 1;
     } else {
       cardinality = n / window_shift_ + (n % window_shift_ == 0 ? 0 : 1);
@@ -183,7 +191,8 @@ class WindowDatasetOp::Dataset : public DatasetBase {
       std::vector<std::vector<Tensor>> window_elements;
       absl::Status status = absl::OkStatus();
       {
-        const size_t target_size = TargetBufferSize(window_size, window_stride);
+        TF_ASSIGN_OR_RETURN(const size_t target_size,
+                            TargetBufferSize(window_size, window_stride));
 
         mutex_lock l(mu_);
         if (!input_impl_ &&
@@ -410,8 +419,19 @@ class WindowDatasetOp::Dataset : public DatasetBase {
       return strings::StrCat(kBuffer, "[", index, "]", kErrorMessage);
     }
 
-    size_t TargetBufferSize(int64_t window_size, int64_t window_stride) {
-      return (window_size - 1) * window_stride + 1;
+    absl::StatusOr<size_t> TargetBufferSize(int64_t window_size,
+                                            int64_t window_stride) {
+      int64_t result = MultiplyWithoutOverflow(window_size - 1, window_stride);
+      if (result >= 0) result = AddWithoutOverflow(result, 1);
+      if (result < 0 || static_cast<uint64_t>(result) >
+                            std::numeric_limits<size_t>::max()) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Window target buffer size overflow: (window_size=%lld - 1) * "
+            "window_stride=%lld + 1 is not representable.",
+            static_cast<long long>(window_size),
+            static_cast<long long>(window_stride)));
+      }
+      return static_cast<size_t>(result);
     }
 
     mutex mu_;

--- a/tensorflow/core/kernels/data/window_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/window_dataset_op_test.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "xla/tsl/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/status_matchers.h"
 #include "tensorflow/core/data/dataset_test_base.h"
 #include "tensorflow/core/data/name_utils.h"
 #include "tensorflow/core/data/serialization_utils.h"
@@ -626,6 +627,37 @@ TEST_F(WindowDatasetOpTest, MalformedCheckpoint_TriggersOutOfBoundsRead) {
       << status.message();
 }
 
+// Regression test: large window_size and window_stride whose target buffer
+// size (window_size - 1) * window_stride + 1 overflows int64. Before the fix,
+// the overflow silently wrapped to a small value and emitted undersized
+// windows. After the fix, iteration must return InvalidArgument.
+WindowDatasetParams WindowDatasetParamsWithOverflowingSizeAndStride() {
+  // (2^32 + 1 - 1) * 2^32 + 1 = 2^64 + 1, which overflows int64/size_t.
+  const int64_t large_size = (static_cast<int64_t>(1) << 32) + 1;
+  const int64_t large_stride = static_cast<int64_t>(1) << 32;
+  return WindowDatasetParams(RangeDatasetParams(0, 3, 1),
+                             /*size=*/large_size,
+                             /*shift=*/1,
+                             /*stride=*/large_stride,
+                             /*drop_remainder=*/true,
+                             /*output_dtypes=*/{DT_VARIANT},
+                             /*output_shapes=*/{PartialTensorShape({})},
+                             /*node_name=*/kNodeName);
+}
+
+TEST_F(WindowDatasetOpTest, OverflowingTargetBufferSize) {
+  auto dataset_params = WindowDatasetParamsWithOverflowingSizeAndStride();
+  TF_ASSERT_OK(Initialize(dataset_params));
+
+  bool end_of_sequence = false;
+  std::vector<Tensor> out_tensors;
+  EXPECT_THAT(
+      iterator_->GetNext(iterator_ctx_.get(), &out_tensors, &end_of_sequence),
+      tensorflow::testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                                    ::testing::HasSubstr("overflow")));
+}
+
 }  // namespace
 }  // namespace data
 }  // namespace tensorflow
+


### PR DESCRIPTION
**Description**
`WindowDataset` computes the number of input elements needed for a complete window as `(window_size - 1) * window_stride + 1`. This multiplication was unchecked. With large valid positive attributes, the target wrapped to a small value, causing `drop_remainder=True` to silently emit undersized windows instead of dropping them.

**Changes:**
* Updated `TargetBufferSize` in both `window_dataset_op.cc` and `sliding_window_dataset_op.cc` to use checked arithmetic (`MultiplyWithoutOverflow` and `AddWithoutOverflow`).
* If the target buffer size is unrepresentable, it now returns an `InvalidArgumentError` instead of silently yielding incorrect data.
* Added a C++ regression test to verify `InvalidArgumentError` is correctly thrown when overflow-inducing size and stride values are provided.

Fixes #126131