### PR TITLE
Reject JXL dimensions that do not fit in int (uncatchable CHECK abort in decode_image)

### DIFF
--- a/tensorflow/core/lib/jxl/jxl_io.cc
+++ b/tensorflow/core/lib/jxl/jxl_io.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include "absl/strings/string_view.h"
 #include "lib/include/jxl/codestream_header.h"  // from @jpegxl
@@ -63,8 +64,16 @@ bool DecodeHeader(absl::string_view encoded, int* width, int* height,
     if (JXL_DEC_SUCCESS != JxlDecoderGetBasicInfo(dec.get(), &info)) {
       return false;
     }
-    *width = info.xsize;
-    *height = info.ysize;
+    // `info.xsize` and `info.ysize` are uint32_t, while the callers hold the
+    // dimensions in `int`. Reject anything that does not fit rather than
+    // narrowing: a value above INT_MAX becomes negative, and the caller then
+    // builds a TensorShape from it, which CHECK-fails and aborts the process.
+    if (info.xsize > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
+        info.ysize > static_cast<uint32_t>(std::numeric_limits<int>::max())) {
+      return false;
+    }
+    *width = static_cast<int>(info.xsize);
+    *height = static_cast<int>(info.ysize);
     if (channels != nullptr) {
       *channels = info.num_color_channels + (info.alpha_bits != 0);
     }

--- a/tensorflow/core/lib/jxl/jxl_io.cc
+++ b/tensorflow/core/lib/jxl/jxl_io.cc
@@ -64,18 +64,23 @@ bool DecodeHeader(absl::string_view encoded, int* width, int* height,
     if (JXL_DEC_SUCCESS != JxlDecoderGetBasicInfo(dec.get(), &info)) {
       return false;
     }
-    // `info.xsize` and `info.ysize` are uint32_t, while the callers hold the
-    // dimensions in `int`. Reject anything that does not fit rather than
-    // narrowing: a value above INT_MAX becomes negative, and the caller then
-    // builds a TensorShape from it, which CHECK-fails and aborts the process.
-    if (info.xsize > static_cast<uint32_t>(std::numeric_limits<int>::max()) ||
-        info.ysize > static_cast<uint32_t>(std::numeric_limits<int>::max())) {
+    // `info.xsize`, `info.ysize` and `info.num_color_channels` are uint32_t,
+    // while the callers hold these values in `int`. Reject anything that does
+    // not fit rather than narrowing: a value above INT_MAX becomes negative,
+    // and the caller then builds a TensorShape from it, which CHECK-fails and
+    // aborts the process. The channel bound also leaves room for the alpha
+    // channel added below so that sum cannot overflow either.
+    const uint32_t max_int =
+        static_cast<uint32_t>(std::numeric_limits<int>::max());
+    if (info.xsize > max_int || info.ysize > max_int ||
+        info.num_color_channels > max_int - (info.alpha_bits != 0 ? 1 : 0)) {
       return false;
     }
     *width = static_cast<int>(info.xsize);
     *height = static_cast<int>(info.ysize);
     if (channels != nullptr) {
-      *channels = info.num_color_channels + (info.alpha_bits != 0);
+      *channels =
+          static_cast<int>(info.num_color_channels) + (info.alpha_bits != 0);
     }
     return true;
   }

--- a/tensorflow/python/kernel_tests/image_ops/decode_image_op_test.py
+++ b/tensorflow/python/kernel_tests/image_ops/decode_image_op_test.py
@@ -113,6 +113,19 @@ class DecodeImageOpTest(test.TestCase):
       with self.assertRaises(errors_impl.InvalidArgumentError):
         self.evaluate(decode)
 
+  @test_util.run_deprecated_v1
+  def testInvalidJxlDimensions(self):
+    # JXL header declaring xsize = 0x80000000, which does not fit in int.
+    data = bytes.fromhex(
+        "ff0afeffffff7f980208c400b19f200000152aa38c1bbc9ceb3232f24387c5b48"
+        "deb0c6db56f0d68b89028a2e1af323374f8b7e479d69e5c16c2c99153d4c95c14"
+        "669b6c39b9c4f30734c4"
+    )
+    decode = image_ops.decode_image(data)
+    with self.cached_session():
+      with self.assertRaises(errors_impl.InvalidArgumentError):
+        self.evaluate(decode)
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
`JxlBasicInfo::xsize` / `ysize` are `uint32_t`; `DecodeHeader` assigns them to `int`
out-parameters with no range check (`tensorflow/core/lib/jxl/jxl_io.cc:66`):

```c
*width = info.xsize;    // uint32_t -> int
*height = info.ysize;
```

A header declaring a dimension above `INT_MAX` therefore yields a **negative** width or
height. `DecodeImageV2Op::DecodeJxl` builds a `TensorShape` straight from those values:

```c
int width = 0, height = 0, channels = 0;
OP_REQUIRES(context, jxl::DecodeHeader(input, &width, &height, &channels), ...);
OP_REQUIRES_OK(context, context->allocate_output(
                   0, TensorShape({height, width, channels}), &output));
```

and `TensorShape` rejects a negative dimension with a `CHECK`, which **aborts the
process** instead of returning an error:

```
F0000 tensor_shape.cc:204] Check failed: InitDims(dim_sizes) is OK
  (INVALID_ARGUMENT: Expected a non-negative size, got -2147483648)
    @ tensorflow::TensorShapeBase<>::TensorShapeBase()
    @ tensorflow::(anonymous namespace)::DecodeImageV2Op::Compute()
    @ tensorflow::ThreadPoolDevice::Compute()
```

`-2147483648` is `INT_MIN` — `info.xsize` was `0x80000000`.

### Why this matters beyond a normal error

The abort is **not catchable**. A caller cannot `try`/`except` it, so a single malformed
input terminates the process. It is reachable through `tf.io.decode_image`, which
dispatches to the JXL decoder purely on the codestream signature
(`ClassifyFileFormat` → `HasJxlHeader`) — so an application that only intends to accept
PNG still routes JPEG XL bytes here. Well-formed JXL files decode correctly and are
unaffected.

### Reproduction

75 bytes, on `2.21.0` and `master`:

```python
import binascii, tensorflow as tf
data = binascii.unhexlify(
    "ff0afeffffff7f980208c400b19f200000152aa38c1bbc9ceb3232f24387c5b48deb0c6db56f0d68b89028a2e1af323374f8b7e479d69e5c16c2c99153d4c95c14669b6c39b9c4f30734c4")
tf.io.decode_image(data)     # process aborts
```

```
$ python3 repro.py
F0000 tensor_shape.cc:204] Check failed: ... Expected a non-negative size, got -2147483648
Aborted (core dumped)          # exit 134
```

Found by mutation-fuzzing `tf.io.decode_image` (30,000 cases from valid JXL seeds) in a
Debian container with the official `tensorflow==2.21.0` wheel; 1 crash, this one.

### The fix

Reject dimensions that do not fit in `int` inside `DecodeHeader`, so the op fails with
`"Failed to decode JXL header"` rather than aborting. This keeps the range check next to
the narrowing conversion that causes it, rather than relying on every caller to
re-validate.

I considered widening the out-parameters to `int64_t` instead, but `DecodeImageV2Op`
holds all image dimensions as `int` (as do the JPEG/PNG/GIF/BMP paths in that file), so
rejecting at the boundary is the smaller and more consistent change. Happy to switch if
you would prefer the wider type.

### Tests

No test added: `tensorflow/core/lib/jxl/` has no test target yet (unlike
`tensorflow/core/lib/gif/gif_io_test.cc`), so this would mean adding a new
`jxl_io_test.cc` plus a BUILD rule and a crafted testdata file. Glad to add that if you
would like it in this PR — the reproducer above is a ready testdata candidate.

Not compile-tested (no Bazel environment) — please run CI.
