### PR TITLE
Export tflite::ConvertMlirBytecode from the Windows pywrap library

### DIFF
--- a/tensorflow/python/_pywrap_tensorflow.def
+++ b/tensorflow/python/_pywrap_tensorflow.def
@@ -256,6 +256,7 @@ EXPORTS
  ?ComputeGradient@Tape@gradients@tensorflow@@QEAA?AVStatus@lts_20260526@absl@@PEAVAbstractContext@3@V?$Span@QEAVAbstractTensorHandle@tensorflow@@@56@11V?$Span@PEAVAbstractTensorHandle@tensorflow@@@56@@Z
  ?Convert@PythonTensorConverter@tensorflow@@QEBA?AV?$unique_ptr@U_object@@UPyDecrefDeleter@detail@tensorflow@@@std@@PEAU_object@@AEAW4DataType@2@PEA_N@Z
  ?Convert@tflite@@YAPEAU_object@@PEAU2@00_N0PEBVPyFunctionLibrary@quantization@tensorflow@@@Z
+ ?ConvertMlirBytecode@tflite@@YAPEAU_object@@PEAU2@00@Z
  ?ConvertPyObjectToAttributeType@tensorflow@@YA?AV?$unique_ptr@U_object@@UPyDecrefDeleter@detail@tensorflow@@@std@@PEAU_object@@W4AttributeType@1@@Z
  ?ConvertPythonAPIParameters@tensorflow@@YA_NAEBVPythonAPIInfo@1@AEBVPythonTensorConverter@1@V?$Span@PEAU_object@@@lts_20260526@absl@@PEAUInferredAttributes@21@@Z
  ?ConvertToEagerTensor@tensorflow@@YAPEAUTFE_TensorHandle@@PEAUTFE_Context@@PEAU_object@@W4DataType@1@PEBD@Z

--- a/tensorflow/tools/def_file_filter/symbols_pybind.txt
+++ b/tensorflow/tools/def_file_filter/symbols_pybind.txt
@@ -264,6 +264,7 @@ tflite::MlirSparsifyModel
 tflite::RegisterCustomOpdefs
 tflite::RetrieveCollectedErrors
 tflite::FlatBufferFileToMlir
+tflite::ConvertMlirBytecode
 
 [//tensorflow/core:op_gen_lib] # tf_session
 tensorflow::ApiDefMap::~ApiDefMap


### PR DESCRIPTION
## What

Adds `tflite::ConvertMlirBytecode` to the two lists that decide which symbols the Windows pywrap library exports.

## Why

The Windows presubmit fails to link on every pull request, whatever it changes:

```
lld-link: error: undefined symbol: ?ConvertMlirBytecode@tflite@@YAPEAU_object@@PEAU2@00@Z
ERROR: Linking tensorflow/python/__pywrap_tensorflow_0_shared_object.dll failed:
  (Exit 1): lld-link.exe failed
```

b8fb4eb5422 ("Add an interface for loading a model from mlir bytecode", 2026-08-25) added `ConvertMlirBytecode` to `converter_python_api` and called it from `converter_python_api_wrapper.cc`. Windows exports only the symbols named in `tensorflow/python/_pywrap_tensorflow.def` and `tensorflow/tools/def_file_filter/symbols_pybind.txt`, and the new function is in neither, so the wrapper's reference has nothing to bind to.

`converter_python_api.h` states the requirement immediately below the declaration:

```c++
// All the exported functions should be listed in
// tensorflow/tools/def_file_filter/symbols_pybind.txt for the Windows build.
```

The other six functions in that namespace, `Convert`, `MlirQuantizeModel`, `MlirSparsifyModel`, `RegisterCustomOpdefs`, `RetrieveCollectedErrors` and `FlatBufferFileToMlir`, are in both lists. This is the seventh.

## Scope

Two added lines, no code change. The `.def` entry preserves the file's C sort order, and the mangled name is the one the linker asks for verbatim.

Unrelated to any particular pull request: it is reproducible on current `master` and is currently failing the Windows job on every open PR I checked.
