### PR TITLE
Fix error message typo in np.diff for negative n

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1169,7 +1169,7 @@ def diff(a, n=1, axis=-1):  # pylint: disable=missing-function-docstring
       )
     if n < 0:
       raise ValueError(
-          f'Argument `order` must be a non-negative integer. Received: n={n}'
+          f'Argument `n` must be a non-negative integer. Received: n={n}'
       )
     slice1 = [slice(None)] * nd
     slice2 = [slice(None)] * nd

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1169,7 +1169,7 @@ def diff(a, n=1, axis=-1):  # pylint: disable=missing-function-docstring
       )
     if n < 0:
       raise ValueError(
-          f'Argument `order` must be a non-negative integer. Received: axis={n}'
+          f'Argument `order` must be a non-negative integer. Received: n={n}'
       )
     slice1 = [slice(None)] * nd
     slice2 = [slice(None)] * nd

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -426,7 +426,9 @@ class MathTest(test.TestCase, parameterized.TestCase):
   def testDiffErrorMessage(self):
     # Verify the error message for negative n mentions the parameter correctly.
     x = np_array_ops.array([1, 2, 3])
-    with self.assertRaisesRegex(ValueError, 'n=-1'):
+    with self.assertRaisesRegex(
+        ValueError,
+        r'Argument `n` must be a non-negative integer\. Received: n=-1'):
       np_math_ops.diff(x, n=-1)
 
   def testAverageWrongShape(self):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -423,6 +423,12 @@ class MathTest(test.TestCase, parameterized.TestCase):
     )
     self.match(dynamic_cross(a, b), np.cross(a, b), check_dtype=False)
 
+  def testDiffErrorMessage(self):
+    # Verify the error message for negative n mentions the parameter correctly.
+    x = np_array_ops.array([1, 2, 3])
+    with self.assertRaisesRegex(ValueError, 'n=-1'):
+      np_math_ops.diff(x, n=-1)
+
   def testAverageWrongShape(self):
     with self.assertRaisesWithPredicateMatch(errors.InvalidArgumentError, r''):
       np_math_ops.average(np.ones([2, 3]), weights=np.ones([2, 4]))


### PR DESCRIPTION
## Summary

Fixes a typo in the error message raised by `np.diff` when `n` is negative.

### Problem

The error message says `Received: axis={n}` but the parameter is `n`, not `axis`. This is confusing for users debugging their code.

### Fix

Changed `Received: axis={n}` to `Received: n={n}` in the ValueError message.

### Tests

Added `testDiffErrorMessage` verifying the error message contains the correct parameter name.