### PR TITLE
Fix int32 prefix-stride overflow in CPU ScatterNd.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5802,6 +5802,7 @@ tf_cuda_cc_test(
         "//tensorflow/core:testlib",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@eigen_archive//:eigen3",
     ],
 )
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5730,6 +5730,7 @@ tf_kernel_library(
         "scatter_nd_op_cpu_impl_7.cc",
     ],
     hdrs = [
+        "scatter_nd_index.h",
         "scatter_nd_op.h",
     ],
     features = ["-layering_check"],
@@ -5737,6 +5738,7 @@ tf_kernel_library(
         "-Wno-pass-failed",  # clang misses #pragma loop optimizations
     ]),
     gpu_srcs = [
+        "scatter_nd_index.h",
         "scatter_nd_op.h",
         "scatter_nd_op_gpu.cu.cc",
     ],
@@ -6854,6 +6856,7 @@ filegroup(
         "save_restore_tensor.h",
         "scan_ops.h",
         "scatter_functor.h",
+        "scatter_nd_index.h",
         "scatter_nd_op.h",
         "scatter_nd_util.h",
         "searchsorted_op.h",

--- a/tensorflow/core/kernels/scatter_nd_index.h
+++ b/tensorflow/core/kernels/scatter_nd_index.h
@@ -1,0 +1,87 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_SCATTER_ND_INDEX_H_
+#define TENSORFLOW_CORE_KERNELS_SCATTER_ND_INDEX_H_
+
+#include <cstdint>
+
+#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
+#include "tensorflow/core/framework/bounds_check.h"
+#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/overflow.h"
+
+namespace tensorflow {
+namespace scatter_nd_op {
+
+// Computes prefix strides in int64. Returns false if a product overflows.
+// Do not store strides in the index tensor dtype: int32 indices into a
+// valid large shape would wrap and chip out of bounds.
+template <int IXDIM>
+bool ComputeScatterNdBatchStrides(
+    const Eigen::array<Eigen::DenseIndex, IXDIM>& output_shape_prefix,
+    Eigen::array<int64_t, IXDIM>* batch_strides) {
+  if (IXDIM > 0) {
+    (*batch_strides)[IXDIM - 1] = 1;
+  }
+  for (int dim = IXDIM - 2; dim >= 0; --dim) {
+    const int64_t prod = MultiplyWithoutOverflow(
+        (*batch_strides)[dim + 1],
+        static_cast<int64_t>(output_shape_prefix[dim + 1]));
+    if (TF_PREDICT_FALSE(prod < 0)) {
+      return false;
+    }
+    (*batch_strides)[dim] = prod;
+  }
+  return true;
+}
+
+// Flattens `coords` using int64 strides. Returns false if any coordinate is
+// out of range, arithmetic overflows, or the flat index is not in
+// [0, num_slices).
+template <typename Index, int IXDIM>
+bool ComputeScatterNdFlatIndex(
+    const Eigen::array<Eigen::DenseIndex, IXDIM>& output_shape_prefix,
+    const Eigen::array<int64_t, IXDIM>& batch_strides,
+    const Eigen::array<Index, IXDIM>& coords, int64_t num_slices,
+    int64_t* flat_index) {
+  int64_t i = 0;
+  for (int dim = 0; dim < IXDIM; ++dim) {
+    const Index ix_d = coords[dim];
+    if (TF_PREDICT_FALSE(!FastBoundsCheck(ix_d, output_shape_prefix[dim]))) {
+      return false;
+    }
+    const int64_t contrib = MultiplyWithoutOverflow(
+        static_cast<int64_t>(ix_d), batch_strides[dim]);
+    if (TF_PREDICT_FALSE(contrib < 0)) {
+      return false;
+    }
+    i = AddWithoutOverflow(i, contrib);
+    if (TF_PREDICT_FALSE(i < 0)) {
+      return false;
+    }
+  }
+  if (TF_PREDICT_FALSE(!FastBoundsCheck(i, num_slices))) {
+    return false;
+  }
+  *flat_index = i;
+  return true;
+}
+
+}  // namespace scatter_nd_op
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_SCATTER_ND_INDEX_H_

--- a/tensorflow/core/kernels/scatter_nd_op_cpu_impl.h
+++ b/tensorflow/core/kernels/scatter_nd_op_cpu_impl.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/kernels/fill_functor.h"
+#include "tensorflow/core/kernels/scatter_nd_index.h"
 #include "tensorflow/core/kernels/scatter_nd_op.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/types.h"
@@ -117,38 +118,39 @@ struct ScatterNdFunctor<CPUDevice, T, Index, OP, IXDIM> {
     Index error_loc = -1;
 
     const Eigen::DenseIndex batch_size = Tindices.dimension(0);
+    const Eigen::DenseIndex num_slices = Toutput.dimension(0);
 
-    Index batch_strides[IXDIM];
-    if (IXDIM > 0) {
-      batch_strides[IXDIM - 1] = 1;
-    }
-    for (int dim = IXDIM - 2; dim >= 0; --dim) {
-      batch_strides[dim] =
-          batch_strides[dim + 1] * output_shape_prefix[dim + 1];
+    Eigen::array<int64_t, IXDIM> batch_strides;
+    if (!scatter_nd_op::ComputeScatterNdBatchStrides<IXDIM>(output_shape_prefix,
+                                                            &batch_strides)) {
+      // Valid TensorShapes cannot overflow int64 element counts; this is a
+      // defensive fallback so we never chip with a wrapped stride.
+      return batch_size > 0 ? Index{0} : Index{-1};
     }
 
     for (Eigen::DenseIndex loc = 0; loc < batch_size; ++loc) {
-      Index i = 0;
-      bool out_of_bounds = false;
+      Eigen::array<Index, IXDIM> coords;
       for (int dim = 0; dim < IXDIM; ++dim) {
-        const Index ix_d = internal::SubtleMustCopy(Tindices(loc, dim));
-        out_of_bounds |= !FastBoundsCheck(ix_d, output_shape_prefix[dim]);
-        i += ix_d * batch_strides[dim];
+        coords[dim] = internal::SubtleMustCopy(Tindices(loc, dim));
       }
-      if (TF_PREDICT_FALSE(out_of_bounds)) {
+      int64_t i = 0;
+      const bool index_ok =
+          scatter_nd_op::ComputeScatterNdFlatIndex<Index, IXDIM>(
+              output_shape_prefix, batch_strides, coords, num_slices, &i);
+      if (TF_PREDICT_FALSE(!index_ok)) {
         error_loc = loc;
         // Don't break the loop here, but continue to update the rest because
         // the caller might ignore bad indices.
         continue;
-      } else {
-        auto input_chip = Toutput.template chip<0>(i);
-        auto output_chip = input_chip;
-        auto update_chip = Tupdates.template chip<0>(loc);
-        update_executor::UpdateExecutor<
-            CPUDevice, decltype(input_chip), decltype(update_chip),
-            decltype(output_chip), OP>::Execute(d, input_chip, update_chip,
-                                                output_chip);
       }
+      auto input_chip =
+          Toutput.template chip<0>(static_cast<Eigen::DenseIndex>(i));
+      auto output_chip = input_chip;
+      auto update_chip = Tupdates.template chip<0>(loc);
+      update_executor::UpdateExecutor<
+          CPUDevice, decltype(input_chip), decltype(update_chip),
+          decltype(output_chip), OP>::Execute(d, input_chip, update_chip,
+                                              output_chip);
     }
 
     return error_loc;

--- a/tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/scatter_nd_index.h"
 #include "tensorflow/core/kernels/scatter_nd_op.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
@@ -103,14 +104,18 @@ __global__ void ScatterNdOpKernel(
   auto update = LeftUpdate<T, op>();
 
   GPU_1D_KERNEL_LOOP(index, num_indices) {
-    Index i = 0;
+    int64_t i = 0;
     bool out_of_bounds = false;
 #pragma unroll
     for (int dim = 0; dim < IXDIM; ++dim) {
       int offset = (IXDIM * index + dim);
       const Index ix_d = internal::SubtleMustCopy(ldg(indices + offset));
-      out_of_bounds |= !FastBoundsCheck(ix_d, output_shape_prefix[dim]);
-      i += ix_d * batch_strides[dim] * slice_size;
+      if (!FastBoundsCheck(ix_d, output_shape_prefix[dim])) {
+        out_of_bounds = true;
+      } else if (!out_of_bounds) {
+        i += static_cast<int64_t>(ix_d) * batch_strides[dim] *
+             static_cast<int64_t>(slice_size);
+      }
     }
     if (!out_of_bounds) {
 #pragma unroll
@@ -140,14 +145,10 @@ struct ScatterNdFunctor<GPUDevice, T, Index, op, IXDIM> {
 
     const Eigen::DenseIndex batch_size = Tindices.dimension(0);
 
-    // Index batch_strides[IXDIM];
     Eigen::array<int64_t, IXDIM> batch_strides;
-    if (IXDIM > 0) {
-      batch_strides[IXDIM - 1] = 1;
-    }
-    for (int dim = IXDIM - 2; dim >= 0; --dim) {
-      batch_strides[dim] =
-          batch_strides[dim + 1] * output_shape_prefix[dim + 1];
+    if (!scatter_nd_op::ComputeScatterNdBatchStrides<IXDIM>(output_shape_prefix,
+                                                            &batch_strides)) {
+      return batch_size > 0 ? Index{0} : Index{-1};
     }
 
     GpuLaunchConfig config = GetGpuLaunchConfig(Toutput.size(), d);

--- a/tensorflow/core/kernels/scatter_nd_op_test.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_test.cc
@@ -671,8 +671,11 @@ TEST(ScatterNdIndexTest, Int32PrefixStrideDoesNotWrap) {
   Eigen::array<int32_t, 3> coords = {1, 0, 61440};
   const int64_t num_slices = 2LL * 65536LL * 65535LL;
   int64_t flat = -1;
-  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
-      prefix, strides, coords, num_slices, &flat));
+  // Assign first: ASSERT_TRUE(fn<T, N>(...)) treats the template comma as a
+  // second macro argument.
+  const bool in_range = scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, num_slices, &flat);
+  ASSERT_TRUE(in_range);
   EXPECT_EQ(flat, 4294963200LL);
   EXPECT_EQ(flat - (1LL << 32), -4096);
 }
@@ -683,8 +686,9 @@ TEST(ScatterNdIndexTest, Int64IndicesSameFlatIndex) {
   ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
   Eigen::array<int64_t, 3> coords = {1, 0, 61440};
   int64_t flat = -1;
-  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdFlatIndex<int64_t, 3>(
-      prefix, strides, coords, /*num_slices=*/2LL * 65536LL * 65535LL, &flat));
+  const bool in_range = scatter_nd_op::ComputeScatterNdFlatIndex<int64_t, 3>(
+      prefix, strides, coords, /*num_slices=*/2LL * 65536LL * 65535LL, &flat);
+  ASSERT_TRUE(in_range);
   EXPECT_EQ(flat, 4294963200LL);
 }
 
@@ -696,8 +700,9 @@ TEST(ScatterNdIndexTest, TwoDimStrideExceedsInt32) {
   EXPECT_EQ(strides[0], 3000000000LL);
   Eigen::array<int32_t, 2> coords = {1, 0};
   int64_t flat = -1;
-  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 2>(
-      prefix, strides, coords, /*num_slices=*/6000000000LL, &flat));
+  const bool in_range = scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 2>(
+      prefix, strides, coords, /*num_slices=*/6000000000LL, &flat);
+  ASSERT_TRUE(in_range);
   EXPECT_EQ(flat, 3000000000LL);
 }
 
@@ -707,8 +712,9 @@ TEST(ScatterNdIndexTest, SmallThreeDMatchesChipLayout) {
   ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
   Eigen::array<int32_t, 3> coords = {1, 0, 2};
   int64_t flat = -1;
-  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
-      prefix, strides, coords, /*num_slices=*/24, &flat));
+  const bool in_range = scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, /*num_slices=*/24, &flat);
+  ASSERT_TRUE(in_range);
   EXPECT_EQ(flat, 14);
 }
 
@@ -718,8 +724,9 @@ TEST(ScatterNdIndexTest, OutOfRangeCoordinateRejected) {
   ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
   Eigen::array<int32_t, 3> coords = {1, 0, 4};
   int64_t flat = -1;
-  EXPECT_FALSE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
-      prefix, strides, coords, /*num_slices=*/24, &flat));
+  const bool in_range = scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, /*num_slices=*/24, &flat);
+  EXPECT_FALSE(in_range);
 }
 
 TEST(ScatterNdIndexTest, NegativeCoordinateRejected) {
@@ -728,8 +735,9 @@ TEST(ScatterNdIndexTest, NegativeCoordinateRejected) {
   ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
   Eigen::array<int32_t, 3> coords = {-1, 0, 0};
   int64_t flat = -1;
-  EXPECT_FALSE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
-      prefix, strides, coords, /*num_slices=*/24, &flat));
+  const bool in_range = scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, /*num_slices=*/24, &flat);
+  EXPECT_FALSE(in_range);
 }
 
 TEST(ScatterNdIndexTest, FlatIndexPastNumSlicesRejected) {
@@ -738,8 +746,9 @@ TEST(ScatterNdIndexTest, FlatIndexPastNumSlicesRejected) {
   ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
   Eigen::array<int32_t, 3> coords = {1, 0, 2};  // flat index 14
   int64_t flat = -1;
-  EXPECT_FALSE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
-      prefix, strides, coords, /*num_slices=*/10, &flat));
+  const bool in_range = scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, /*num_slices=*/10, &flat);
+  EXPECT_FALSE(in_range);
 }
 
 TEST(ScatterNdIndexTest, StrideProductOverflowRejected) {

--- a/tensorflow/core/kernels/scatter_nd_op_test.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_test.cc
@@ -20,7 +20,6 @@ limitations under the License.
 
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
-#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "xla/tsl/lib/core/status_test_util.h"
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/framework/fake_input.h"

--- a/tensorflow/core/kernels/scatter_nd_op_test.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
+#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "xla/tsl/lib/core/status_test_util.h"
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/framework/fake_input.h"
@@ -32,6 +33,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/kernels/ops_testutil.h"
 #include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/kernels/scatter_nd_index.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/lib/random/simple_philox.h"
 #include "tensorflow/core/lib/strings/str_util.h"
@@ -336,6 +338,41 @@ TEST_F(ScatterNdUpdateOpTest, Simple_OneD) {
   test::ExpectTensorEqual<float>(expected, params_tensor);
 }
 
+TEST_F(ScatterNdUpdateOpTest, ThreeD_Int32Indices) {
+  MakeOp(DT_FLOAT_REF, DT_INT32);
+
+  // IXDIM=3 / int32 path used by GitHub issue 126136, on a small shape so
+  // prefix strides still fit in int32. The overflow case is covered by
+  // ScatterNdIndexTest below without allocating an 8GiB tensor.
+  AddInputFromArray<float>(TensorShape({2, 3, 4}),
+                           {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+  AddInputFromArray<int32_t>(TensorShape({1, 3}), {1, 0, 2});
+  AddInputFromArray<float>(TensorShape({1}), {9});
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor params_tensor = *mutable_input(0).tensor;
+  Tensor expected(allocator(), DT_FLOAT, TensorShape({2, 3, 4}));
+  test::FillValues<float>(&expected, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+  test::ExpectTensorEqual<float>(expected, params_tensor);
+}
+
+TEST_F(ScatterNdUpdateOpTest, ThreeD_Int32IndexOutOfRange) {
+  MakeOp(DT_FLOAT_REF, DT_INT32);
+
+  AddInputFromArray<float>(TensorShape({2, 3, 4}),
+                           {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+  AddInputFromArray<int32_t>(TensorShape({1, 3}), {1, 0, 4});
+  AddInputFromArray<float>(TensorShape({1}), {9});
+  absl::Status s = RunOpKernel();
+  EXPECT_TRUE(absl::StrContains(
+      s.ToString(),
+      "indices[0] = [1, 0, 4] does not index into shape [2,3,4]"))
+      << s;
+}
+
 TEST_F(ScatterNdUpdateOpTest, HigherRank) {
   MakeOp(DT_FLOAT_REF, DT_INT32);
 
@@ -615,6 +652,101 @@ TEST_F(ScatterNdOpConstructionTest, Error_BadIndicesPolicyInvalid) {
                    .Attr("bad_indices_policy", "AN_UNRECOGNIZED_POLICY")
                    .Finalize(node_def()));
   EXPECT_NE(InitOp(), absl::OkStatus());
+}
+
+TEST(ScatterNdIndexTest, Int32PrefixStrideDoesNotWrap) {
+  // Repro from GitHub issue 126136: shape [2, 65536, 65535], int32 indices
+  // [[1, 0, 61440]]. Storing the prefix stride in int32 wraps 65535*65536
+  // and chips 4096 bytes before the buffer. int64 strides keep the in-range
+  // flat index.
+  Eigen::array<Eigen::DenseIndex, 3> prefix = {2, 65536, 65535};
+  Eigen::array<int64_t, 3> strides;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
+  EXPECT_EQ(strides[2], 1);
+  EXPECT_EQ(strides[1], 65535);
+  EXPECT_EQ(strides[0], 4294901760LL);
+  // 65535*65536 modulo 2^32 is -65536; that plus 61440 is the ASan -4096.
+  EXPECT_EQ(strides[0] - (1LL << 32), -65536);
+
+  Eigen::array<int32_t, 3> coords = {1, 0, 61440};
+  const int64_t num_slices = 2LL * 65536LL * 65535LL;
+  int64_t flat = -1;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, num_slices, &flat));
+  EXPECT_EQ(flat, 4294963200LL);
+  EXPECT_EQ(flat - (1LL << 32), -4096);
+}
+
+TEST(ScatterNdIndexTest, Int64IndicesSameFlatIndex) {
+  Eigen::array<Eigen::DenseIndex, 3> prefix = {2, 65536, 65535};
+  Eigen::array<int64_t, 3> strides;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
+  Eigen::array<int64_t, 3> coords = {1, 0, 61440};
+  int64_t flat = -1;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdFlatIndex<int64_t, 3>(
+      prefix, strides, coords, /*num_slices=*/2LL * 65536LL * 65535LL, &flat));
+  EXPECT_EQ(flat, 4294963200LL);
+}
+
+TEST(ScatterNdIndexTest, TwoDimStrideExceedsInt32) {
+  Eigen::array<Eigen::DenseIndex, 2> prefix = {2, 3000000000LL};
+  Eigen::array<int64_t, 2> strides;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<2>(prefix, &strides));
+  EXPECT_EQ(strides[1], 1);
+  EXPECT_EQ(strides[0], 3000000000LL);
+  Eigen::array<int32_t, 2> coords = {1, 0};
+  int64_t flat = -1;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 2>(
+      prefix, strides, coords, /*num_slices=*/6000000000LL, &flat));
+  EXPECT_EQ(flat, 3000000000LL);
+}
+
+TEST(ScatterNdIndexTest, SmallThreeDMatchesChipLayout) {
+  Eigen::array<Eigen::DenseIndex, 3> prefix = {2, 3, 4};
+  Eigen::array<int64_t, 3> strides;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
+  Eigen::array<int32_t, 3> coords = {1, 0, 2};
+  int64_t flat = -1;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, /*num_slices=*/24, &flat));
+  EXPECT_EQ(flat, 14);
+}
+
+TEST(ScatterNdIndexTest, OutOfRangeCoordinateRejected) {
+  Eigen::array<Eigen::DenseIndex, 3> prefix = {2, 3, 4};
+  Eigen::array<int64_t, 3> strides;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
+  Eigen::array<int32_t, 3> coords = {1, 0, 4};
+  int64_t flat = -1;
+  EXPECT_FALSE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, /*num_slices=*/24, &flat));
+}
+
+TEST(ScatterNdIndexTest, NegativeCoordinateRejected) {
+  Eigen::array<Eigen::DenseIndex, 3> prefix = {2, 3, 4};
+  Eigen::array<int64_t, 3> strides;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
+  Eigen::array<int32_t, 3> coords = {-1, 0, 0};
+  int64_t flat = -1;
+  EXPECT_FALSE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, /*num_slices=*/24, &flat));
+}
+
+TEST(ScatterNdIndexTest, FlatIndexPastNumSlicesRejected) {
+  Eigen::array<Eigen::DenseIndex, 3> prefix = {2, 3, 4};
+  Eigen::array<int64_t, 3> strides;
+  ASSERT_TRUE(scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
+  Eigen::array<int32_t, 3> coords = {1, 0, 2};  // flat index 14
+  int64_t flat = -1;
+  EXPECT_FALSE(scatter_nd_op::ComputeScatterNdFlatIndex<int32_t, 3>(
+      prefix, strides, coords, /*num_slices=*/10, &flat));
+}
+
+TEST(ScatterNdIndexTest, StrideProductOverflowRejected) {
+  Eigen::array<Eigen::DenseIndex, 3> prefix = {2, 1LL << 40, 1LL << 40};
+  Eigen::array<int64_t, 3> strides;
+  EXPECT_FALSE(
+      scatter_nd_op::ComputeScatterNdBatchStrides<3>(prefix, &strides));
 }
 
 class ScatterNdUpdateBM : public ScatterNdUpdateOpTest {

--- a/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
@@ -231,6 +231,21 @@ class StatefulScatterNdTest(test.TestCase):
       result = self.evaluate(scatter)
       self.assertAllClose(result, expected)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testRank3Int32IndicesUint8(self):
+    # CPU IXDIM=3 + int32 indices (issue 126136 op path) on a small tensor.
+    ref = resource_variable_ops.ResourceVariable(
+        array_ops.zeros([2, 3, 4], dtypes.uint8), dtype=dtypes.uint8)
+    indices = constant_op.constant([[1, 0, 2]], dtype=dtypes.int32)
+    updates = constant_op.constant([0xA5], dtype=dtypes.uint8)
+    scatter = state_ops.scatter_nd_update(ref, indices, updates)
+    expected = np.zeros([2, 3, 4], dtype=np.uint8)
+    expected[1, 0, 2] = 0xA5
+    with test_util.device(use_gpu=False):
+      self.evaluate(ref.initializer)
+      self.evaluate(scatter)
+      self.assertAllEqual(self.evaluate(ref), expected)
+
   def testVariableRankUpdate(self):
     self._VariableRankTests(_NumpyUpdate, state_ops.scatter_nd_update)
 

--- a/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
@@ -234,14 +234,14 @@ class StatefulScatterNdTest(test.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def testRank3Int32IndicesUint8(self):
     # CPU IXDIM=3 + int32 indices (issue 126136 op path) on a small tensor.
-    ref = resource_variable_ops.ResourceVariable(
-        array_ops.zeros([2, 3, 4], dtypes.uint8), dtype=dtypes.uint8)
-    indices = constant_op.constant([[1, 0, 2]], dtype=dtypes.int32)
-    updates = constant_op.constant([0xA5], dtype=dtypes.uint8)
-    scatter = state_ops.scatter_nd_update(ref, indices, updates)
-    expected = np.zeros([2, 3, 4], dtype=np.uint8)
-    expected[1, 0, 2] = 0xA5
     with test_util.device(use_gpu=False):
+      ref = resource_variable_ops.ResourceVariable(
+          array_ops.zeros([2, 3, 4], dtypes.uint8), dtype=dtypes.uint8)
+      indices = constant_op.constant([[1, 0, 2]], dtype=dtypes.int32)
+      updates = constant_op.constant([0xA5], dtype=dtypes.uint8)
+      scatter = state_ops.scatter_nd_update(ref, indices, updates)
+      expected = np.zeros([2, 3, 4], dtype=np.uint8)
+      expected[1, 0, 2] = 0xA5
       self.evaluate(ref.initializer)
       self.evaluate(scatter)
       self.assertAllEqual(self.evaluate(ref), expected)


### PR DESCRIPTION
## Summary
- CPU `ScatterNd` stored prefix strides and the flat chip index in the index dtype, so valid int32 coordinates into a large shape wrapped (`65535*65536` → `-65536`) and wrote OOB (`i=-4096`, matching ASan on #126136).
- Compute strides and the flat offset in int64 with overflow checks; GPU uses the same stride helper and no longer accumulates into `Index`.
- Tests cover the wrap math without an 8GiB allocation, plus small 3D success/OOB paths.

## Test plan
- [ ] `bazel test //tensorflow/core/kernels:scatter_nd_op_test`
- [ ] `bazel test //tensorflow/python/kernel_tests/array_ops:scatter_nd_ops_test`
- [ ] Optional: ASan replay of the issue PoC if memory allows (~8–12 GiB)