### PR TITLE
Security: fix heap information disclosure in RFFT/IRFFT (empty FFT axis returns an uninitialized output)

### DIFF
--- a/tensorflow/core/kernels/fft_ops.cc
+++ b/tensorflow/core/kernels/fft_ops.cc
@@ -201,6 +201,14 @@ class FFTBase : public OpKernel {
         uint64_t dim = IsForward() && inner_most && fft_shape[i] != 0
                            ? fft_shape[i] / 2 + 1
                            : fft_shape[i];
+        // An empty FFT axis is passed through by the check above. Keep it
+        // empty in the output too. Sizing it from `fft_length` instead would
+        // give a non-empty output for an empty input, and the
+        // `num_elements() == 0` early return below would then hand back the
+        // output buffer without ever writing it.
+        if (input_shape.dim_size(input_index) == 0) {
+          dim = 0;
+        }
         output_shape.set_dim(output_shape.dims() - fft_rank + i, dim);
       }
     } else {
@@ -329,6 +337,14 @@ class FFTNBase : public OpKernel {
         uint64_t dim = IsForward() && inner_most && fft_shape[i] != 0
                            ? fft_shape[i] / 2 + 1
                            : fft_shape[i];
+        // An empty FFT axis is passed through by the check above. Keep it
+        // empty in the output too. Sizing it from `fft_length` instead would
+        // give a non-empty output for an empty input, and the
+        // `num_elements() == 0` early return below would then hand back the
+        // output buffer without ever writing it.
+        if (input_shape.dim_size(input_index) == 0) {
+          dim = 0;
+        }
         output_shape.set_dim(output_shape.dims() - fft_rank + i, dim);
       } else {
         output_shape.set_dim(output_shape.dims() - fft_rank + i, fft_shape[i]);

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -612,6 +612,23 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     x = np.zeros((0,) * dims).astype(np_ctype)
     self.assertEqual(x.shape, self._tf_ifft(x, rank).shape)
 
+  @parameterized.parameters(
+      itertools.product(VALID_FFT_RANKS, range(3), (np.float32, np.float64)))
+  def test_empty_with_explicit_fft_length(self, rank, extra_dims, np_rtype):
+    # An empty FFT axis skips the "input dimension must be at least
+    # fft_length" requirement. `fft_length` must not then size that axis in
+    # the output: the kernel returns early without writing the output for an
+    # empty input, so a non-empty output would be returned uninitialized.
+    np_ctype = np.complex64 if np_rtype == np.float32 else np.complex128
+    dims = rank + extra_dims
+    fft_length = (16,) * rank
+
+    x = np.zeros((0,) * dims).astype(np_rtype)
+    self.assertEqual(0, self._tf_fft(x, rank, fft_length).size)
+
+    x = np.zeros((0,) * dims).astype(np_ctype)
+    self.assertEqual(0, self._tf_ifft(x, rank, fft_length).size)
+
   @parameterized.parameters(itertools.product(
       VALID_FFT_RANKS, range(3), (5, 6), (np.float32, np.float64)))
   def test_basic(self, rank, extra_dims, size, np_rtype):

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -620,13 +620,15 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     # the output: the kernel returns early without writing the output for an
     # empty input, so a non-empty output would be returned uninitialized.
     np_ctype = np.complex64 if np_rtype == np.float32 else np.complex128
-    dims = rank + extra_dims
     fft_length = (16,) * rank
 
-    x = np.zeros((0,) * dims).astype(np_rtype)
+    # Batch dimensions must stay non-empty: if every dimension is zero the
+    # output is empty regardless of how the FFT axes are sized, and the test
+    # would pass against the unfixed kernel too.
+    x = np.zeros((2,) * extra_dims + (0,) * rank).astype(np_rtype)
     self.assertEqual(0, self._tf_fft(x, rank, fft_length).size)
 
-    x = np.zeros((0,) * dims).astype(np_ctype)
+    x = np.zeros((2,) * extra_dims + (0,) * rank).astype(np_ctype)
     self.assertEqual(0, self._tf_ifft(x, rank, fft_length).size)
 
   @parameterized.parameters(itertools.product(


### PR DESCRIPTION
> **Security impact:** heap **information disclosure** (CWE-908, use of uninitialised
> memory). An FFT with an empty input axis returns a non-empty output tensor that the
> kernel never writes, handing the caller whatever the allocator last left in that
> block. Verified to return a previous request's data verbatim — see *Demonstrated
> impact*. Affects 2.21.0 and master. **Not** an out-of-bounds access: the read stays
> inside a correctly-sized allocation, which is why sanitizers do not flag it.

### Root cause

The length check for real-valued transforms deliberately passes empty inputs through
(`tensorflow/core/kernels/fft_ops.cc`):

```c
OP_REQUIRES(
    ctx,
    // We pass through empty tensors, so special case them here.
    input_shape.dim_size(input_index) == 0 ||
        input_shape.dim_size(input_index) >= min_input_dim_length, ...);
```

but `fft_length` still sizes that axis in the output:

```c
uint64_t dim = IsForward() && inner_most && fft_shape[i] != 0
                   ? fft_shape[i] / 2 + 1
                   : fft_shape[i];
output_shape.set_dim(output_shape.dims() - fft_rank + i, dim);
```

so an empty **input** produces a non-empty **output**. `Compute()` then returns early
without writing anything:

```c
if (input_shape.num_elements() == 0) {
  DCHECK_EQ(0, output_shape.num_elements());
  return;
}
```

The `DCHECK` states exactly the invariant this early return depends on — *empty input
implies empty output*. That invariant is false for a zero-length FFT axis, and `DCHECK`
compiles out in release builds, so the check that would have caught it is not present
where it matters. `allocate_output` does not zero the buffer, so the caller receives
recycled heap.

DUCC never writes the buffer because it only truncates, never pads
(`fft_ops.cc`, `DuccFftImpl`): `if (in_shape[axes[i]] > limit) in_shape[axes[i]] = limit;`

### Demonstrated impact: one request reads another request's data

A service that calls `rfft` with a fixed `fft_length` allocates an identically-sized
output block on every request. Two users, one process, sequential requests. The attacker
sends an **empty input** — no other hostile value.

```
victim A spectrum: 513 distinct values
victim B spectrum: 513 distinct values
overlap A vs B   : 0

                  request sequence | matches A | matches B
           victim A, then attacker |       511 |         0
           victim B, then attacker |         0 |       511
           victim A, then attacker |       511 |         0
           victim B, then attacker |         0 |       511
```

**511 of 513 values (99.6%) of the victim's spectrum are returned to the attacker
verbatim**, and only ever the victim who ran last — the other victim's values never
appear. The two spectra share **zero** values, so this is not coincidence. Reproducible
across runs. Only synthetic data was used; no real data was accessed.

Reproducer:

```python
import numpy as np, tensorflow as tf
N = 1024
rfft  = lambda x: np.asarray(tf.raw_ops.RFFT(
    input=tf.constant(x, tf.float32), fft_length=tf.constant([N], tf.int32)))
rfft0 = lambda: np.asarray(tf.raw_ops.RFFT(
    input=tf.zeros([0], tf.float32), fft_length=tf.constant([N], tf.int32)))

victim = rfft(np.random.default_rng(0).standard_normal(N).astype(np.float32))
rfft0()                                  # warm the allocator
print((rfft0() == victim).sum(), "of", victim.size, "victim values recovered")
```

The guard works correctly for every non-empty length — `RFFT(input=[4], fft_length=[64])`
is properly rejected with *"Input dimension 0 must have length of at least 64"*. Only the
`== 0` case escapes it.

### Affected family

The defect is specific to the real-valued transforms, where `fft_length` sizes the output
independently of the input: `RFFT`, `IRFFT`, `RFFT2D`, `IRFFT2D`, `RFFT3D`, `IRFFT3D`, and
the `FFTNBase` equivalents. The plain complex transforms take no `fft_length`, so their
output follows the input and an empty axis yields an empty output — nothing to disclose.

### The fix

Keep an empty FFT axis empty in the output. That restores the invariant the early return
already assumes, and matches the stated "we pass through empty tensors" intent: empty in,
empty out.

A zero-length **batch** dimension is unaffected — the length check only covers the
`fft_rank` inner-most axes, and such an input already produced an empty output and
returned through the same path.

I chose this over zero-filling the output because it needs no device-specific code
(`FFTBase` is shared by the CPU and GPU kernels) and it makes the existing `DCHECK` true
rather than leaving a false invariant in place. It does change the returned shape for this
one case, from `(fft_length/2+1,)` to `(0,)` — but the current contents of that tensor are
uninitialised, so no correct program can depend on them. Happy to switch to zero-filling
if you would rather preserve the shape.

Applied at both sites: `FFTBase` and `FFTNBase`.

### Tests

`test_empty_with_explicit_fft_length` in `fft_ops_test.py`, beside the existing
`test_empty`, which does not pass an `fft_length` and so does not reach this path. Covers
forward and inverse across all valid FFT ranks and extra dimensions.

Not compile-tested (no Bazel environment) — please run CI.

Reported to the Google OSS VRP; filing the patch as instructed for memory-safety issues
in this repository.
