### PR TITLE
Validate axis bounds in np.split for negative out-of-bounds axes

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1206,6 +1206,15 @@ def _boundaries_to_sizes(a, boundaries, axis):
 @np_utils.np_doc('split')
 def split(ary, indices_or_sections, axis=0):
   ary = asarray(ary)
+  if isinstance(axis, (int, np.integer)):
+    rank = ary.shape.rank
+    if rank is not None:
+      norm = int(axis) + rank if int(axis) < 0 else int(axis)
+      if norm < 0 or norm >= rank:
+        raise ValueError(
+            f'Argument `axis` (received axis={axis}) is out of bounds '
+            f'for input {ary} of rank {rank}.'
+        )
   if not isinstance(indices_or_sections, int):
     indices_or_sections = _boundaries_to_sizes(ary, indices_or_sections, axis)
   return array_ops.split(ary, indices_or_sections, axis=axis)

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -1363,6 +1363,13 @@ class ArrayMethodsTest(test.TestCase):
     y = np_array_ops.split(x, [3, 5, 6, 10])
     self.assertListEqual([([0, 1, 2]), ([3, 4]), ([5]), ([6, 7]), ([])], y)
 
+  def testSplitOutOfBoundsAxis(self):
+    x = np_array_ops.arange(6).reshape(2, 3)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.split(x, 2, axis=-3)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.split(x, 2, axis=2)
+
   def testHSplitBecomesVsplitFor1DInput(self):
     @def_function.function
     def f(arr):


### PR DESCRIPTION
## Summary

This PR adds static axis bounds validation to `np.split`, matching NumPy's behavior.

### Problem

Currently, `np.split` does not validate the `axis` argument before passing it to `tf.split`. When `axis` is a negative value that exceeds the input's rank (e.g. `axis=-3` on a rank-2 tensor), TensorFlow raises an opaque `IndexError: tuple index out of range` instead of a clear `ValueError`.

### Fix

Added a static bounds check in `split()` that normalizes negative axes and raises `ValueError` if the normalized axis is out of range. The check only fires when both `axis` and the input rank are statically known.

### Tests

Added `testSplitOutOfBoundsAxis` verifying that out-of-bounds axes (both positive and negative) raise `ValueError`.