### PR TITLE
Security: fix heap out-of-bounds write in the fast Example context parsers (incomplete fix of 16584652da)

### DIFF
--- a/tensorflow/core/util/example_proto_fast_parsing.cc
+++ b/tensorflow/core/util/example_proto_fast_parsing.cc
@@ -2372,7 +2372,15 @@ absl::Status ParseContextDenseFeatures(
             reinterpret_cast<const uint8_t*>(feature_proto.data()),
             feature_proto.size());
         EnableAliasing(&stream);
-        num_elements += ParseFeature(dtype, &stream, &out, &out_offset);
+        const int num_added = ParseFeature(dtype, &stream, &out, &out_offset);
+        if (num_added < 0) {
+          // This should be unreachable -- we already scanned the feature in
+          // GetContextFeatureLengths, and it hasn't changed since then.
+          return absl::InvalidArgumentError(
+              absl::StrCat("Error in context feature ", c.feature_name,
+                           " in example ", ExampleName(example_names, e)));
+        }
+        num_elements += num_added;
       }
       if (num_elements != data_max_elements) {
         return absl::InvalidArgumentError(
@@ -2422,10 +2430,17 @@ absl::Status ParseContextSparseFeatures(
           reinterpret_cast<const uint8_t*>(feature_proto.data()),
           feature_proto.size());
       EnableAliasing(&stream);
-      size_t num_added =
+      int num_added =
           ParseFeature(dtype, &stream, &out_values, &out_values_offset);
+      if (num_added < 0) {
+        // This should be unreachable -- we already scanned the feature in
+        // GetContextFeatureLengths, and it hasn't changed since then.
+        return absl::InvalidArgumentError(
+            absl::StrCat("Error in context feature ", c.feature_name,
+                         " in example ", ExampleName(example_names, e)));
+      }
       num_elements += num_added;
-      max_num_cols = std::max(max_num_cols, num_added);
+      max_num_cols = std::max(max_num_cols, static_cast<size_t>(num_added));
       for (int i = 0; i < num_added; i++) {
         if (is_batch) *out_indices++ = e;
         *out_indices++ = i;
@@ -2492,8 +2507,15 @@ absl::Status ParseContextRaggedFeatures(
             reinterpret_cast<const uint8_t*>(feature_proto.data()),
             feature_proto.size());
         EnableAliasing(&stream);
-        size_t num_added =
+        int num_added =
             ParseFeature(dtype, &stream, &out_values, &out_values_offset);
+        if (num_added < 0) {
+          // This should be unreachable -- we already scanned the feature in
+          // GetContextFeatureLengths, and it hasn't changed since then.
+          return absl::InvalidArgumentError(
+              absl::StrCat("Error in context feature ", c.feature_name,
+                           " in example ", ExampleName(example_names, e)));
+        }
         split += num_added;
       }
       if (int32_splits) {


### PR DESCRIPTION
> **Security impact:** heap **out-of-bounds write** (CWE-787), unbounded and sequential.
> This completes [`16584652da`](https://github.com/tensorflow/tensorflow/commit/16584652da),
> which hardened `ParseFeature` and fixed three of its six callers. Affects 2.21.0 and
> master.
>
> **Scope, stated plainly up front:** the trigger is a malformed *op configuration*, not
> attacker-supplied data. I could not find a serialized-bytes-only trigger, and I detail
> below what I checked. This is memory-safety hardening that finishes an existing fix — I
> am not claiming a reachable vulnerability.

### Root cause

`16584652da` made `ParseFeature` return `-1` when the wire dtype does not match the
requested dtype, and updated the three `ParseSequence*Features` callers to reject it. The
three structurally identical `ParseContext*Features` functions, ~300 lines above in the
same file, were not updated.

`ParseContextSparseFeatures` (`tensorflow/core/util/example_proto_fast_parsing.cc:2425`):

```c
size_t num_added =
    ParseFeature(dtype, &stream, &out_values, &out_values_offset);
num_elements += num_added;
max_num_cols = std::max(max_num_cols, num_added);
for (int i = 0; i < num_added; i++) {     // (size_t)(-1) => bound is SIZE_MAX
  if (is_batch) *out_indices++ = e;
  *out_indices++ = i;                     // raw int64_t*, no bounds check
}
```

`out_indices` points into a tensor sized `expected_num_elements * (is_batch ? 2 : 1)`,
taken from the first parsing pass. `ParseFeature` itself writes at
`out->flat<T>().data() + *out_offset` with no bound of its own — it trusts that count. The
`num_elements != expected_num_elements` check at :2434 only runs *after* the write loop.

`ParseContextRaggedFeatures:2495` has the same `size_t`. `ParseContextDenseFeatures:2375`
accumulates the negative value into a `size_t` instead, which the trailing equality check
rejects — lesser impact, same missing check.

The fixed twin at :2746 already does exactly what this PR adds:

```c
int num_added;
...
if (num_added < 0) {
  // This should be unreachable -- we already scanned the feature in
  // GetSequenceFeatureLengths, and it hasn't changed since then.
  return absl::InvalidArgumentError(...);
}
```

### How the two passes are made to disagree

Pass 1 (`GetContextFeatureLengths`) validates using `feature.dtype`, which is stored once
per feature **name**:

```c
for (auto& c : context_config.sparse) {
  FeatureProtos& feature = context_features[c.feature_name];
  feature.dtype = c.dtype;      // last config entry with this name wins
```

Pass 2 uses each config entry's own `c.dtype`. Two sparse entries sharing a name with
different dtypes therefore disagree: pass 1 validates against the last entry's dtype and
succeeds, pass 2 parses the first entry with a dtype that no longer matches the wire, and
gets `-1`.

There are guards for `"cannot be both ragged and sparse"` and `"cannot be both dense and
sparse"`, but none for two entries of the *same* kind sharing a name.

### Reproduction (TF 2.21.0)

```python
import tensorflow as tf
ex = tf.train.SequenceExample()
ex.context.feature["k"].bytes_list.value.append(b"aaaa")   # wire dtype = DT_STRING

tf.raw_ops.ParseSequenceExample(
    serialized=[ex.SerializeToString()], debug_name=[], context_dense_defaults=[],
    feature_list_dense_missing_assumed_empty=[],
    context_sparse_keys=["k", "k"], context_dense_keys=[],
    feature_list_sparse_keys=[], feature_list_dense_keys=[],
    Ncontext_sparse=2, Ncontext_dense=0,
    Nfeature_list_sparse=0, Nfeature_list_dense=0,
    context_sparse_types=[tf.int64, tf.string])   # pass1 uses string, pass2 entry0 int64
```

| case | result |
|---|---|
| single key, matching type | clean exit |
| duplicate key, **same** types | clean exit |
| duplicate key, `[int64, string]` | **SIGBUS** |
| duplicate key, `[float32, string]` | **SIGBUS** |

The two controls isolate the dtype mismatch as the sole trigger. Prior valgrind output on
this path: `Invalid write of size 8 ... 0 bytes after a block of size 16 alloc'd`, in
`FastParseSequenceExample` ← `ParseSequenceExampleOp::Compute`.

### Why I am not claiming a data-only trigger

`context_sparse_keys` / `context_sparse_types` are op attributes, fixed by whoever builds
the graph — a Python dict cannot even express a duplicate key, so this needs a direct
`tf.raw_ops` call with a malformed config. Someone supplying only serialized bytes to a
normal `parse_sequence_example` cannot reach it.

I checked the five ways the two passes could be made to disagree on bytes alone, and all
are closed on master:

- `ParseBytesFeature` — the `out == nullptr` and non-null branches both honour the stream
  limit (`Skip(n)` succeeds iff `n <= BytesUntilLimit()`), and the `uint32_t`→`int`
  narrowing fails closed on both.
- `ParseFloatFeature` / `ParseInt64Feature` — `out` gates only the store
  (`if (out != nullptr) *out++ = ...`); every control-flow and error path is shared.
- Both passes skip empty protos identically (`if (proto.empty()) continue;`).
- `feature.protos` is `resize(num_examples)` at all six sites, so the two loop bounds match.
- Duplicate feature keys in the serialized proto overwrite (`feature.protos[d] = value`)
  rather than creating a second entry.

So the context parsers are safe today only because the shared primitive was hardened, not
because of any check of their own. They retain the exact shape that `16584652da` removed
from their siblings, one primitive-level regression away from being reachable.

### The fix

Reject a negative count at all three sites, matching the sequence parsers — including the
same "should be unreachable" comment, since that is precisely the situation. `max_num_cols`
takes an explicit `static_cast<size_t>` now that `num_added` is signed.

No test added: expressing this needs a duplicate-key config that the Python API cannot
construct, so the test would have to go through `tf.raw_ops` with a hand-built attribute
list. Happy to add one if you would like it in that form.

Not compile-tested (no Bazel environment) — please run CI.
