### PR TITLE
Security: fix heap out-of-bounds read in TFLite BIDIRECTIONAL_SEQUENCE_RNN (aux_input strided by input_size)

### DIFF
--- a/tensorflow/lite/kernels/bidirectional_sequence_rnn.cc
+++ b/tensorflow/lite/kernels/bidirectional_sequence_rnn.cc
@@ -425,7 +425,7 @@ TfLiteStatus EvalFloat(const TfLiteTensor* input, const TfLiteTensor* bw_input,
           GetTensorData<float>(input) + s * input_size * batch_size;
       const float* aux_input_ptr_batch =
           (aux_input != nullptr)
-              ? GetTensorData<float>(aux_input) + s * input_size * batch_size
+              ? GetTensorData<float>(aux_input) + s * aux_input_size * batch_size
               : nullptr;
       float* output_ptr_batch =
           GetTensorData<float>(fw_output) + s * fw_output_step * batch_size;
@@ -443,7 +443,7 @@ TfLiteStatus EvalFloat(const TfLiteTensor* input, const TfLiteTensor* bw_input,
           GetTensorData<float>(bw_input) + s * input_size * batch_size;
       const float* aux_input_ptr_batch =
           (aux_input != nullptr)
-              ? GetTensorData<float>(aux_input) + s * input_size * batch_size
+              ? GetTensorData<float>(aux_input) + s * aux_input_size * batch_size
               : nullptr;
       float* output_ptr_batch =
           (params->merge_outputs
@@ -598,7 +598,7 @@ TfLiteStatus EvalHybrid(
             GetTensorData<float>(input) + s * input_size * batch_size;
         const float* aux_input_ptr_batch =
             (aux_input != nullptr)
-                ? GetTensorData<float>(aux_input) + s * input_size * batch_size
+                ? GetTensorData<float>(aux_input) + s * aux_input_size * batch_size
                 : nullptr;
         float* output_ptr_batch =
             GetTensorData<float>(fw_output) + s * fw_output_step * batch_size;
@@ -622,7 +622,7 @@ TfLiteStatus EvalHybrid(
             GetTensorData<float>(bw_input) + s * input_size * batch_size;
         const float* aux_input_ptr_batch =
             (aux_input != nullptr)
-                ? GetTensorData<float>(aux_input) + s * input_size * batch_size
+                ? GetTensorData<float>(aux_input) + s * aux_input_size * batch_size
                 : nullptr;
         float* output_ptr_batch =
             (params->merge_outputs

--- a/tensorflow/lite/kernels/bidirectional_sequence_rnn_test.cc
+++ b/tensorflow/lite/kernels/bidirectional_sequence_rnn_test.cc
@@ -1361,6 +1361,76 @@ TEST(BidirectionalRNNOpTest, ClosedBoxTestCrossLinkingAuxInputOnly) {
 // Same as ClosedBox test, but an input is passed to auxiliary input instead of
 // the regular one. Regular input and weights are set to zero. Time major inputs
 // and outputs.
+// Every other test in this file uses aux_input_size == input_size, so a stride
+// computed from the wrong one is invisible. These two exercise the case where
+// they differ.
+//
+// The regular input weights, the recurrent weights and the biases are all zero,
+// so each output element is just relu(aux_weights . aux_input[t]) and the time
+// steps are independent. That makes the expected values exact.
+TEST(BidirectionalRNNOpTest, AuxInputLargerThanInputIsStridedCorrectly) {
+  // aux_input_size > input_size, so striding aux_input by input_size stays
+  // inside the tensor but lands on the wrong time step: the second step would
+  // read elements [2, 6) instead of [4, 8), giving 22 instead of 40.
+  BidirectionalRNNOpModel rnn(/*batches=*/1, /*sequence_len=*/2,
+                              /*fw_units=*/1, /*bw_units=*/1,
+                              /*input_size=*/2, /*aux_input_size=*/4,
+                              /*aux_input_mode=*/AuxInputMode::kCrossLinking,
+                              /*time_major=*/true,
+                              /*merge_outputs=*/false);
+  rnn.SetFwWeights({0.0f, 0.0f});
+  rnn.SetBwWeights({0.0f, 0.0f});
+  rnn.SetFwRecurrentWeights({0.0f});
+  rnn.SetBwRecurrentWeights({0.0f});
+  rnn.SetFwBias({0.0f});
+  rnn.SetBwBias({0.0f});
+  rnn.SetAuxFwWeights({1.0f, 1.0f, 1.0f, 1.0f});
+  rnn.SetAuxBwWeights({1.0f, 1.0f, 1.0f, 1.0f});
+
+  std::vector<float> input(2 * 1 * 2, 0.0f);
+  rnn.SetInput(0, input.data(), input.data() + input.size());
+  // [t0 | t1]
+  std::vector<float> aux_input = {1.0f, 1.0f, 1.0f, 1.0f,
+                                  10.0f, 10.0f, 10.0f, 10.0f};
+  rnn.SetAuxInput(0, aux_input.data(), aux_input.data() + aux_input.size());
+
+  ASSERT_EQ(rnn.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(rnn.GetFwOutput(), ElementsAreArray(ArrayFloatNear({4.0f, 40.0f})));
+  EXPECT_THAT(rnn.GetBwOutput(), ElementsAreArray(ArrayFloatNear({4.0f, 40.0f})));
+}
+
+TEST(BidirectionalRNNOpTest, AuxInputSmallerThanInputIsStridedCorrectly) {
+  // The reported configuration: input_size = 4096, aux_input_size = 1. The
+  // aux_input tensor holds sequence_len * batches * 1 = 2 floats, so striding
+  // it by input_size reads 4096 floats past the end on the second time step.
+  constexpr int kInputSize = 4096;
+  BidirectionalRNNOpModel rnn(/*batches=*/1, /*sequence_len=*/2,
+                              /*fw_units=*/1, /*bw_units=*/1,
+                              /*input_size=*/kInputSize, /*aux_input_size=*/1,
+                              /*aux_input_mode=*/AuxInputMode::kCrossLinking,
+                              /*time_major=*/true,
+                              /*merge_outputs=*/false);
+  rnn.SetFwWeights(std::vector<float>(kInputSize, 0.0f));
+  rnn.SetBwWeights(std::vector<float>(kInputSize, 0.0f));
+  rnn.SetFwRecurrentWeights({0.0f});
+  rnn.SetBwRecurrentWeights({0.0f});
+  rnn.SetFwBias({0.0f});
+  rnn.SetBwBias({0.0f});
+  rnn.SetAuxFwWeights({1.0f});
+  rnn.SetAuxBwWeights({1.0f});
+
+  std::vector<float> input(2 * 1 * kInputSize, 0.0f);
+  rnn.SetInput(0, input.data(), input.data() + input.size());
+  std::vector<float> aux_input = {1.0f, 10.0f};
+  rnn.SetAuxInput(0, aux_input.data(), aux_input.data() + aux_input.size());
+
+  ASSERT_EQ(rnn.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(rnn.GetFwOutput(), ElementsAreArray(ArrayFloatNear({1.0f, 10.0f})));
+  EXPECT_THAT(rnn.GetBwOutput(), ElementsAreArray(ArrayFloatNear({1.0f, 10.0f})));
+}
+
 TEST(BidirectionalRNNOpTest, ClosedBoxTestCrossLinkingAuxInputOnlyTimeMajor) {
   BidirectionalRNNOpModel rnn(/*batches=*/2, /*sequence_len=*/16,
                               /*fw_units=*/16, /*bw_units=*/16,


### PR DESCRIPTION
> **Security impact:** heap **out-of-bounds read** (CWE-125), ASan-confirmed. The
> out-of-bounds values are accumulated into the op's output tensor and returned to the
> caller. Affects 2.21.0 and master. Sibling of `4c2dd32d4b`
> ("Fix out-of-bounds read in TFLite BIDIRECTIONAL_SEQUENCE_LSTM", 2026-08-21), which
> hardened the LSTM twin's auxiliary-input handling but not this kernel.

### Root cause

The time-major paths of `EvalFloat` and `EvalHybrid` advance the `aux_input` pointer by
the **main input's** feature size (`tensorflow/lite/kernels/bidirectional_sequence_rnn.cc`,
lines 428, 446, 601, 625):

```c
const float* aux_input_ptr_batch =
    (aux_input != nullptr)
        ? GetTensorData<float>(aux_input) + s * input_size * batch_size
        : nullptr;
```

`aux_input` has shape `[max_time, batch, aux_input_size]`, so one timestep is
`aux_input_size * batch_size`. **The batch-major path in the same function already does
this correctly:**

```c
? GetTensorData<float>(aux_input) +
      b * aux_input_size * max_time + s * aux_input_size
```

Nothing constrains `input_size == aux_input_size`. The dimension checks tie
`aux_input->dims->data[2]` to the aux weights and `input->dims->data[2]` to the input
weights, but never to each other:

```c
TF_LITE_ASSERT_EQ(aux_input->dims->data[0], input->dims->data[0]);
TF_LITE_ASSERT_EQ(aux_input->dims->data[1], input->dims->data[1]);
TF_LITE_ASSERT_EQ(aux_input->dims->data[2], fw_aux_input_weights->dims->data[1]);
TF_LITE_ASSERT_EQ(aux_input->dims->data[2], bw_aux_input_weights->dims->data[1]);
```

An auxiliary input with its own feature size is the intended use, so `input_size >
aux_input_size` is a legitimate configuration that passes every check.

### Reproduction

`input = [8,2,4096]`, `aux_input = [8,2,1]`, `time_major = true`. Every dimension check
passes. The last timestep reads at offset `7 * 4096 * 2 = 57344` floats into a 16-float
tensor.

```
==8==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x529000004a00
READ of size 16 at 0x529000004a00 thread T0
    ...
    tflite::ops::builtin::bidirectional_sequence_rnn::Eval
    tflite::Subgraph::InvokeImpl

0x529000004a00 is located 1216 bytes after 17216-byte region [0x529000000200,0x529000004540)
```

The out-of-bounds values are multiplied by the aux weights and accumulated into the
output. With **all-zero** `input` and `aux_input`, all weights zero except the aux weights
at 1.0 — a configuration where a correct kernel must return all zeros — the op returns
heap contents:

```
fw_out: [0, 0, ..., 4.6332811e+27, 4.6332811e+27, -8755156992.0, nan, 4.9045446e-44, ...]
  nonzero: 36/64
```

**Benign control:** the same model with `aux_input_size == input_size` (no stride
mismatch) returns `0/64` non-zero and produces no ASan report.

I want to be precise about the limit of what I demonstrated: the out-of-bounds read is
deterministic and ASan-confirmed, and the values reach the output. Whether those bytes
hold anything meaningful depends on heap layout — in some runs the over-read lands in
zeroed memory. I did **not** establish which allocation is being read, and I am not
claiming disclosure of any particular data.

### The fix

Use `aux_input_size` for the aux_input stride, matching the batch-major path in the same
function. Applied at all four sites: forward and backward cells, float and hybrid.

### Tests

No test added: `bidirectional_sequence_rnn_test.cc` has no case with
`aux_input_size != input_size`, so covering this means a new fixture. Happy to add one —
the reproducer above (`input=[8,2,4096]`, `aux_input=[8,2,1]`, time-major) is a ready
test case, and under ASan it fails before the fix and passes after.

Not compile-tested (no Bazel environment) — please run CI.
