### PR TITLE
Convert the input before inferring axes in the N-D FFT ops

### DIFF
--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -24,6 +24,7 @@ from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
+from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_spectral_ops
@@ -470,6 +471,16 @@ class FFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     self._check_grad_complex(self._tf_ifft_for_rank(rank), re, im,
                              rtol=tol, atol=tol)
 
+  def testNDOpsAcceptNonTensorInput(self):
+    # The axes used to be inferred from the input before it was converted to
+    # a tensor, so a plain Python list raised AttributeError rather than
+    # being accepted like the equivalent tensor. Build the ops in a graph so
+    # this does not depend on an FFTND/IFFTND kernel being registered.
+    x = [[1., 2.], [3., 4.]]
+    with ops.Graph().as_default():
+      self.assertIsNotNone(fft_ops.fftnd(x))
+      self.assertIsNotNone(fft_ops.ifftnd(x))
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
@@ -522,6 +533,16 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
       fft_ops.irfft(x, fft_length=[-5, -5])
     with self.assertRaisesRegex(ValueError, "Dimension must be 2 but is 1"):
       fft_ops.irfftnd(x, fft_length=[-5])
+
+  def testNDOpsAcceptNonTensorInput(self):
+    # The axes used to be inferred from the input before it was converted to
+    # a tensor, so a plain Python list raised AttributeError rather than
+    # being accepted like the equivalent tensor. Build the ops in a graph so
+    # this does not depend on an RFFTND/IRFFTND kernel being registered.
+    x = [[1., 2.], [3., 4.]]
+    with ops.Graph().as_default():
+      self.assertIsNotNone(fft_ops.rfftnd(x))
+      self.assertIsNotNone(fft_ops.irfftnd(x))
 
   def _np_fftn(self, x, fft_length=None, axes=None, norm=None):
     return np.fft.rfftn(x, s=fft_length, axes=axes, norm=norm)

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -233,11 +233,13 @@ def _fftn_wrapper(fft_n, default_name):
     with _ops.name_scope(
         name, default_name, [input_tensor, fft_length, axes]
     ) as name:
-      axes = _process_empty_axes(input_tensor, axes)
-      fft_rank = axes.shape[0]
+      # Convert first: inferring the axes reads `input_tensor.shape`,
+      # which a list or a scalar does not have.
       input_tensor = _ops.convert_to_tensor(
           input_tensor, preferred_dtype=_dtypes.complex64
       )
+      axes = _process_empty_axes(input_tensor, axes)
+      fft_rank = axes.shape[0]
       input_tensor.shape.with_rank_at_least(fft_rank)
       if fft_length is None:
         fft_length = _infer_fft_length_for_fftn(input_tensor)
@@ -273,11 +275,13 @@ def _ifftn_wrapper(ifft_n, default_name):
     with _ops.name_scope(
         name, default_name, [input_tensor, fft_length, axes]
     ) as name:
-      axes = _process_empty_axes(input_tensor, axes)
-      fft_rank = axes.shape[0]
+      # Convert first: inferring the axes reads `input_tensor.shape`,
+      # which a list or a scalar does not have.
       input_tensor = _ops.convert_to_tensor(
           input_tensor, preferred_dtype=_dtypes.complex64
       )
+      axes = _process_empty_axes(input_tensor, axes)
+      fft_rank = axes.shape[0]
       input_tensor.shape.with_rank_at_least(fft_rank)
       if fft_length is None:
         fft_length = _infer_fft_length_for_fftn(input_tensor)
@@ -313,11 +317,13 @@ def _rfftn_wrapper(rfft_n, default_name):
     with _ops.name_scope(
         name, default_name, [input_tensor, fft_length, axes]
     ) as name:
-      axes = _process_empty_axes(input_tensor, axes)
-      fft_rank = axes.shape[0]
+      # Convert first: inferring the axes reads `input_tensor.shape`,
+      # which a list or a scalar does not have.
       input_tensor = _ops.convert_to_tensor(
           input_tensor, preferred_dtype=_dtypes.float32
       )
+      axes = _process_empty_axes(input_tensor, axes)
+      fft_rank = axes.shape[0]
       if input_tensor.dtype not in (_dtypes.float32, _dtypes.float64):
         raise ValueError(
             "RFFT requires tf.float32 or tf.float64 inputs, got: %s"
@@ -370,11 +376,13 @@ def _irfftn_wrapper(irfft_n, default_name):
     with _ops.name_scope(
         name, default_name, [input_tensor, fft_length]
     ) as name:
-      axes = _process_empty_axes(input_tensor, axes)
-      fft_rank = axes.shape[0]
+      # Convert first: inferring the axes reads `input_tensor.shape`,
+      # which a list or a scalar does not have.
       input_tensor = _ops.convert_to_tensor(
           input_tensor, preferred_dtype=_dtypes.complex64
       )
+      axes = _process_empty_axes(input_tensor, axes)
+      fft_rank = axes.shape[0]
       input_tensor.shape.with_rank_at_least(fft_rank)
       if input_tensor.dtype not in (_dtypes.complex64, _dtypes.complex128):
         raise ValueError(


### PR DESCRIPTION
`tf.signal.fftnd`, `ifftnd`, `rfftnd` and `irfftnd` reject a plain Python list:

```python
>>> import tensorflow as tf
>>> tf.signal.fftnd([[1.0, 2.0], [3.0, 4.0]])
AttributeError: 'list' object has no attribute 'shape'
```

The same value works if you wrap it in `tf.constant` first, and a numpy array works too — because a numpy array happens to have `.shape`.

All four wrappers start the same way:

```python
axes = _process_empty_axes(input_tensor, axes)
fft_rank = axes.shape[0]
input_tensor = _ops.convert_to_tensor(input_tensor, preferred_dtype=...)
```

When `axes` is left at its default, `_process_empty_axes` calls `_infer_axes_for_fftn`, which does `len(input_tensor.shape)` — on the raw argument, one line before it's converted. Every other op in the file converts first, so this is just the two statements being in the wrong order.

The fix moves the conversion above the axes inference in all four. An already converted tensor is unaffected: `convert_to_tensor` is a no-op on a tensor, so `_process_empty_axes` gets exactly the object it got before.

### Checking it

The property I used is that a non-tensor input should behave the same as the equivalent tensor of the same rank. Across the four ops with lists, numpy arrays, Python scalars and 1-D lists, that's 8 mismatches before the change and 0 after.

The N-D FFT kernels aren't registered for CPU on my machine, so I can't check the numerics here — after the change these calls reach the kernel and report `NotFoundError`, exactly as the tensor form already did. What I can show is that the Python-level failure is gone and both forms now behave identically. The new tests are written to build the ops in a graph rather than execute them, so they exercise this path without needing a kernel on the test device.

I verified against master by copying the current `fft_ops.py` into an installed wheel and running the repo's own tests. The two new tests fail before the change in both graph and eager mode with the `AttributeError` above, and pass after. The full `fft_ops_test.py` is 483 tests: on unmodified master it reports 4 errors, which are exactly the 4 new test cases, and with the change it's clean. No other test changes state either way.

### One thing I did not fix

`tf.signal.irfftnd` on a rank 0 input raises `IndexError: list index out of range` from `_maybe_pad_for_rfft`. That's independent of this change — it happens identically whether you pass `2.0` or `tf.constant(2.0)` — so it's a separate rank 0 problem rather than a conversion one, and I've left it alone here. I started to add a guard to `_infer_fft_length_for_irfftn` (its non-N-D sibling `_infer_fft_length_for_irfft` already has an `if fft_length:` check that the N-D one lacks) but backed it out, because it moves the crash to the next line rather than fixing it, and deciding what rank 0 should actually do belongs in its own change.