### PR TITLE
Validate axes are different in np.rot90 and reject out-of-bounds axes

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1528,8 +1528,28 @@ def roll(a, shift, axis=None):  # pylint: disable=missing-docstring
 @tf_export.tf_export('experimental.numpy.rot90', v1=[])
 @np_utils.np_doc('rot90')
 def rot90(m, k=1, axes=(0, 1)):  # pylint: disable=missing-docstring
-  m_rank = array_ops.rank(m)
-  ax1, ax2 = np_utils._canonicalize_axes(axes, m_rank)  # pylint: disable=protected-access
+  m = asarray(m)
+  m_rank = m.shape.rank
+  ax1, ax2 = axes[0], axes[1]
+
+  # Validate axes are integers and different (matching NumPy).
+  if isinstance(ax1, (int, np.integer)) and isinstance(ax2, (int, np.integer)):
+    if ax1 == ax2:
+      raise ValueError('Axes must be different.')
+    if m_rank is not None:
+      for name, ax in (('axis1', ax1), ('axis2', ax2)):
+        norm = int(ax) + m_rank if int(ax) < 0 else int(ax)
+        if norm < 0 or norm >= m_rank:
+          raise ValueError(
+              f'{name} axis is out of bounds for array of dimension {m_rank}.'
+          )
+  else:
+    control_flow_assert.Assert(
+        math_ops.not_equal(ax1, ax2),
+        ['Axes must be different.'],
+    )
+
+  ax1, ax2 = np_utils._canonicalize_axes(axes, array_ops.rank(m))  # pylint: disable=protected-access
 
   k = k % 4
   if k == 0:

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -1398,6 +1398,13 @@ class ArrayManipulationTest(test.TestCase):
         np_array_ops.array,
     ]
 
+  def testRot90SameAxes(self):
+    x = np_array_ops.array(np.arange(6).reshape(2, 3))
+    with self.assertRaisesRegex(ValueError, 'Axes must be different'):
+      np_array_ops.rot90(x, k=1, axes=(0, 0))
+    with self.assertRaisesRegex(ValueError, 'Axes must be different'):
+      np_array_ops.rot90(x, k=2, axes=(1, 1))
+
   def testBroadcastTo(self):
 
     def run_test(arr, shape):


### PR DESCRIPTION
## Summary

This PR adds validation to `np.rot90` to reject identical axes and out-of-bounds axes, matching NumPy's behavior.

### Problem

Currently, `np.rot90` does not check that `axes` contains two different values. When the same axis is passed twice (e.g. `axes=(0, 0)`), NumPy raises `ValueError: Axes must be different.`, but TensorFlow silently produces incorrect results. Additionally, out-of-bounds axes are not caught early.

### Fix

Added static validation that:
1. Rejects identical axes with `ValueError('Axes must be different.')`
2. Rejects out-of-bounds axes with a clear `ValueError`
3. Uses a runtime `Assert` for symbolic axes to catch same-axes at graph execution time

### Tests

Added `testRot90SameAxes` verifying that identical axes raise `ValueError`.