### PR TITLE
Replace assert with ValueError for axis validation in np.compress

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -460,7 +460,10 @@ def compress(condition, a, axis=None):  # pylint: disable=redefined-outer-name,m
   if axis < 0:
     axis += a.ndim
 
-  assert axis >= 0 and axis < a.ndim
+  if axis < 0 or axis >= a.ndim:
+    raise ValueError(
+        f'Argument `axis` is out of bounds for input of rank {a.ndim}.'
+    )
 
   # `tf.boolean_mask` requires `a`'s size along `axis` to equal `condition`'s
   # length. `np.compress` instead pairs `condition[k]` with `a[k]` along `axis`

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -641,6 +641,13 @@ class ArrayMethodsTest(test.TestCase):
     run_test([True, False], [[1, 2, 3], [4, 5, 6]], axis=1)
     run_test([True], [[1, 2], [3, 4], [5, 6]], axis=0)
 
+  def testCompressOutOfBoundsAxis(self):
+    x = np_array_ops.array([[1, 2], [3, 4]])
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.compress([True, False], x, axis=-3)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.compress([True, False], x, axis=2)
+
   def testCompressJitCompile(self):
     # Regression test for #122055: `compress` produced a dynamic size bounded by
     # `a.shape[axis]` rather than `len(condition)`, so feeding its result into an


### PR DESCRIPTION
## Summary

This PR replaces the fragile `assert` statement in `np.compress` with a proper `ValueError`, matching NumPy's behavior.

### Problem

`np.compress` uses `assert axis >= 0 and axis < a.ndim` to validate the axis. This has two issues:
1. `assert` can be disabled entirely with `python -O`, silently accepting invalid axes
2. When triggered, it raises `AssertionError` instead of the `ValueError` that NumPy raises

### Fix

Replaced the `assert` with an explicit bounds check that raises `ValueError` with a descriptive message, matching NumPy's AxisError (a ValueError subclass).

### Tests

Added `testCompressOutOfBoundsAxis` verifying that out-of-bounds axes (both positive and negative) raise `ValueError`.