### PR TITLE
Validate snapshot tensor shapes before constructing a TensorShape

### DIFF
--- a/tensorflow/core/data/snapshot_utils.cc
+++ b/tensorflow/core/data/snapshot_utils.cc
@@ -966,7 +966,13 @@ absl::Status CustomReader::SnappyUncompress(
   for (int i = 0, end = simple_tensor_mask_.size(); i < end; ++i) {
     const auto& tensor_metadata = metadata->tensor_metadata(i);
     if (simple_tensor_mask_[i]) {
-      TensorShape shape(tensor_metadata.tensor_shape());
+      // The shape comes from the snapshot file. Build it through the checked
+      // API: constructing a TensorShape directly from an unvalidated proto
+      // CHECK-fails on a negative or overflowing dimension, which aborts the
+      // process instead of reporting a corrupt snapshot.
+      TensorShape shape;
+      TF_RETURN_IF_ERROR(
+          TensorShape::BuildTensorShape(tensor_metadata.tensor_shape(), &shape));
       Tensor simple_tensor(dtypes_[i], shape);
       TensorBuffer* buffer = DMAHelper::buffer(&simple_tensor);
       iov[index].iov_base = buffer->data();

--- a/tensorflow/core/data/snapshot_utils_test.cc
+++ b/tensorflow/core/data/snapshot_utils_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/core/data/snapshot_utils.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -24,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.pb.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/lib/io/compression.h"
+#include "tensorflow/core/platform/coding.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/test.h"
@@ -146,6 +148,68 @@ TEST(SnapshotUtilTest, SnappyTensorSizeMismatch) {
 
   std::vector<Tensor> read_tensors;
   EXPECT_TRUE(absl::IsDataLoss(reader->ReadTensors(&read_tensors)));
+
+  TF_ASSERT_OK(Env::Default()->DeleteFile(filename));
+}
+
+TEST(SnapshotUtilTest, SnappyInvalidTensorShapeIsAnError) {
+  // A corrupt snapshot whose metadata carries a negative dimension must be
+  // reported as an error. Building a TensorShape directly from the proto
+  // CHECK-fails instead, which aborts the process.
+  //
+  // Uses a memcpy-able dtype so the tensors take the simple-tensor path in
+  // CustomReader::SnappyUncompress, which is where the shape is built.
+  std::vector<Tensor> tensors;
+  tensorflow::DataTypeVector dtypes;
+  for (int i = 0; i < 2; ++i) {
+    Tensor t(DT_INT64, TensorShape({4}));
+    t.flat<int64_t>().setZero();
+    dtypes.push_back(DT_INT64);
+    tensors.push_back(t);
+  }
+
+  std::string filename;
+  EXPECT_TRUE(Env::Default()->LocalTempFilename(&filename));
+
+  std::unique_ptr<Writer> writer;
+  TF_ASSERT_OK(Writer::Create(Env::Default(), filename, io::compression::kSnappy,
+                              /*version=*/1, dtypes, &writer));
+  TF_ASSERT_OK(writer->WriteTensors(tensors));
+  TF_ASSERT_OK(writer->Close());
+
+  // Records are an 8-byte little-endian length followed by the payload; the
+  // metadata is the first record written for a snappy snapshot. Rewrite it
+  // with a negative dimension.
+  constexpr size_t kHeaderSize = sizeof(uint64_t);
+  std::string contents;
+  TF_ASSERT_OK(ReadFileToString(Env::Default(), filename, &contents));
+  ASSERT_GT(contents.size(), kHeaderSize);
+  const uint64_t metadata_size = core::DecodeFixed64(contents.data());
+  ASSERT_GE(contents.size(), kHeaderSize + metadata_size);
+
+  experimental::SnapshotTensorMetadata metadata;
+  ASSERT_TRUE(
+      metadata.ParseFromString(contents.substr(kHeaderSize, metadata_size)));
+  ASSERT_GT(metadata.tensor_metadata_size(), 0);
+  ASSERT_GT(metadata.tensor_metadata(0).tensor_shape().dim_size(), 0);
+  metadata.mutable_tensor_metadata(0)
+      ->mutable_tensor_shape()
+      ->mutable_dim(0)
+      ->set_size(-1);
+
+  const std::string patched = metadata.SerializeAsString();
+  char header[kHeaderSize];
+  core::EncodeFixed64(header, patched.size());
+  TF_ASSERT_OK(WriteStringToFile(
+      Env::Default(), filename,
+      std::string(header, kHeaderSize) + patched +
+          contents.substr(kHeaderSize + metadata_size)));
+
+  std::unique_ptr<Reader> reader;
+  TF_ASSERT_OK(Reader::Create(Env::Default(), filename, io::compression::kSnappy,
+                              /*version=*/1, dtypes, &reader));
+  std::vector<Tensor> read_tensors;
+  EXPECT_FALSE(reader->ReadTensors(&read_tensors).ok());
 
   TF_ASSERT_OK(Env::Default()->DeleteFile(filename));
 }


### PR DESCRIPTION
`CustomReader::SnappyUncompress` (`tensorflow/core/data/snapshot_utils.cc:969`) builds a
`TensorShape` directly from snapshot-file metadata:

```c
const auto& tensor_metadata = metadata->tensor_metadata(i);
if (simple_tensor_mask_[i]) {
  TensorShape shape(tensor_metadata.tensor_shape());
  Tensor simple_tensor(dtypes_[i], shape);
```

`metadata` is a `SnapshotTensorMetadata` parsed from a record in the snapshot file
(`snapshot_utils.cc:879-884`), so its dimensions are file-controlled. The
`TensorShape(TensorShapeProto)` constructor `CHECK`-fails on a negative or overflowing
dimension:

```
F0000 tensor_shape.cc:416] Check failed: size >= 0 (-5 vs. 0)
    @ tensorflow::TensorShapeBase<>::AddDim()
    @ tensorflow::TensorShapeBase<>::TensorShapeBase()
```

so a corrupt or hostile snapshot aborts the process instead of producing an error. The
abort is not catchable by the caller.

### Why this is inconsistent with the surrounding code

Every other failure in this function is reported as a status — `DataLossError` for an
unparseable metadata record, `InvalidArgumentError` for a size mismatch. The sibling
branch a few lines below already rejects a negative value explicitly:

```c
int64_t tensor_size = tensor_metadata.tensor_size_bytes();
if (tensor_size < 0) {
  return absl::InvalidArgumentError(
      absl::StrCat("Tensor size is negative: ", tensor_size));
}
```

so negative metadata was considered for one path and not the other.

The two core call sites that build a `TensorShape` from a proto both validate first:

* `tensorflow/core/framework/tensor.cc:1246` — `if (!TensorShape::IsValid(proto.tensor_shape())) return false;`
* `tensorflow/core/ops/array_ops.cc:773` — `TF_RETURN_IF_ERROR(TensorShape::IsValidShape(proto->tensor_shape()));`

### Relationship to #123572

The same unguarded pattern exists in `tensorflow/core/data/compression_utils.cc`, and
**#123572** is already converting those three sites to
`TensorShape::BuildTensorShape`. That PR touches only `compression_utils.cc` and its
test — the snapshot reader is not covered by it. This change applies the same idiom
there, and the two are independent.

I confirmed the `compression_utils.cc` path is reachable and aborts today, via
`tf.raw_ops.UncompressElement` with a `CompressedElement` whose component metadata
carries `dim { size: -5 }`:

```
F0000 tensor_shape.cc:416] Check failed: size >= 0 (-5 vs. 0)
    @ tensorflow::data::UncompressElement()
    @ tensorflow::data::experimental::UncompressElementOp::Compute()
```

That one is #123572's to fix; this PR is the sibling it misses.

### The fix

Use `TensorShape::BuildTensorShape`, which returns a status, matching the idiom #123572
adopts and the validation the core call sites already perform.

### Tests

No test added: exercising this needs a snapshot file written with hand-crafted metadata,
which `snapshot_utils_test.cc` has no scaffolding for. Happy to add one if you would like
it in this PR.

Not compile-tested (no Bazel environment) — please run CI.
