### PR TITLE
[TFLite] Fuse coefficient-first tanh-approximation GELU to tfl.gelu

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -4067,6 +4067,46 @@ func.func @gelu_approximate1_with_mul1(%arg0: tensor<3xf32>) -> tensor<3xf32> {
 // CHECK: "tfl.gelu"(%arg0) <{approximate = true}> : (tensor<3xf32>) -> tensor<3xf32>
 }
 
+func.func @gelu_approximate_with_mul3(%arg0: tensor<3xf32>) -> tensor<3xf32> {
+  %cst = arith.constant dense<0.797884583> : tensor<f32>
+  %cst_0 = arith.constant dense<5.000000e-01> : tensor<f32>
+  %cst_1 = arith.constant dense<1.000000e+00> : tensor<f32>
+  %cst_3 = arith.constant dense<4.471500e-02> : tensor<f32>
+  %0 = "tfl.mul"(%arg0, %cst_3) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
+  %1 = "tfl.mul"(%0, %arg0) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %2 = "tfl.mul"(%1, %arg0) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %3 = "tfl.add"(%arg0, %2) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %4 = "tfl.mul"(%3, %cst) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
+  %5 = "tfl.tanh"(%4) : (tensor<3xf32>) -> tensor<3xf32>
+  %6 = "tfl.add"(%5, %cst_1) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
+  %7 = "tfl.mul"(%arg0, %cst_0) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
+  %8 = "tfl.mul"(%7, %6) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  func.return %8 : tensor<3xf32>
+
+// CHECK-LABEL:gelu_approximate
+// CHECK: "tfl.gelu"(%arg0) <{approximate = true}> : (tensor<3xf32>) -> tensor<3xf32>
+}
+
+func.func @gelu_approximate1_with_mul3(%arg0: tensor<3xf32>) -> tensor<3xf32> {
+  %cst = arith.constant dense<0.797884583> : tensor<f32>
+  %cst_0 = arith.constant dense<5.000000e-01> : tensor<f32>
+  %cst_1 = arith.constant dense<1.000000e+00> : tensor<f32>
+  %cst_3 = arith.constant dense<4.471500e-02> : tensor<f32>
+  %0 = "tfl.mul"(%arg0, %cst_3) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
+  %1 = "tfl.mul"(%0, %arg0) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %2 = "tfl.mul"(%1, %arg0) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %3 = "tfl.add"(%arg0, %2) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  %4 = "tfl.mul"(%3, %cst) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
+  %5 = "tfl.tanh"(%4) : (tensor<3xf32>) -> tensor<3xf32>
+  %6 = "tfl.add"(%5, %cst_1) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
+  %7 = "tfl.mul"(%6, %cst_0) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
+  %8 = "tfl.mul"(%arg0, %7) {fused_activation_function = "NONE"} : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+  func.return %8 : tensor<3xf32>
+
+// CHECK-LABEL:gelu_approximate
+// CHECK: "tfl.gelu"(%arg0) <{approximate = true}> : (tensor<3xf32>) -> tensor<3xf32>
+}
+
 func.func @gelu_approximate_no_match(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %cst = arith.constant dense<0.797884583> : tensor<f32>
   %cst_0 = arith.constant dense<5.000000e-01> : tensor<f32>

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -1526,6 +1526,41 @@ def MatchGeluApproximate_Mul2 : Pat<
    (HasOneUse $sqr_out),
   ]>;
 
+// Alternate pattern for GeluApproximate to match mul(mul(mul(x, coeff), x), x),
+// the cube shape produced by the left-associative spelling
+// `0.044715 * x * x * x` (common in Python model code), where the coefficient
+// is folded into the innermost mul so no bare x^3 subterm exists.
+//   0.5 * x * ( 1 + tanh( sqrt_2dPi  * ( x + mul(mul(mul(x, 0.044715), x), x) ) ) )
+def MatchGeluApproximate_Mul3 : Pat<
+  (TFL_MulOp
+   (TFL_MulOp:$mul_out $arg0, (Arith_ConstantOp F32ElementsAttr:$Cst_1_2), TFL_AF_None),
+   (TFL_AddOp:$add_out
+    (TFL_TanhOp:$tanh_out
+     (TFL_MulOp:$mul_out1
+      (TFL_AddOp:$add_out1 $arg0,
+       (TFL_MulOp:$mul_out2
+        (TFL_MulOp:$mul_out3
+         (TFL_MulOp:$mul_out4 $arg0,
+          (Arith_ConstantOp F32ElementsAttr:$Coeff), TFL_AF_None),
+         $arg0, TFL_AF_None),
+        $arg0, TFL_AF_None), TFL_AF_None),
+      (Arith_ConstantOp F32ElementsAttr:$Cst_sqrt_2dPi), TFL_AF_None)),
+    (Arith_ConstantOp F32ElementsAttr:$Cst_1), TFL_AF_None), TFL_AF_None),
+  (TFL_GeluOp $arg0, ConstBoolAttrTrue),
+  [(FloatValueEquals<"0.5"> $Cst_1_2),
+   (FloatValueEquals<"1"> $Cst_1),
+   (FloatValueEquals<"0.797884583"> $Cst_sqrt_2dPi),
+   (FloatValueEquals<"0.044715"> $Coeff),
+   (HasOneUse $mul_out),
+   (HasOneUse $add_out),
+   (HasOneUse $tanh_out),
+   (HasOneUse $mul_out1),
+   (HasOneUse $add_out1),
+   (HasOneUse $mul_out2),
+   (HasOneUse $mul_out3),
+   (HasOneUse $mul_out4),
+  ]>;
+
 // Alternate pattern for GeluApproximate (see different order for mul), replaces
 //   x * ( 0.5 * ( 1 + tanh( sqrt_2dPi  * ( x + 0.044715 * pow( x, 3 ) ) ) ) )
 def MatchGeluApproximate1 : Pat<
@@ -1614,6 +1649,38 @@ def MatchGeluApproximate1_Mul2 : Pat<
    (HasOneUse $mul_out2),
    (HasOneUse $pow_out),
    (HasOneUse $sqr_out),
+  ]>;
+
+// Alternate pattern for GeluApproximate1 to match mul(mul(mul(x, coeff), x), x).
+//   x * ( 0.5 * ( 1 + tanh( sqrt_2dPi  * ( x + mul(mul(mul(x, 0.044715), x), x) ) ) ) )
+def MatchGeluApproximate1_Mul3 : Pat<
+  (TFL_MulOp $arg0,
+   (TFL_MulOp:$mul_out
+    (TFL_AddOp:$add_out
+     (TFL_TanhOp:$tanh_out
+      (TFL_MulOp:$mul_out1
+       (TFL_AddOp:$add_out1 $arg0,
+        (TFL_MulOp:$mul_out2
+         (TFL_MulOp:$mul_out3
+          (TFL_MulOp:$mul_out4 $arg0,
+           (Arith_ConstantOp F32ElementsAttr:$Coeff), TFL_AF_None),
+          $arg0, TFL_AF_None),
+         $arg0, TFL_AF_None), TFL_AF_None),
+       (Arith_ConstantOp F32ElementsAttr:$Cst_sqrt_2dPi), TFL_AF_None)),
+     (Arith_ConstantOp F32ElementsAttr:$Cst_1), TFL_AF_None), (Arith_ConstantOp F32ElementsAttr:$Cst_1_2), TFL_AF_None), TFL_AF_None),
+  (TFL_GeluOp $arg0, ConstBoolAttrTrue),
+  [(FloatValueEquals<"0.5"> $Cst_1_2),
+   (FloatValueEquals<"1"> $Cst_1),
+   (FloatValueEquals<"0.797884583"> $Cst_sqrt_2dPi),
+   (FloatValueEquals<"0.044715"> $Coeff),
+   (HasOneUse $mul_out),
+   (HasOneUse $add_out),
+   (HasOneUse $tanh_out),
+   (HasOneUse $mul_out1),
+   (HasOneUse $add_out1),
+   (HasOneUse $mul_out2),
+   (HasOneUse $mul_out3),
+   (HasOneUse $mul_out4),
   ]>;
 
 // For Gelu, replaces


### PR DESCRIPTION
## Description

The optimize pass fuses the raw tanh-approximation GELU `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))` into `tfl.gelu(approximate = true)` when the cube is spelled `pow(x, 3)` (`MatchGeluApproximate`, `MatchGeluApproximate1`), `mul(x, mul(x, x))` (`*_Mul1`) or `mul(mul(x, x), x)` (`*_Mul2`). The equally common left-associative spelling `0.044715 * x * x * x` — Python's natural association `((0.044715*x)*x)*x`, common in PyTorch model code — folds the coefficient into the innermost mul, so no x^3 subterm exists and none of the six variants match. Such graphs ship a 6-MUL/2-ADD/1-TANH chain instead of `tfl.gelu`.

On accelerators where the builtin GELU has a fast path this is a large end-to-end cost: on a Galaxy S26 Hexagon NPU (LiteRT 2.2.0), DINOv2-S with the chain runs 85.9 ms vs 38.5 ms with `tfl.gelu(approximate=true)`. Measurements and reproduction in google-ai-edge/litert-torch#1190, where @sirakiin suggested adding the fusion alongside the existing patterns.

## Solution

Add `MatchGeluApproximate_Mul3` and `MatchGeluApproximate1_Mul3` — the coefficient-first cube `mul(mul(mul(x, 0.044715), x), x)` for both existing outer-multiply-order families — with the same exact-constant and one-use constraints as the siblings. Same math as the existing variants' target: on a real DINOv2-S conversion the chain and `tfl.gelu(approximate=true)` differ by max_abs 9e-05 (fp32).

## Testing

Two FileCheck tests (`@gelu_approximate_with_mul3`, `@gelu_approximate1_with_mul3`) in `tensorflow/compiler/mlir/lite/tests/optimize.mlir`, mirroring the existing GELU fusion tests; the op chains are exactly what litert-torch 0.9.3 emits for the left-associative spelling (verified in the exported flatbuffers).

```
bazel test //tensorflow/compiler/mlir/lite/tests:optimize.mlir.test
```
