### PR TITLE
Add a Metal PluggableDevice backend for Apple silicon: the foundation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -248,6 +248,10 @@ common:macos_arm64 --macos_minimum_os=11.0
 common:macos_arm64 --config=clang_local
 common:macos_arm64 --platforms=@build_bazel_apple_support//platforms:darwin_arm64
 
+# Metal PluggableDevice backend for Apple Silicon GPUs. Implies macos_arm64.
+build:metal --config=macos_arm64
+build:metal --define=with_metal_support=true
+
 # iOS configs for each architecture and the fat binary builds.
 common:ios --apple_platform_type=ios
 common:ios --copt=-fembed-bitcode

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Windows)*:
 Other devices (DirectX and MacOS-metal) are supported using
 [Device Plugins](https://www.tensorflow.org/install/gpu_plugins#available_devices).
 
+Experimental GPU support on Apple silicon is also built into TensorFlow and is
+enabled by building from source with `--config=metal`; see
+[tensorflow/core/common_runtime/metal](tensorflow/core/common_runtime/metal/README.md).
+
 A smaller CPU-only TensorFlow package is also available:
 
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,12 @@ In `tensorflow/c/experimental/filesystem/filesystem_interface.h`, removed `TF_Tr
 
 ### Major Features and Improvements
 
+* Experimental Metal GPU support on Apple silicon, built into TensorFlow
+  and enabled with `--config=metal`. This first change is the device and
+  memory foundation plus a small set of kernels; see
+  `tensorflow/core/common_runtime/metal/README.md`. Builds without
+  `--config=metal` are unchanged on every platform.
+
 * `tf.lite`
     * Adds support for QUI4 (Quantized Unsigned 4-bit) in Dequantize operator.
     * Adds support for FP16 and BF16 in Unpack operator.

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -19,6 +19,7 @@ load(
     "VERSION_MAJOR",
     "check_deps",
     "if_google",
+    "if_metal",
     "if_oss",
     "if_xla_available",
     "pywrap_aware_tf_cc_shared_object",
@@ -691,6 +692,14 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# Metal PluggableDevice backend for Apple Silicon. Only meaningful on
+# macos_arm64; enabled by --config=metal (see .bazelrc).
+config_setting(
+    name = "with_metal_support",
+    define_values = {"with_metal_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
 # By default, XLA GPU is compiled into tensorflow when building with
 # --config=cuda even when `with_xla_support` is false. The config setting
 # here allows us to override the behavior if needed.
@@ -1215,7 +1224,11 @@ tf_cc_shared_library(
         "@xla//xla/tsl/framework:bfc_allocator",
         "@xla//xla/tsl/framework:metrics",
         "//tensorflow/core/data:captured_function",
-    ] + tf_additional_binary_deps(),
+    ] + tf_additional_binary_deps() + if_metal([
+        # Static initializer that registers the Metal PluggableDevice. Empty
+        # unless the build was configured with --config=metal.
+        "//tensorflow/core/common_runtime/metal:metal_plugin_registrar",
+    ]),
     soversion = VERSION,
     static_deps = PACKAGE_STATIC_DEPS,
     visibility = ["//visibility:public"],

--- a/tensorflow/core/common_runtime/metal/BUILD
+++ b/tensorflow/core/common_runtime/metal/BUILD
@@ -1,0 +1,149 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Metal PluggableDevice backend for Apple Silicon GPUs.
+#
+# Every target here is target_compatible_with macOS, so wildcard builds on
+# other platforms skip the package instead of failing to compile Objective-C++.
+# Nothing in the framework depends on these targets unless the build was
+# configured with --config=metal (see if_metal() in tensorflow.bzl).
+
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
+load("//tensorflow:tensorflow.bzl", "tf_copts")
+load("//tensorflow/core/platform:rules_cc.bzl", "cc_library", "cc_test")
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = [
+        "//tensorflow:internal",
+    ],
+    licenses = ["notice"],
+)
+
+# Warnings that fire on Apple SDK headers rather than on our own sources.
+METAL_COPTS = [
+    "-Wno-shorten-64-to-32",
+]
+
+objc_library(
+    name = "metal_buffer_registry",
+    srcs = ["metal_buffer_registry.mm"],
+    hdrs = ["metal_buffer_registry.h"],
+    copts = METAL_COPTS,
+    sdk_frameworks = ["Metal"],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+objc_library(
+    name = "metal_stream",
+    srcs = ["metal_stream.mm"],
+    hdrs = ["metal_stream.h"],
+    copts = METAL_COPTS,
+    sdk_frameworks = ["Metal"],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        "//tensorflow/c/experimental/stream_executor:stream_executor_hdrs",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+objc_library(
+    name = "metal_stream_executor",
+    srcs = ["metal_stream_executor.mm"],
+    hdrs = ["metal_stream_executor.h"],
+    copts = METAL_COPTS,
+    sdk_frameworks = ["Metal"],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":metal_buffer_registry",
+        ":metal_stream",
+        # Headers only. The TF_Status symbols resolve against the framework
+        # this plugin is linked into; depending on the implementation target
+        # from //tensorflow/core would invert the core -> c layering.
+        "//tensorflow/c:tf_status_headers",
+        "//tensorflow/c/experimental/stream_executor:stream_executor_hdrs",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+objc_library(
+    name = "metal_platform",
+    srcs = ["metal_platform.mm"],
+    hdrs = ["metal_platform.h"],
+    copts = METAL_COPTS,
+    sdk_frameworks = ["Metal"],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":metal_stream",
+        ":metal_stream_executor",
+        # Headers only; see the note on :metal_stream_executor.
+        "//tensorflow/c:tf_status_headers",
+        "//tensorflow/c/experimental/stream_executor:stream_executor_hdrs",
+        "@com_google_absl//absl/log",
+    ],
+)
+
+# Entry point of the backend. Depend on this target (through if_metal) to pull
+# the Metal device into a binary; everything else here is reachable from it.
+cc_library(
+    name = "metal_plugin_registrar",
+    srcs = ["metal_plugin_registrar.cc"],
+    copts = tf_copts(),
+    target_compatible_with = ["@platforms//os:macos"],
+    # Nothing references this translation unit, so without alwayslink the
+    # linker would drop the static initializer that performs the registration.
+    alwayslink = 1,
+    deps = [
+        ":metal_platform",
+        "//tensorflow/core/common_runtime/metal/kernels:metal_kernels",
+        "//tensorflow/core/common_runtime/pluggable_device:pluggable_device_plugin_init",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+objc_library(
+    name = "metal_buffer_registry_test_lib",
+    testonly = 1,
+    srcs = ["metal_buffer_registry_test.mm"],
+    copts = METAL_COPTS,
+    sdk_frameworks = ["Metal"],
+    target_compatible_with = ["@platforms//os:macos"],
+    # The gtest cases live in this library; without alwayslink the linker drops
+    # their static registration and the test binary runs zero cases.
+    alwayslink = 1,
+    deps = [
+        ":metal_buffer_registry",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "metal_buffer_registry_test",
+    size = "small",
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":metal_buffer_registry_test_lib",
+        "//tensorflow/core:test_main",
+    ],
+)

--- a/tensorflow/core/common_runtime/metal/README.md
+++ b/tensorflow/core/common_runtime/metal/README.md
@@ -1,0 +1,126 @@
+# Metal PluggableDevice backend
+
+GPU support for Apple silicon Macs, built into TensorFlow rather than
+installed as a separate plugin.
+
+## Status
+
+The device and memory foundation, plus enough kernels to prove the compute
+path end to end. Building with `--config=metal` on an Apple silicon Mac gives
+a `/device:GPU:0` that allocates, copies, synchronises, and runs the ops
+listed below. Anything else falls back to the host, which is correct and slow.
+
+This is deliberately a small first change. The op coverage that makes the
+backend useful for training is a separate discussion and separate changes; the
+foundation is what has to be right first, because everything else is built on
+its memory model.
+
+## Building
+
+```
+./configure    # answer yes to "Metal GPU"
+bazel test --config=metal //tensorflow/core/common_runtime/metal/...
+```
+
+Without `--config=metal` the `if_metal()` select collapses to its default on
+every platform: no Objective-C++ is compiled, no dependency is added, and the
+Linux and Windows build graphs are unchanged. Every target in the new packages
+is `target_compatible_with = ["@platforms//os:macos"]`, so wildcard builds
+elsewhere skip them rather than failing.
+
+`TF_DISABLE_METAL=1` keeps the backend out of the process without a rebuild.
+
+## Why a PluggableDevice rather than a device factory
+
+The backend implements the StreamExecutor C API, the same interface an
+out-of-tree plugin implements, and registers it in-process instead of through
+`dlopen`. `RegisterPluggableDevicePlugin` already has an overload taking a
+`PluggableDeviceInit_Api` by pointer; until now only tests used it.
+
+That reuses the whole of `tensorflow/core/common_runtime/pluggable_device`
+unchanged, and keeps the backend extractable to a separate repository if that
+turns out to be the right home.
+
+The platform reports device type `GPU` and platform name `METAL`, so devices
+appear as `/device:GPU:0` and existing placement, Keras and `tf.distribute`
+code works without modification. CUDA is never built on macOS, so there is no
+collision.
+
+## Unified memory is the load-bearing decision
+
+Apple silicon has one physical memory, and this is what makes the backend
+worth having: host and device copies are `memcpy` rather than staged blits,
+which removes the transfer cost that dominates small-model performance on a
+Mac.
+
+Only devices reporting `hasUnifiedMemory` are accepted, and that is a
+correctness gate rather than a preference. On a discrete GPU, shared-storage
+buffers are host-side staging that needs explicit `didModifyRange:` and
+`synchronizeResource:`, so the zero-copy transfers would silently read stale
+data. Skipped devices are logged by name.
+
+## The buffer registry
+
+TensorFlow does not treat a device address as opaque. The BFC allocator carves
+sub-allocations out of a region by pointer arithmetic, and kernels receive
+interior pointers. A plugin that returned an `id<MTLBuffer>` in that field
+would break the first time core added an offset to it.
+
+`MetalBufferRegistry` recovers the `(buffer, offset)` pair a Metal encoder
+needs from an arbitrary interior pointer. Every kernel goes through it, and
+`metal_buffer_registry_test.mm` covers the cases that matter: an interior
+pointer, the boundary between two allocations, and a pointer that belongs to
+no allocation at all.
+
+## Stream ordering
+
+A `SP_Stream` is an `MTLCommandQueue` plus an `MTLSharedEvent` and a counter.
+Every command buffer waits for the previous value and signals the next, so
+work executes in the order TensorFlow enqueued it even though Metal command
+buffers may otherwise complete out of order.
+
+## Supported ops
+
+| Op | dtypes |
+| --- | --- |
+| `Add`, `AddV2`, `Sub`, `Mul`, `Div`, `RealDiv` | float32, float16 |
+| `Maximum`, `Minimum`, `Pow`, `SquaredDifference` | float32, float16 |
+| `Neg`, `Sqrt`, `Rsqrt`, `Exp`, `Log`, `Square`, `Abs`, `Reciprocal` | float32, float16 |
+| `Tanh`, `Sigmoid`, `Elu`, `Selu`, `Softplus` | float32, float16 |
+| `MatMul` | float32, float16 |
+| `Identity` | int32 |
+
+Binary ops broadcast with NumPy's rules. `MatMul` takes rank-2 tensors, and
+float16 requires an even column count, since an odd one produces a row stride
+MPS will not accept.
+
+`Identity` is registered for int32 alone on purpose: TensorFlow registers it
+for `DEVICE_GPU` itself, outside any CUDA guard, for every other number type
+and for bool, so those apply to this device already. Registering them again
+would give TensorFlow two registrations it cannot choose between, and it
+refuses to dispatch an op whose registrations tie.
+
+Resource variables, `Reshape`, `Const`, `Shape`, `StridedSlice` and `Pack`
+need no kernel here: TensorFlow registers them for `DEVICE_DEFAULT`, which any
+device type inherits when it has no kernel of its own.
+
+## Limitations
+
+* **Op coverage is deliberately small.** See Status.
+* **No graph optimizer or profiler module.** The `TF_InitGraph` and
+  `TF_InitProfiler` hooks are unimplemented, so there is no op fusion and no
+  Metal timeline in the TensorFlow profiler.
+* **Single device.** Every Apple silicon Mac reports one GPU; multi-device has
+  had no testing.
+* **`memset32`** with a pattern that is not four equal bytes runs on the host.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `metal_platform.{h,mm}` | `SP_Platform` and its function tables |
+| `metal_stream_executor.{h,mm}` | the forty-odd StreamExecutor callbacks |
+| `metal_stream.{h,mm}` | command queues, ordering events, timers |
+| `metal_buffer_registry.{h,mm}` | interior pointer to `(buffer, offset)` |
+| `metal_plugin_registrar.cc` | static registration into core |
+| `kernels/` | the op kernels, through the Kernel C API |

--- a/tensorflow/core/common_runtime/metal/kernels/BUILD
+++ b/tensorflow/core/common_runtime/metal/kernels/BUILD
@@ -1,0 +1,101 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Op kernels for the Metal PluggableDevice backend, registered through the
+# TensorFlow Kernel C API. As in the parent package, every target is macOS-only
+# and is only reachable from a build configured with --config=metal.
+
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = [
+        "//tensorflow/core/common_runtime/metal:__subpackages__",
+    ],
+    licenses = ["notice"],
+)
+
+METAL_COPTS = [
+    "-Wno-shorten-64-to-32",
+]
+
+objc_library(
+    name = "metal_kernel_util",
+    srcs = ["metal_kernel_util.mm"],
+    hdrs = ["metal_kernel_util.h"],
+    copts = METAL_COPTS,
+    sdk_frameworks = ["Metal"],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        "//tensorflow/c:kernels_experimental_hdrs",
+        "//tensorflow/c:kernels_hdrs",
+        "//tensorflow/c:tf_status_headers",
+        "//tensorflow/c:tf_tensor_hdrs",
+        "//tensorflow/core/common_runtime/metal:metal_buffer_registry",
+        "//tensorflow/core/common_runtime/metal:metal_stream",
+    ],
+)
+
+objc_library(
+    name = "metal_mps_graph",
+    srcs = ["metal_mps_graph.mm"],
+    hdrs = ["metal_mps_graph.h"],
+    copts = METAL_COPTS,
+    sdk_frameworks = [
+        "Metal",
+        "MetalPerformanceShaders",
+        "MetalPerformanceShadersGraph",
+    ],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":metal_kernel_util",
+        "//tensorflow/c:tf_datatype_hdrs",
+        "//tensorflow/c:tf_status_headers",
+        "//tensorflow/c:tf_tensor_hdrs",
+        "//tensorflow/core/common_runtime/metal:metal_stream",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+objc_library(
+    name = "metal_kernels",
+    srcs = [
+        "metal_elementwise_ops.mm",
+        "metal_identity_op.mm",
+        "metal_kernels.mm",
+        "metal_matmul_op.mm",
+    ],
+    hdrs = ["metal_kernels.h"],
+    copts = METAL_COPTS,
+    sdk_frameworks = [
+        "Metal",
+        "MetalPerformanceShaders",
+        "MetalPerformanceShadersGraph",
+    ],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":metal_kernel_util",
+        ":metal_mps_graph",
+        "//tensorflow/c:kernels_hdrs",
+        "//tensorflow/c:tf_datatype_hdrs",
+        "//tensorflow/c:tf_status_headers",
+        "//tensorflow/c:tf_tensor_hdrs",
+        "//tensorflow/core/common_runtime/metal:metal_platform",
+        "//tensorflow/core/common_runtime/metal:metal_stream",
+        "@com_google_absl//absl/log",
+    ],
+)

--- a/tensorflow/core/common_runtime/metal/kernels/metal_elementwise_ops.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_elementwise_ops.mm
@@ -1,0 +1,850 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernels.h"
+
+#import <Metal/Metal.h>
+#import <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/log/log.h"
+#include "tensorflow/c/kernels.h"
+#include "tensorflow/c/tf_datatype.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/c/tf_tensor.h"
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.h"
+#include "tensorflow/core/common_runtime/metal/kernels/metal_mps_graph.h"
+#include "tensorflow/core/common_runtime/metal/metal_platform.h"
+#include "tensorflow/core/common_runtime/metal/metal_stream.h"
+
+namespace tensorflow {
+namespace metal {
+namespace {
+
+// Elementwise arithmetic on MPSGraph.
+//
+// An earlier version of this file used hand-written compute shaders and could
+// only broadcast a scalar operand. That is not a limitation real graphs
+// tolerate: gradients broadcast against reduced axes constantly. MPSGraph
+// applies NumPy broadcasting natively, so moving these ops onto it removes the
+// restriction rather than working around it, and brings the rest of the maths
+// library with it.
+
+// NumPy broadcasting: right-align the shapes, and each pair of extents must be
+// equal or one of them must be 1.
+bool BroadcastShape(const std::vector<int64_t>& lhs,
+                    const std::vector<int64_t>& rhs,
+                    std::vector<int64_t>* out, TF_Status* status) {
+  const size_t rank = std::max(lhs.size(), rhs.size());
+  out->assign(rank, 1);
+  for (size_t i = 0; i < rank; ++i) {
+    const int64_t a = i < rank - lhs.size() ? 1 : lhs[i - (rank - lhs.size())];
+    const int64_t b = i < rank - rhs.size() ? 1 : rhs[i - (rank - rhs.size())];
+    if (a != b && a != 1 && b != 1) {
+      auto describe = [](const std::vector<int64_t>& s) {
+        std::string t = "[";
+        for (size_t j = 0; j < s.size(); ++j) {
+          if (j > 0) t += ",";
+          t += std::to_string(s[j]);
+        }
+        return t + "]";
+      };
+      TF_SetStatus(status, TF_INVALID_ARGUMENT,
+                   ("Metal: shapes " + describe(lhs) + " and " + describe(rhs) +
+                    " do not broadcast.")
+                       .c_str());
+      return false;
+    }
+    (*out)[i] = std::max(a, b);
+  }
+  return true;
+}
+
+int64_t ElementCount(const std::vector<int64_t>& shape) {
+  int64_t n = 1;
+  for (int64_t d : shape) n *= d;
+  return n;
+}
+
+/*** BINARY ***/
+
+enum class BinaryKind {
+  kAdd, kSub, kMul, kDiv, kMaximum, kMinimum, kPow, kSquaredDifference,
+  kFloorDiv, kFloorMod, kMod, kAtan2, kXdivy, kXlogy,
+};
+
+const char* NameOf(BinaryKind k) {
+  switch (k) {
+    case BinaryKind::kAdd: return "Add";
+    case BinaryKind::kSub: return "Sub";
+    case BinaryKind::kMul: return "Mul";
+    case BinaryKind::kDiv: return "Div";
+    case BinaryKind::kMaximum: return "Maximum";
+    case BinaryKind::kMinimum: return "Minimum";
+    case BinaryKind::kPow: return "Pow";
+    case BinaryKind::kSquaredDifference: return "SquaredDifference";
+    case BinaryKind::kFloorDiv: return "FloorDiv";
+    case BinaryKind::kFloorMod: return "FloorMod";
+    case BinaryKind::kMod: return "Mod";
+    case BinaryKind::kAtan2: return "Atan2";
+    case BinaryKind::kXdivy: return "Xdivy";
+    case BinaryKind::kXlogy: return "Xlogy";
+  }
+  return "?";
+}
+
+MPSGraphTensor* ApplyBinary(MPSGraph* g, BinaryKind k, MPSGraphTensor* a,
+                            MPSGraphTensor* b, MPSDataType t) {
+  switch (k) {
+    case BinaryKind::kAdd:
+      return [g additionWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kSub:
+      return [g subtractionWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kMul:
+      return [g multiplicationWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kDiv:
+      return [g divisionWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kMaximum:
+      return [g maximumWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kMinimum:
+      return [g minimumWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kPow:
+      return [g powerWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kSquaredDifference: {
+      MPSGraphTensor* d =
+          [g subtractionWithPrimaryTensor:a secondaryTensor:b name:nil];
+      return [g squareWithTensor:d name:nil];
+    }
+    case BinaryKind::kFloorDiv: {
+      MPSGraphTensor* d =
+          [g divisionWithPrimaryTensor:a secondaryTensor:b name:nil];
+      return [g floorWithTensor:d name:nil];
+    }
+    case BinaryKind::kFloorMod:
+      // Floored modulo takes the sign of the divisor, which is what
+      // TensorFlow's FloorMod means and what Mod below does not.
+      return [g floorModuloWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kMod:
+      return [g moduloWithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kAtan2:
+      return [g atan2WithPrimaryTensor:a secondaryTensor:b name:nil];
+    case BinaryKind::kXdivy: {
+      // x/y, but 0 wherever x is 0, even where y is 0 too.
+      MPSGraphTensor* zero = [g constantWithScalar:0.0 dataType:t];
+      MPSGraphTensor* is_zero =
+          [g equalWithPrimaryTensor:a secondaryTensor:zero name:nil];
+      return [g selectWithPredicateTensor:is_zero
+                      truePredicateTensor:zero
+                     falsePredicateTensor:
+                         [g divisionWithPrimaryTensor:a
+                                      secondaryTensor:b
+                                                 name:nil]
+                                     name:nil];
+    }
+    case BinaryKind::kXlogy: {
+      // x*log(y), but 0 wherever x is 0, even where log(y) is -inf.
+      MPSGraphTensor* zero = [g constantWithScalar:0.0 dataType:t];
+      MPSGraphTensor* is_zero =
+          [g equalWithPrimaryTensor:a secondaryTensor:zero name:nil];
+      MPSGraphTensor* prod =
+          [g multiplicationWithPrimaryTensor:a
+                             secondaryTensor:[g logarithmWithTensor:b name:nil]
+                                        name:nil];
+      return [g selectWithPredicateTensor:is_zero
+                      truePredicateTensor:zero
+                     falsePredicateTensor:prod
+                                     name:nil];
+    }
+  }
+  return nil;
+}
+
+struct DTypeOp {
+  TF_DataType dtype = TF_FLOAT;
+};
+
+void* DTypeOp_Create(TF_OpKernelConstruction* ctx) {
+  TF_Status* status = TF_NewStatus();
+  auto* op = new DTypeOp();
+  TF_OpKernelConstruction_GetAttrType(ctx, "T", &op->dtype, status);
+  if (TF_GetCode(status) != TF_OK) {
+    TF_OpKernelConstruction_Failure(ctx, status);
+    TF_DeleteStatus(status);
+    delete op;
+    return nullptr;
+  }
+  TF_DeleteStatus(status);
+  return op;
+}
+
+void DTypeOp_Delete(void* kernel) { delete static_cast<DTypeOp*>(kernel); }
+
+template <BinaryKind kKind>
+void Binary_ComputeImpl(DTypeOp* op, TF_OpKernelContext* ctx,
+                        TF_Status* status) {
+  ScopedTensor lhs;
+  ScopedTensor rhs;
+  TF_GetInput(ctx, 0, lhs.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+  TF_GetInput(ctx, 1, rhs.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+
+  const std::vector<int64_t> lhs_shape = ShapeOf(lhs.get());
+  const std::vector<int64_t> rhs_shape = ShapeOf(rhs.get());
+  std::vector<int64_t> out_shape;
+  if (!BroadcastShape(lhs_shape, rhs_shape, &out_shape, status)) return;
+
+  ScopedTensor output;
+  const int64_t count = ElementCount(out_shape);
+  output.reset(TF_AllocateOutput(
+      ctx, 0, op->dtype, out_shape.data(), static_cast<int>(out_shape.size()),
+      static_cast<size_t>(count) * TF_DataTypeSize(op->dtype), status));
+  if (TF_GetCode(status) != TF_OK) return;
+  if (count == 0) return;
+
+  SP_Stream stream = StreamForContext(ctx, status);
+  if (TF_GetCode(status) != TF_OK) return;
+  id<MTLDevice> device = DeviceForStream(stream);
+
+  MPSDataType mps_dtype;
+  if (!MPSTypeFor(op->dtype, &mps_dtype, status)) return;
+
+  std::string key = NameOf(kKind);
+  AppendShapeToKey(lhs_shape, &key);
+  AppendShapeToKey(rhs_shape, &key);
+  key.append("/t").append(std::to_string(static_cast<int>(op->dtype)));
+
+  const CachedGraph* cached = LookupOrBuildGraph(
+      key,
+      ^(CachedGraph* out) {
+        MPSGraphTensor* a = [out->graph placeholderWithShape:MPSShape(lhs_shape)
+                                                    dataType:mps_dtype
+                                                        name:nil];
+        MPSGraphTensor* b = [out->graph placeholderWithShape:MPSShape(rhs_shape)
+                                                    dataType:mps_dtype
+                                                        name:nil];
+        [out->inputs addObject:a];
+        [out->inputs addObject:b];
+        [out->outputs addObject:ApplyBinary(out->graph, kKind, a, b, mps_dtype)];
+      },
+      status);
+  if (cached == nullptr) return;
+
+  MPSGraphTensorData* a_data =
+      TensorDataForTensor(lhs.get(), op->dtype, device, status);
+  if (a_data == nil) return;
+  MPSGraphTensorData* b_data =
+      TensorDataForTensor(rhs.get(), op->dtype, device, status);
+  if (b_data == nil) return;
+  MPSGraphTensorData* out_data =
+      TensorDataForTensor(output.get(), op->dtype, device, status);
+  if (out_data == nil) return;
+  RunGraph(stream, *cached, @[ a_data, b_data ], @[ out_data ], status);
+}
+
+/*** UNARY ***/
+
+enum class UnaryKind {
+  kNeg, kSqrt, kRsqrt, kExp, kLog, kSquare, kTanh, kSigmoid, kAbs, kReciprocal,
+  kFloor, kCeil, kRound, kRint, kSign, kErf, kSoftplus, kElu, kSelu, kLog1p,
+  kExpm1,
+  kSin, kCos, kTan, kAsin, kAcos, kAtan, kSinh, kCosh, kAsinh, kAcosh, kAtanh,
+};
+
+const char* NameOf(UnaryKind k) {
+  switch (k) {
+    case UnaryKind::kNeg: return "Neg";
+    case UnaryKind::kSqrt: return "Sqrt";
+    case UnaryKind::kRsqrt: return "Rsqrt";
+    case UnaryKind::kExp: return "Exp";
+    case UnaryKind::kLog: return "Log";
+    case UnaryKind::kSquare: return "Square";
+    case UnaryKind::kTanh: return "Tanh";
+    case UnaryKind::kSigmoid: return "Sigmoid";
+    case UnaryKind::kAbs: return "Abs";
+    case UnaryKind::kReciprocal: return "Reciprocal";
+    case UnaryKind::kFloor: return "Floor";
+    case UnaryKind::kCeil: return "Ceil";
+    case UnaryKind::kRound: return "Round";
+    case UnaryKind::kRint: return "Rint";
+    case UnaryKind::kSign: return "Sign";
+    case UnaryKind::kErf: return "Erf";
+    case UnaryKind::kSoftplus: return "Softplus";
+    case UnaryKind::kElu: return "Elu";
+    case UnaryKind::kSelu: return "Selu";
+    case UnaryKind::kLog1p: return "Log1p";
+    case UnaryKind::kExpm1: return "Expm1";
+    case UnaryKind::kSin: return "Sin";
+    case UnaryKind::kCos: return "Cos";
+    case UnaryKind::kTan: return "Tan";
+    case UnaryKind::kAsin: return "Asin";
+    case UnaryKind::kAcos: return "Acos";
+    case UnaryKind::kAtan: return "Atan";
+    case UnaryKind::kSinh: return "Sinh";
+    case UnaryKind::kCosh: return "Cosh";
+    case UnaryKind::kAsinh: return "Asinh";
+    case UnaryKind::kAcosh: return "Acosh";
+    case UnaryKind::kAtanh: return "Atanh";
+  }
+  return "?";
+}
+
+// Softplus, written the stable way TensorFlow writes it:
+//   max(x, 0) + log(1 + exp(-|x|))
+// Rather than log(1 + exp(x)), which overflows for large positive x.
+MPSGraphTensor* Softplus(MPSGraph* g, MPSGraphTensor* x, MPSDataType t) {
+  MPSGraphTensor* zero = [g constantWithScalar:0.0 dataType:t];
+  MPSGraphTensor* one = [g constantWithScalar:1.0 dataType:t];
+  MPSGraphTensor* pos = [g maximumWithPrimaryTensor:x secondaryTensor:zero name:nil];
+  MPSGraphTensor* negabs =
+      [g negativeWithTensor:[g absoluteWithTensor:x name:nil] name:nil];
+  MPSGraphTensor* e = [g exponentWithTensor:negabs name:nil];
+  MPSGraphTensor* l =
+      [g logarithmWithTensor:[g additionWithPrimaryTensor:one
+                                         secondaryTensor:e
+                                                    name:nil]
+                        name:nil];
+  return [g additionWithPrimaryTensor:pos secondaryTensor:l name:nil];
+}
+
+// Elu: x for x > 0, exp(x) - 1 otherwise. Built from a select rather than a
+// clamp so the negative branch keeps its exact exponential shape.
+MPSGraphTensor* Elu(MPSGraph* g, MPSGraphTensor* x, MPSDataType t) {
+  MPSGraphTensor* zero = [g constantWithScalar:0.0 dataType:t];
+  MPSGraphTensor* one = [g constantWithScalar:1.0 dataType:t];
+  MPSGraphTensor* neg =
+      [g subtractionWithPrimaryTensor:[g exponentWithTensor:x name:nil]
+                      secondaryTensor:one
+                                 name:nil];
+  MPSGraphTensor* mask =
+      [g greaterThanWithPrimaryTensor:x secondaryTensor:zero name:nil];
+  return [g selectWithPredicateTensor:mask
+                  truePredicateTensor:x
+                 falsePredicateTensor:neg
+                                 name:nil];
+}
+
+MPSGraphTensor* ApplyUnary(MPSGraph* g, UnaryKind k, MPSGraphTensor* x,
+                           MPSDataType t) {
+  switch (k) {
+    case UnaryKind::kNeg: return [g negativeWithTensor:x name:nil];
+    case UnaryKind::kSqrt: return [g squareRootWithTensor:x name:nil];
+    case UnaryKind::kRsqrt: return [g reciprocalSquareRootWithTensor:x name:nil];
+    case UnaryKind::kExp: return [g exponentWithTensor:x name:nil];
+    case UnaryKind::kLog: return [g logarithmWithTensor:x name:nil];
+    case UnaryKind::kSquare: return [g squareWithTensor:x name:nil];
+    case UnaryKind::kTanh: return [g tanhWithTensor:x name:nil];
+    case UnaryKind::kSigmoid: return [g sigmoidWithTensor:x name:nil];
+    case UnaryKind::kAbs: return [g absoluteWithTensor:x name:nil];
+    case UnaryKind::kReciprocal: return [g reciprocalWithTensor:x name:nil];
+    case UnaryKind::kFloor: return [g floorWithTensor:x name:nil];
+    case UnaryKind::kCeil: return [g ceilWithTensor:x name:nil];
+    // TensorFlow's Round rounds halves to even, which is rint, not round:
+    // MPSGraph's roundWithTensor rounds halves away from zero and would send
+    // 2.5 to 3 where TensorFlow sends it to 2.
+    case UnaryKind::kRound: return [g rintWithTensor:x name:nil];
+    case UnaryKind::kRint: return [g rintWithTensor:x name:nil];
+    case UnaryKind::kSign: return [g signWithTensor:x name:nil];
+    case UnaryKind::kErf: return [g erfWithTensor:x name:nil];
+    case UnaryKind::kSoftplus: return Softplus(g, x, t);
+    case UnaryKind::kElu: return Elu(g, x, t);
+    case UnaryKind::kSelu: {
+      // The fixed constants from the self-normalising networks paper, which
+      // is what TensorFlow's Selu uses.
+      MPSGraphTensor* alpha =
+          [g constantWithScalar:1.6732632423543772 dataType:t];
+      MPSGraphTensor* scale =
+          [g constantWithScalar:1.0507009873554805 dataType:t];
+      MPSGraphTensor* zero = [g constantWithScalar:0.0 dataType:t];
+      MPSGraphTensor* one = [g constantWithScalar:1.0 dataType:t];
+      MPSGraphTensor* neg = [g
+          multiplicationWithPrimaryTensor:alpha
+                          secondaryTensor:
+                              [g subtractionWithPrimaryTensor:
+                                     [g exponentWithTensor:x name:nil]
+                                              secondaryTensor:one
+                                                         name:nil]
+                                     name:nil];
+      MPSGraphTensor* mask =
+          [g greaterThanWithPrimaryTensor:x secondaryTensor:zero name:nil];
+      MPSGraphTensor* branch = [g selectWithPredicateTensor:mask
+                                        truePredicateTensor:x
+                                       falsePredicateTensor:neg
+                                                       name:nil];
+      return [g multiplicationWithPrimaryTensor:scale
+                                secondaryTensor:branch
+                                           name:nil];
+    }
+    case UnaryKind::kLog1p: {
+      MPSGraphTensor* one = [g constantWithScalar:1.0 dataType:t];
+      return [g logarithmWithTensor:[g additionWithPrimaryTensor:x
+                                                secondaryTensor:one
+                                                           name:nil]
+                               name:nil];
+    }
+    case UnaryKind::kExpm1: {
+      MPSGraphTensor* one = [g constantWithScalar:1.0 dataType:t];
+      return [g subtractionWithPrimaryTensor:[g exponentWithTensor:x name:nil]
+                             secondaryTensor:one
+                                        name:nil];
+    }
+    case UnaryKind::kSin: return [g sinWithTensor:x name:nil];
+    case UnaryKind::kCos: return [g cosWithTensor:x name:nil];
+    case UnaryKind::kTan: return [g tanWithTensor:x name:nil];
+    case UnaryKind::kAsin: return [g asinWithTensor:x name:nil];
+    case UnaryKind::kAcos: return [g acosWithTensor:x name:nil];
+    case UnaryKind::kAtan: return [g atanWithTensor:x name:nil];
+    case UnaryKind::kSinh: return [g sinhWithTensor:x name:nil];
+    case UnaryKind::kCosh: return [g coshWithTensor:x name:nil];
+    case UnaryKind::kAsinh: return [g asinhWithTensor:x name:nil];
+    case UnaryKind::kAcosh: return [g acoshWithTensor:x name:nil];
+    case UnaryKind::kAtanh: return [g atanhWithTensor:x name:nil];
+  }
+  return nil;
+}
+
+template <UnaryKind kKind>
+void Unary_ComputeImpl(DTypeOp* op, TF_OpKernelContext* ctx,
+                       TF_Status* status) {
+  ScopedTensor input;
+  TF_GetInput(ctx, 0, input.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+
+  const std::vector<int64_t> shape = ShapeOf(input.get());
+  const int64_t count = ElementCount(shape);
+
+  ScopedTensor output;
+  output.reset(TF_AllocateOutput(
+      ctx, 0, op->dtype, shape.data(), static_cast<int>(shape.size()),
+      static_cast<size_t>(count) * TF_DataTypeSize(op->dtype), status));
+  if (TF_GetCode(status) != TF_OK) return;
+  if (count == 0) return;
+
+  SP_Stream stream = StreamForContext(ctx, status);
+  if (TF_GetCode(status) != TF_OK) return;
+  id<MTLDevice> device = DeviceForStream(stream);
+
+  MPSDataType mps_dtype;
+  if (!MPSTypeFor(op->dtype, &mps_dtype, status)) return;
+
+  std::string key = NameOf(kKind);
+  AppendShapeToKey(shape, &key);
+  key.append("/t").append(std::to_string(static_cast<int>(op->dtype)));
+
+  const CachedGraph* cached = LookupOrBuildGraph(
+      key,
+      ^(CachedGraph* out) {
+        MPSGraphTensor* x = [out->graph placeholderWithShape:MPSShape(shape)
+                                                    dataType:mps_dtype
+                                                        name:nil];
+        [out->inputs addObject:x];
+        [out->outputs addObject:ApplyUnary(out->graph, kKind, x, mps_dtype)];
+      },
+      status);
+  if (cached == nullptr) return;
+
+  MPSGraphTensorData* in_data =
+      TensorDataForTensor(input.get(), op->dtype, device, status);
+  if (in_data == nil) return;
+  MPSGraphTensorData* out_data =
+      TensorDataForTensor(output.get(), op->dtype, device, status);
+  if (out_data == nil) return;
+  RunGraph(stream, *cached, @[ in_data ], @[ out_data ], status);
+}
+
+/*** UNARY GRADIENTS ***/
+
+// TensorFlow's *Grad ops take the forward output y and the incoming gradient
+// dy, not the forward input, so each formula is expressed in terms of y.
+enum class UnaryGradKind { kTanh, kSigmoid, kSqrt, kRsqrt };
+
+const char* NameOf(UnaryGradKind k) {
+  switch (k) {
+    case UnaryGradKind::kTanh: return "TanhGrad";
+    case UnaryGradKind::kSigmoid: return "SigmoidGrad";
+    case UnaryGradKind::kSqrt: return "SqrtGrad";
+    case UnaryGradKind::kRsqrt: return "RsqrtGrad";
+  }
+  return "?";
+}
+
+MPSGraphTensor* ApplyUnaryGrad(MPSGraph* g, UnaryGradKind k, MPSGraphTensor* y,
+                               MPSGraphTensor* dy, MPSDataType dtype) {
+  MPSGraphTensor* one = [g constantWithScalar:1.0 dataType:dtype];
+  switch (k) {
+    case UnaryGradKind::kTanh: {
+      // dy * (1 - y^2)
+      MPSGraphTensor* y2 = [g squareWithTensor:y name:nil];
+      MPSGraphTensor* t =
+          [g subtractionWithPrimaryTensor:one secondaryTensor:y2 name:nil];
+      return [g multiplicationWithPrimaryTensor:dy secondaryTensor:t name:nil];
+    }
+    case UnaryGradKind::kSigmoid: {
+      // dy * y * (1 - y)
+      MPSGraphTensor* t =
+          [g subtractionWithPrimaryTensor:one secondaryTensor:y name:nil];
+      MPSGraphTensor* u =
+          [g multiplicationWithPrimaryTensor:y secondaryTensor:t name:nil];
+      return [g multiplicationWithPrimaryTensor:dy secondaryTensor:u name:nil];
+    }
+    case UnaryGradKind::kSqrt: {
+      // dy * 0.5 / y
+      MPSGraphTensor* half = [g constantWithScalar:0.5 dataType:dtype];
+      MPSGraphTensor* t =
+          [g multiplicationWithPrimaryTensor:dy secondaryTensor:half name:nil];
+      return [g divisionWithPrimaryTensor:t secondaryTensor:y name:nil];
+    }
+    case UnaryGradKind::kRsqrt: {
+      // dy * -0.5 * y^3
+      MPSGraphTensor* mhalf = [g constantWithScalar:-0.5 dataType:dtype];
+      MPSGraphTensor* y2 = [g squareWithTensor:y name:nil];
+      MPSGraphTensor* y3 =
+          [g multiplicationWithPrimaryTensor:y2 secondaryTensor:y name:nil];
+      MPSGraphTensor* t =
+          [g multiplicationWithPrimaryTensor:dy secondaryTensor:mhalf name:nil];
+      return [g multiplicationWithPrimaryTensor:t secondaryTensor:y3 name:nil];
+    }
+  }
+  return nil;
+}
+
+template <UnaryGradKind kKind>
+void UnaryGrad_ComputeImpl(DTypeOp* op, TF_OpKernelContext* ctx,
+                           TF_Status* status) {
+  ScopedTensor y;
+  ScopedTensor dy;
+  TF_GetInput(ctx, 0, y.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+  TF_GetInput(ctx, 1, dy.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+
+  const std::vector<int64_t> shape = ShapeOf(y.get());
+  const int64_t count = ElementCount(shape);
+
+  ScopedTensor output;
+  output.reset(TF_AllocateOutput(
+      ctx, 0, op->dtype, shape.data(), static_cast<int>(shape.size()),
+      static_cast<size_t>(count) * TF_DataTypeSize(op->dtype), status));
+  if (TF_GetCode(status) != TF_OK) return;
+  if (count == 0) return;
+
+  SP_Stream stream = StreamForContext(ctx, status);
+  if (TF_GetCode(status) != TF_OK) return;
+  id<MTLDevice> device = DeviceForStream(stream);
+
+  MPSDataType mps_dtype;
+  if (!MPSTypeFor(op->dtype, &mps_dtype, status)) return;
+
+  std::string key = NameOf(kKind);
+  AppendShapeToKey(shape, &key);
+  key.append("/t").append(std::to_string(static_cast<int>(op->dtype)));
+
+  const CachedGraph* cached = LookupOrBuildGraph(
+      key,
+      ^(CachedGraph* out) {
+        MPSGraphTensor* a = [out->graph placeholderWithShape:MPSShape(shape)
+                                                    dataType:mps_dtype
+                                                        name:nil];
+        MPSGraphTensor* b = [out->graph placeholderWithShape:MPSShape(shape)
+                                                    dataType:mps_dtype
+                                                        name:nil];
+        [out->inputs addObject:a];
+        [out->inputs addObject:b];
+        [out->outputs
+            addObject:ApplyUnaryGrad(out->graph, kKind, a, b, mps_dtype)];
+      },
+      status);
+  if (cached == nullptr) return;
+
+  MPSGraphTensorData* y_data =
+      TensorDataForTensor(y.get(), op->dtype, device, status);
+  if (y_data == nil) return;
+  MPSGraphTensorData* dy_data =
+      TensorDataForTensor(dy.get(), op->dtype, device, status);
+  if (dy_data == nil) return;
+  MPSGraphTensorData* out_data =
+      TensorDataForTensor(output.get(), op->dtype, device, status);
+  if (out_data == nil) return;
+  RunGraph(stream, *cached, @[ y_data, dy_data ], @[ out_data ], status);
+}
+
+/*** CAST ***/
+
+struct CastOp {
+  TF_DataType src = TF_FLOAT;
+  TF_DataType dst = TF_FLOAT;
+};
+
+void* CastOp_Create(TF_OpKernelConstruction* ctx) {
+  TF_Status* status = TF_NewStatus();
+  auto* op = new CastOp();
+  TF_OpKernelConstruction_GetAttrType(ctx, "SrcT", &op->src, status);
+  if (TF_GetCode(status) == TF_OK) {
+    TF_OpKernelConstruction_GetAttrType(ctx, "DstT", &op->dst, status);
+  }
+  if (TF_GetCode(status) != TF_OK) {
+    TF_OpKernelConstruction_Failure(ctx, status);
+    TF_DeleteStatus(status);
+    delete op;
+    return nullptr;
+  }
+  TF_DeleteStatus(status);
+  return op;
+}
+
+void CastOp_Delete(void* kernel) { delete static_cast<CastOp*>(kernel); }
+
+void Cast_ComputeImpl(CastOp* op, TF_OpKernelContext* ctx, TF_Status* status) {
+  ScopedTensor input;
+  TF_GetInput(ctx, 0, input.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+
+  const std::vector<int64_t> shape = ShapeOf(input.get());
+  const int64_t count = ElementCount(shape);
+
+  ScopedTensor output;
+  output.reset(TF_AllocateOutput(
+      ctx, 0, op->dst, shape.data(), static_cast<int>(shape.size()),
+      static_cast<size_t>(count) * TF_DataTypeSize(op->dst), status));
+  if (TF_GetCode(status) != TF_OK) return;
+  if (count == 0) return;
+
+  SP_Stream stream = StreamForContext(ctx, status);
+  if (TF_GetCode(status) != TF_OK) return;
+  id<MTLDevice> device = DeviceForStream(stream);
+
+  MPSDataType src_type;
+  MPSDataType dst_type;
+  if (!MPSTypeFor(op->src, &src_type, status)) return;
+  if (!MPSTypeFor(op->dst, &dst_type, status)) return;
+
+  std::string key = "Cast";
+  AppendShapeToKey(shape, &key);
+  key.append("/").append(std::to_string(static_cast<int>(op->src)));
+  key.append("->").append(std::to_string(static_cast<int>(op->dst)));
+
+  const CachedGraph* cached = LookupOrBuildGraph(
+      key,
+      ^(CachedGraph* out) {
+        MPSGraphTensor* x = [out->graph placeholderWithShape:MPSShape(shape)
+                                                    dataType:src_type
+                                                        name:nil];
+        [out->inputs addObject:x];
+        [out->outputs addObject:[out->graph castTensor:x
+                                                toType:dst_type
+                                                  name:nil]];
+      },
+      status);
+  if (cached == nullptr) return;
+
+  MPSGraphTensorData* in_data =
+      TensorDataForTensor(input.get(), op->src, device, status);
+  if (in_data == nil) return;
+  MPSGraphTensorData* out_data =
+      TensorDataForTensor(output.get(), op->dst, device, status);
+  if (out_data == nil) return;
+  RunGraph(stream, *cached, @[ in_data ], @[ out_data ], status);
+}
+
+/*** WRAPPERS AND REGISTRATION ***/
+
+#define METAL_COMPUTE(NAME, STATE, IMPL)                                      \
+  void NAME(void* kernel, TF_OpKernelContext* ctx) {                          \
+    ScopedAutoreleasePool pool;                                               \
+    TF_Status* status = TF_NewStatus();                                       \
+    auto* op = static_cast<STATE*>(kernel);                                   \
+    if (op == nullptr) {                                                      \
+      TF_SetStatus(status, TF_INTERNAL, "Metal: kernel has no state.");       \
+    } else {                                                                  \
+      IMPL(op, ctx, status);                                                  \
+    }                                                                         \
+    if (TF_GetCode(status) != TF_OK) TF_OpKernelContext_Failure(ctx, status); \
+    TF_DeleteStatus(status);                                                  \
+  }
+
+METAL_COMPUTE(Add_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kAdd>)
+METAL_COMPUTE(Sub_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kSub>)
+METAL_COMPUTE(Mul_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kMul>)
+METAL_COMPUTE(Div_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kDiv>)
+METAL_COMPUTE(Max_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kMaximum>)
+METAL_COMPUTE(Min_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kMinimum>)
+METAL_COMPUTE(Pow_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kPow>)
+METAL_COMPUTE(SqDiff_Compute, DTypeOp,
+              Binary_ComputeImpl<BinaryKind::kSquaredDifference>)
+METAL_COMPUTE(FloorDiv_Compute, DTypeOp,
+              Binary_ComputeImpl<BinaryKind::kFloorDiv>)
+METAL_COMPUTE(FloorMod_Compute, DTypeOp,
+              Binary_ComputeImpl<BinaryKind::kFloorMod>)
+METAL_COMPUTE(Mod_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kMod>)
+
+METAL_COMPUTE(Neg_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kNeg>)
+METAL_COMPUTE(Sqrt_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kSqrt>)
+METAL_COMPUTE(Rsqrt_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kRsqrt>)
+METAL_COMPUTE(Exp_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kExp>)
+METAL_COMPUTE(Log_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kLog>)
+METAL_COMPUTE(Square_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kSquare>)
+METAL_COMPUTE(Tanh_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kTanh>)
+METAL_COMPUTE(Sigmoid_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kSigmoid>)
+METAL_COMPUTE(Abs_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kAbs>)
+METAL_COMPUTE(Recip_Compute, DTypeOp,
+              Unary_ComputeImpl<UnaryKind::kReciprocal>)
+METAL_COMPUTE(Floor_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kFloor>)
+METAL_COMPUTE(Ceil_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kCeil>)
+METAL_COMPUTE(Round_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kRound>)
+METAL_COMPUTE(Rint_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kRint>)
+METAL_COMPUTE(Sign_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kSign>)
+METAL_COMPUTE(Erf_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kErf>)
+METAL_COMPUTE(Expm1_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kExpm1>)
+METAL_COMPUTE(Log1p_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kLog1p>)
+METAL_COMPUTE(Sin_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kSin>)
+METAL_COMPUTE(Cos_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kCos>)
+METAL_COMPUTE(Tan_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kTan>)
+METAL_COMPUTE(Asin_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kAsin>)
+METAL_COMPUTE(Acos_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kAcos>)
+METAL_COMPUTE(Atan_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kAtan>)
+METAL_COMPUTE(Sinh_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kSinh>)
+METAL_COMPUTE(Cosh_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kCosh>)
+METAL_COMPUTE(Asinh_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kAsinh>)
+METAL_COMPUTE(Acosh_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kAcosh>)
+METAL_COMPUTE(Atanh_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kAtanh>)
+METAL_COMPUTE(Softplus_Compute, DTypeOp,
+              Unary_ComputeImpl<UnaryKind::kSoftplus>)
+METAL_COMPUTE(Elu_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kElu>)
+METAL_COMPUTE(Selu_Compute, DTypeOp, Unary_ComputeImpl<UnaryKind::kSelu>)
+METAL_COMPUTE(TanhGrad_Compute, DTypeOp,
+              UnaryGrad_ComputeImpl<UnaryGradKind::kTanh>)
+METAL_COMPUTE(SigmoidGrad_Compute, DTypeOp,
+              UnaryGrad_ComputeImpl<UnaryGradKind::kSigmoid>)
+METAL_COMPUTE(SqrtGrad_Compute, DTypeOp,
+              UnaryGrad_ComputeImpl<UnaryGradKind::kSqrt>)
+METAL_COMPUTE(RsqrtGrad_Compute, DTypeOp,
+              UnaryGrad_ComputeImpl<UnaryGradKind::kRsqrt>)
+METAL_COMPUTE(Atan2_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kAtan2>)
+METAL_COMPUTE(Xdivy_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kXdivy>)
+METAL_COMPUTE(Xlogy_Compute, DTypeOp, Binary_ComputeImpl<BinaryKind::kXlogy>)
+
+METAL_COMPUTE(Cast_Compute, CastOp, Cast_ComputeImpl)
+
+#undef METAL_COMPUTE
+
+void Register(const char* op_name, void* (*create)(TF_OpKernelConstruction*),
+              void (*compute)(void*, TF_OpKernelContext*), void (*destroy)(void*),
+              const char* attr, TF_DataType dtype, const std::string& name,
+              const char* attr2 = nullptr, TF_DataType dtype2 = TF_FLOAT) {
+  TF_Status* status = TF_NewStatus();
+  TF_KernelBuilder* builder =
+      TF_NewKernelBuilder(op_name, kMetalDeviceType, create, compute, destroy);
+  TF_KernelBuilder_TypeConstraint(builder, attr, dtype, status);
+  if (TF_GetCode(status) == TF_OK && attr2 != nullptr) {
+    TF_KernelBuilder_TypeConstraint(builder, attr2, dtype2, status);
+  }
+  if (TF_GetCode(status) == TF_OK) {
+    TF_RegisterKernelBuilder(name.c_str(), builder, status);
+  } else {
+    TF_DeleteKernelBuilder(builder);
+  }
+  if (TF_GetCode(status) != TF_OK) {
+    LOG(ERROR) << "Metal: could not register kernel " << name << ": "
+               << TF_Message(status);
+  }
+  TF_DeleteStatus(status);
+}
+
+}  // namespace
+
+void RegisterMetalElementwiseKernels() {
+  static constexpr TF_DataType kDTypes[] = {TF_FLOAT, TF_HALF};
+  static constexpr const char* kSuffixes[] = {"Float", "Half"};
+
+  struct BinaryEntry {
+    const char* op;
+    void (*compute)(void*, TF_OpKernelContext*);
+  };
+  // AddV2 is what modern graphs emit; Add is kept for graphs still carrying
+  // the v1 op. RealDiv and Div are the same operation on floating point.
+  static const BinaryEntry kBinaries[] = {
+      {"AddV2", &Add_Compute},   {"Add", &Add_Compute},
+      {"Sub", &Sub_Compute},     {"Mul", &Mul_Compute},
+      {"Div", &Div_Compute},     {"RealDiv", &Div_Compute},
+      {"FloorDiv", &FloorDiv_Compute}, {"FloorMod", &FloorMod_Compute},
+      {"Mod", &Mod_Compute},
+      {"Maximum", &Max_Compute}, {"Minimum", &Min_Compute},
+      {"Pow", &Pow_Compute},     {"SquaredDifference", &SqDiff_Compute},
+      {"Atan2", &Atan2_Compute},
+      {"Xdivy", &Xdivy_Compute},       {"Xlogy", &Xlogy_Compute},
+  };
+
+  struct UnaryEntry {
+    const char* op;
+    void (*compute)(void*, TF_OpKernelContext*);
+  };
+  static const UnaryEntry kUnaries[] = {
+      {"Neg", &Neg_Compute},         {"Sqrt", &Sqrt_Compute},
+      {"Rsqrt", &Rsqrt_Compute},     {"Exp", &Exp_Compute},
+      {"Log", &Log_Compute},         {"Square", &Square_Compute},
+      {"Tanh", &Tanh_Compute},       {"Sigmoid", &Sigmoid_Compute},
+      {"Abs", &Abs_Compute},         {"Reciprocal", &Recip_Compute},
+      {"Floor", &Floor_Compute},     {"Ceil", &Ceil_Compute},
+      {"Round", &Round_Compute},     {"Rint", &Rint_Compute},
+      {"Sign", &Sign_Compute},       {"Erf", &Erf_Compute},
+      {"Softplus", &Softplus_Compute}, {"Elu", &Elu_Compute},
+      {"Selu", &Selu_Compute},       {"Log1p", &Log1p_Compute},
+      {"Expm1", &Expm1_Compute},
+      {"TanhGrad", &TanhGrad_Compute},
+      {"SigmoidGrad", &SigmoidGrad_Compute},
+      {"SqrtGrad", &SqrtGrad_Compute},
+      {"RsqrtGrad", &RsqrtGrad_Compute},
+      {"Sin", &Sin_Compute},       {"Cos", &Cos_Compute},
+      {"Tan", &Tan_Compute},       {"Asin", &Asin_Compute},
+      {"Acos", &Acos_Compute},     {"Atan", &Atan_Compute},
+      {"Sinh", &Sinh_Compute},     {"Cosh", &Cosh_Compute},
+      {"Asinh", &Asinh_Compute},   {"Acosh", &Acosh_Compute},
+      {"Atanh", &Atanh_Compute},
+  };
+
+  for (int i = 0; i < 2; ++i) {
+    const TF_DataType dtype = kDTypes[i];
+    const std::string suffix = kSuffixes[i];
+    for (const BinaryEntry& e : kBinaries) {
+      Register(e.op, &DTypeOp_Create, e.compute, &DTypeOp_Delete, "T", dtype,
+               std::string("Metal") + e.op + suffix);
+    }
+    for (const UnaryEntry& e : kUnaries) {
+      Register(e.op, &DTypeOp_Create, e.compute, &DTypeOp_Delete, "T", dtype,
+               std::string("Metal") + e.op + suffix);
+    }
+  }
+
+  // Cast, over the pairs a mixed-precision or index-handling graph emits.
+  struct CastPair { TF_DataType src, dst; const char* name; };
+  static const CastPair kCasts[] = {
+      {TF_FLOAT, TF_HALF, "FloatToHalf"},   {TF_HALF, TF_FLOAT, "HalfToFloat"},
+      {TF_FLOAT, TF_BFLOAT16, "FloatToBf"}, {TF_BFLOAT16, TF_FLOAT, "BfToFloat"},
+      {TF_FLOAT, TF_INT32, "FloatToInt32"}, {TF_INT32, TF_FLOAT, "Int32ToFloat"},
+      {TF_INT32, TF_INT64, "Int32ToInt64"}, {TF_INT64, TF_INT32, "Int64ToInt32"},
+      {TF_FLOAT, TF_FLOAT, "FloatToFloat"},
+  };
+  for (const CastPair& c : kCasts) {
+    Register("Cast", &CastOp_Create, &Cast_Compute, &CastOp_Delete, "SrcT",
+             c.src, std::string("MetalCast") + c.name, "DstT", c.dst);
+  }
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/kernels/metal_elementwise_ops.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_elementwise_ops.mm
@@ -754,6 +754,11 @@ void Register(const char* op_name, void* (*create)(TF_OpKernelConstruction*),
   if (TF_GetCode(status) == TF_OK && attr2 != nullptr) {
     TF_KernelBuilder_TypeConstraint(builder, attr2, dtype2, status);
   }
+  // The builder is deleted here and only here. TF_RegisterKernelBuilder hands
+  // it to an OpKernelRegistrar, which owns it from then on, and sets the
+  // status to OK unconditionally: with no serialized KernelDef there is
+  // nothing for it to fail on. So the only way to still hold the builder is
+  // for a type constraint to have failed before the call.
   if (TF_GetCode(status) == TF_OK) {
     TF_RegisterKernelBuilder(name.c_str(), builder, status);
   } else {

--- a/tensorflow/core/common_runtime/metal/kernels/metal_identity_op.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_identity_op.mm
@@ -104,6 +104,11 @@ void RegisterIdentity(const char* op_name, TF_DataType dtype,
       op_name, kMetalDeviceType, /*create_func=*/nullptr, &IdentityOp_Compute,
       /*delete_func=*/nullptr);
   TF_KernelBuilder_TypeConstraint(builder, "T", dtype, status);
+  // The builder is deleted here and only here. TF_RegisterKernelBuilder hands
+  // it to an OpKernelRegistrar, which owns it from then on, and sets the
+  // status to OK unconditionally: with no serialized KernelDef there is
+  // nothing for it to fail on. So the only way to still hold the builder is
+  // for a type constraint to have failed before the call.
   if (TF_GetCode(status) == TF_OK) {
     TF_RegisterKernelBuilder(kernel_name.c_str(), builder, status);
   } else {

--- a/tensorflow/core/common_runtime/metal/kernels/metal_identity_op.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_identity_op.mm
@@ -1,0 +1,151 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernels.h"
+
+#import <Metal/Metal.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/log/log.h"
+#include "tensorflow/c/kernels.h"
+#include "tensorflow/c/tf_datatype.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/c/tf_tensor.h"
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.h"
+#include "tensorflow/core/common_runtime/metal/metal_platform.h"
+#include "tensorflow/core/common_runtime/metal/metal_stream.h"
+
+namespace tensorflow {
+namespace metal {
+namespace {
+
+// Identity is worth having early even though it computes nothing: TensorFlow
+// inserts Identity nodes throughout real graphs, for control dependencies,
+// for variable reads and around function boundaries. Without a Metal kernel
+// for it, every one of those nodes would be placed on the host and drag a
+// device-to-host and host-to-device round trip with it.
+
+void IdentityOp_ComputeImpl(TF_OpKernelContext* ctx, TF_Status* status) {
+  ScopedTensor input;
+  TF_GetInput(ctx, 0, input.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+
+  const std::vector<int64_t> shape = ShapeOf(input.get());
+
+  // Ask core to alias the input buffer as the output. When the input is not
+  // shared with anything else this succeeds and Identity costs nothing at all,
+  // which is the whole point of having the kernel.
+  int forwarded_input = -1;
+  const int candidate = 0;
+  ScopedTensor output;
+  output.reset(TF_ForwardInputOrAllocateOutput(
+      ctx, &candidate, 1, 0, shape.data(), static_cast<int>(shape.size()),
+      &forwarded_input, status));
+  if (TF_GetCode(status) != TF_OK) return;
+  if (forwarded_input == 0) return;  // Aliased; nothing to copy.
+
+  const size_t bytes = TF_TensorByteSize(input.get());
+  if (bytes == 0) return;
+
+  // The input was shared, so core allocated a separate output and the bytes
+  // have to be moved. A blit keeps the copy on the GPU and in stream order.
+  SP_Stream stream = StreamForContext(ctx, status);
+  if (TF_GetCode(status) != TF_OK) return;
+
+  BufferSlice in_slice;
+  BufferSlice out_slice;
+  if (!SliceForTensor(input.get(), &in_slice, status)) return;
+  if (!SliceForTensor(output.get(), &out_slice, status)) return;
+
+  OrderedCommandBuffer command_buffer(stream);
+  if (!command_buffer.ok()) {
+    TF_SetStatus(status, TF_RESOURCE_EXHAUSTED,
+                 "Metal: could not create a command buffer for Identity.");
+    return;
+  }
+  id<MTLBlitCommandEncoder> encoder =
+      [command_buffer.get() blitCommandEncoder];
+  [encoder copyFromBuffer:in_slice.buffer
+             sourceOffset:in_slice.offset
+                 toBuffer:out_slice.buffer
+        destinationOffset:out_slice.offset
+                     size:bytes];
+  [encoder endEncoding];
+  command_buffer.Commit();
+}
+
+void IdentityOp_Compute(void* kernel, TF_OpKernelContext* ctx) {
+  ScopedAutoreleasePool pool;
+  TF_Status* status = TF_NewStatus();
+  IdentityOp_ComputeImpl(ctx, status);
+  if (TF_GetCode(status) != TF_OK) TF_OpKernelContext_Failure(ctx, status);
+  TF_DeleteStatus(status);
+}
+
+void RegisterIdentity(const char* op_name, TF_DataType dtype,
+                      const std::string& kernel_name) {
+  TF_Status* status = TF_NewStatus();
+  TF_KernelBuilder* builder = TF_NewKernelBuilder(
+      op_name, kMetalDeviceType, /*create_func=*/nullptr, &IdentityOp_Compute,
+      /*delete_func=*/nullptr);
+  TF_KernelBuilder_TypeConstraint(builder, "T", dtype, status);
+  if (TF_GetCode(status) == TF_OK) {
+    TF_RegisterKernelBuilder(kernel_name.c_str(), builder, status);
+  } else {
+    TF_DeleteKernelBuilder(builder);
+  }
+  if (TF_GetCode(status) != TF_OK) {
+    LOG(ERROR) << "Metal: could not register kernel " << kernel_name << ": "
+               << TF_Message(status);
+  }
+  TF_DeleteStatus(status);
+}
+
+}  // namespace
+
+void RegisterMetalIdentityKernels() {
+  // Identity carries no state, so unlike the arithmetic kernels it needs no
+  // create callback and Compute ignores the kernel pointer.
+  struct DTypeEntry {
+    TF_DataType dtype;
+    const char* suffix;
+  };
+  // int32 only, and that is the whole list on purpose.
+  //
+  // TensorFlow registers Identity for DEVICE_GPU itself, outside any CUDA
+  // guard, for every number type except int32 plus bool, so those apply to
+  // this device already. Registering them again produced two registrations
+  // TensorFlow cannot choose between, and it refuses to run an op whose
+  // registrations tie: Identity, which is in nearly every graph, could not
+  // execute on the GPU at all.
+  //
+  // int32 is the exception in both directions. TensorFlow's number-type lists
+  // leave it out, and its host-memory int32 kernel sits behind
+  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM, so in this build nothing else
+  // registers it.
+  static constexpr DTypeEntry kDTypes[] = {
+      {TF_INT32, "Int32"},
+  };
+  for (const DTypeEntry& entry : kDTypes) {
+    RegisterIdentity("Identity", entry.dtype,
+                     std::string("MetalIdentity") + entry.suffix);
+  }
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.h
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.h
@@ -1,0 +1,147 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_KERNEL_UTIL_H_
+#define TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_KERNEL_UTIL_H_
+
+// Objective-C++ only.
+
+#import <Metal/Metal.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "tensorflow/c/kernels.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/c/tf_tensor.h"
+#include "tensorflow/core/common_runtime/metal/metal_stream.h"
+
+namespace tensorflow {
+namespace metal {
+
+// Deletes a TF_Tensor on scope exit.
+//
+// The C kernel API hands out owned tensors, and a kernel has several
+// early-return paths (shape rejection, allocation failure, pipeline
+// compilation failure). Leaking one on any of them leaks device memory for the
+// life of the process.
+class ScopedTensor {
+ public:
+  ScopedTensor() = default;
+  ~ScopedTensor() {
+    if (tensor_ != nullptr) TF_DeleteTensor(tensor_);
+  }
+
+  ScopedTensor(const ScopedTensor&) = delete;
+  ScopedTensor& operator=(const ScopedTensor&) = delete;
+
+  // For handing to TF_GetInput, which writes through the pointer.
+  TF_Tensor** address() { return &tensor_; }
+  TF_Tensor* get() const { return tensor_; }
+  void reset(TF_Tensor* tensor) {
+    if (tensor_ != nullptr) TF_DeleteTensor(tensor_);
+    tensor_ = tensor;
+  }
+
+ private:
+  TF_Tensor* tensor_ = nullptr;
+};
+
+// A tensor's storage expressed the way a Metal encoder needs it.
+//
+// Device tensors do not start at the beginning of an MTLBuffer: core's BFC
+// allocator sub-divides one allocation into many tensors, so the offset is the
+// normal case rather than an edge case. Every Metal API this backend uses to
+// reach tensor memory therefore has to accept an offset, which is why
+// setBuffer:offset:atIndex: and MPSMatrix's initWithBuffer:offset:descriptor:
+// are preferred over interfaces that assume a buffer starts at element zero.
+struct BufferSlice {
+  id<MTLBuffer> buffer = nil;
+  size_t offset = 0;
+  size_t length = 0;
+};
+
+// Attributes shared by the spatial ops (convolution, pooling).
+//
+// TensorFlow expresses strides and dilations as one entry per dimension of the
+// data layout, with the batch and channel entries required to be 1; only the
+// two spatial entries carry information, which is what MPSGraph wants.
+struct SpatialParams {
+  int stride_h = 1;
+  int stride_w = 1;
+  int dilation_h = 1;
+  int dilation_w = 1;
+  // TensorFlow's SAME and VALID map exactly onto MPSGraph's TF_SAME and
+  // TF_VALID padding styles. EXPLICIT is rejected by the reader.
+  bool same_padding = false;
+  // NHWC, TensorFlow's default, versus NCHW.
+  bool nhwc = true;
+  TF_DataType dtype = TF_FLOAT;
+};
+
+// Reads strides, padding, data_format, T, and optionally dilations, from a
+// kernel's construction context. Fails `status` on anything unsupported,
+// naming the attribute at fault.
+bool ReadSpatialParams(TF_OpKernelConstruction* ctx, bool want_dilations,
+                       SpatialParams* out, TF_Status* status);
+
+// Index of the height and width entries in a 4-element per-dimension attribute
+// list, given the data format.
+inline int SpatialHeightIndex(bool nhwc) { return nhwc ? 1 : 2; }
+inline int SpatialWidthIndex(bool nhwc) { return nhwc ? 2 : 3; }
+
+// Resolves a device tensor's storage. Fails `status` with a diagnosable
+// message if the tensor's data does not lie in a live Metal allocation, which
+// would mean it was placed on the host rather than the device.
+bool SliceForTensor(TF_Tensor* tensor, BufferSlice* slice, TF_Status* status);
+
+// The stream this kernel must enqueue onto. Fails `status` if the context has
+// no StreamExecutor stream, which happens when the kernel was somehow placed
+// on a device this backend does not own.
+SP_Stream StreamForContext(TF_OpKernelContext* ctx, TF_Status* status);
+
+// The Metal device backing `stream`.
+id<MTLDevice> DeviceForStream(SP_Stream stream);
+
+// One dispatch of a one-dimensional shader over `count` elements.
+//
+// Uses dispatchThreadgroups: rather than dispatchThreads:, so the grid rounds
+// up to whole threadgroups and the call works regardless of GPU family. Every
+// shader in this backend bounds-checks against its element count, which is
+// what makes the rounding safe.
+void Dispatch1D(id<MTLComputeCommandEncoder> encoder,
+                id<MTLComputePipelineState> pipeline, uint32_t count);
+
+// Number of elements described by a tensor's shape.
+int64_t NumElements(TF_Tensor* tensor);
+
+// Shape as a plain vector, for shape checks and for building descriptors.
+std::vector<int64_t> ShapeOf(TF_Tensor* tensor);
+
+// Waits for everything already enqueued on `stream`.
+//
+// A kernel that gives the GPU a temporary buffer must call this before it
+// returns. TF_AllocateTemp memory goes back to the allocator the moment the
+// tensor is destroyed, and the next kernel is handed the same block, so work
+// still in flight reads what that next kernel has since written. Two inverse
+// real transforms in a row were enough: whichever ran first was right and the
+// other was not, in either order.
+void WaitForStream(SP_Stream stream);
+
+}  // namespace metal
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_KERNEL_UTIL_H_

--- a/tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.mm
@@ -1,0 +1,202 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "tensorflow/core/common_runtime/metal/metal_buffer_registry.h"
+
+namespace tensorflow {
+namespace metal {
+
+namespace {
+
+// Reads a 4-element per-dimension attribute, checking that the batch and
+// channel entries are 1. TensorFlow allows striding over batch or channels in
+// principle; no GPU backend implements it, and silently ignoring those entries
+// would compute the wrong thing.
+bool ReadSpatialPair(TF_OpKernelConstruction* ctx, const char* attr_name,
+                     bool nhwc, int* height, int* width, TF_Status* status) {
+  int32_t values[4] = {1, 1, 1, 1};
+  TF_OpKernelConstruction_GetAttrInt32List(ctx, attr_name, values, 4, status);
+  if (TF_GetCode(status) != TF_OK) return false;
+
+  const int batch_index = 0;
+  const int channel_index = nhwc ? 3 : 1;
+  if (values[batch_index] != 1 || values[channel_index] != 1) {
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 (std::string("Metal: ") + attr_name +
+                  " over the batch or channel dimension is not supported.")
+                     .c_str());
+    return false;
+  }
+  *height = values[SpatialHeightIndex(nhwc)];
+  *width = values[SpatialWidthIndex(nhwc)];
+  if (*height < 1 || *width < 1) {
+    TF_SetStatus(status, TF_INVALID_ARGUMENT,
+                 (std::string("Metal: ") + attr_name +
+                  " entries must be at least 1.")
+                     .c_str());
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+bool ReadSpatialParams(TF_OpKernelConstruction* ctx, bool want_dilations,
+                       SpatialParams* out, TF_Status* status) {
+  char format[8] = {0};
+  TF_OpKernelConstruction_GetAttrString(ctx, "data_format", format,
+                                        sizeof(format) - 1, status);
+  if (TF_GetCode(status) != TF_OK) {
+    // data_format is optional on some ops and defaults to NHWC.
+    TF_SetStatus(status, TF_OK, "");
+    out->nhwc = true;
+  } else if (std::strcmp(format, "NHWC") == 0) {
+    out->nhwc = true;
+  } else if (std::strcmp(format, "NCHW") == 0) {
+    out->nhwc = false;
+  } else {
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 (std::string("Metal: data_format '") + format +
+                  "' is not supported; use NHWC or NCHW.")
+                     .c_str());
+    return false;
+  }
+
+  char padding[16] = {0};
+  TF_OpKernelConstruction_GetAttrString(ctx, "padding", padding,
+                                        sizeof(padding) - 1, status);
+  if (TF_GetCode(status) != TF_OK) return false;
+  if (std::strcmp(padding, "SAME") == 0) {
+    out->same_padding = true;
+  } else if (std::strcmp(padding, "VALID") == 0) {
+    out->same_padding = false;
+  } else {
+    // EXPLICIT lands here. MPSGraph can express it, but the offsets have to be
+    // read from a separate attribute and mapped per data format; that is left
+    // until something needs it, rather than guessed at.
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 (std::string("Metal: padding '") + padding +
+                  "' is not supported; use SAME or VALID.")
+                     .c_str());
+    return false;
+  }
+
+  if (!ReadSpatialPair(ctx, "strides", out->nhwc, &out->stride_h,
+                       &out->stride_w, status)) {
+    return false;
+  }
+
+  if (want_dilations) {
+    int height = 1;
+    int width = 1;
+    if (!ReadSpatialPair(ctx, "dilations", out->nhwc, &height, &width,
+                         status)) {
+      // dilations is optional and defaults to all ones.
+      TF_SetStatus(status, TF_OK, "");
+      height = 1;
+      width = 1;
+    }
+    out->dilation_h = height;
+    out->dilation_w = width;
+  }
+
+  TF_OpKernelConstruction_GetAttrType(ctx, "T", &out->dtype, status);
+  if (TF_GetCode(status) != TF_OK) return false;
+  return true;
+}
+
+bool SliceForTensor(TF_Tensor* tensor, BufferSlice* slice, TF_Status* status) {
+  void* data = TF_TensorData(tensor);
+  if (data == nullptr) {
+    TF_SetStatus(status, TF_INVALID_ARGUMENT,
+                 "Metal: tensor has no backing data.");
+    return false;
+  }
+  id<MTLBuffer> buffer = nil;
+  size_t offset = 0;
+  if (!MetalBufferRegistry::Global().Lookup(data, &buffer, &offset)) {
+    // Reaching this means the tensor is in host memory. Either the kernel was
+    // registered with TF_KernelBuilder_HostMemory for this argument, or it ran
+    // on a device this backend does not own.
+    TF_SetStatus(status, TF_INVALID_ARGUMENT,
+                 "Metal: tensor is not backed by a Metal allocation; it is "
+                 "probably in host memory.");
+    return false;
+  }
+  slice->buffer = buffer;
+  slice->offset = offset;
+  slice->length = TF_TensorByteSize(tensor);
+  return true;
+}
+
+SP_Stream StreamForContext(TF_OpKernelContext* ctx, TF_Status* status) {
+  SP_Stream stream = TF_GetStream(ctx, status);
+  if (TF_GetCode(status) != TF_OK) return nullptr;
+  if (stream == nullptr) {
+    TF_SetStatus(status, TF_INTERNAL,
+                 "Metal: op kernel context provided no stream.");
+    return nullptr;
+  }
+  return stream;
+}
+
+id<MTLDevice> DeviceForStream(SP_Stream stream) { return stream->queue.device; }
+
+void Dispatch1D(id<MTLComputeCommandEncoder> encoder,
+                id<MTLComputePipelineState> pipeline, uint32_t count) {
+  const NSUInteger threads_per_group =
+      std::min<NSUInteger>(pipeline.maxTotalThreadsPerThreadgroup, count);
+  const NSUInteger groups = (count + threads_per_group - 1) / threads_per_group;
+  [encoder dispatchThreadgroups:MTLSizeMake(groups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+}
+
+int64_t NumElements(TF_Tensor* tensor) {
+  int64_t count = 1;
+  const int rank = TF_NumDims(tensor);
+  for (int i = 0; i < rank; ++i) count *= TF_Dim(tensor, i);
+  return count;
+}
+
+void WaitForStream(SP_Stream stream) {
+  uint64_t target = 0;
+  {
+    absl::MutexLock lock(&stream->mu);
+    target = stream->last_enqueued;
+  }
+  if (target > 0) {
+    [stream->order_event waitUntilSignaledValue:target timeoutMS:UINT64_MAX];
+  }
+}
+
+std::vector<int64_t> ShapeOf(TF_Tensor* tensor) {
+  const int rank = TF_NumDims(tensor);
+  std::vector<int64_t> shape;
+  shape.reserve(rank);
+  for (int i = 0; i < rank; ++i) shape.push_back(TF_Dim(tensor, i));
+  return shape;
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/kernels/metal_kernels.h
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_kernels.h
@@ -1,0 +1,41 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_KERNELS_H_
+#define TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_KERNELS_H_
+
+// Names no Objective-C types; includable from plain C++.
+
+namespace tensorflow {
+namespace metal {
+
+// Identity, Snapshot and the other pass-through forms.
+void RegisterMetalIdentityKernels();
+
+// The unary and binary arithmetic, with NumPy broadcasting.
+void RegisterMetalElementwiseKernels();
+
+// MatMul, through MPSMatrixMultiplication.
+void RegisterMetalMatMulKernels();
+
+// Every kernel this backend provides. Called by the plugin registrar through
+// the PluggableDevice kernel module, so that core orders kernel registration
+// against device registration rather than leaving it to link order.
+void RegisterAllMetalKernels();
+
+}  // namespace metal
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_KERNELS_H_

--- a/tensorflow/core/common_runtime/metal/kernels/metal_kernels.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_kernels.mm
@@ -1,0 +1,29 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernels.h"
+
+namespace tensorflow {
+namespace metal {
+
+
+void RegisterAllMetalKernels() {
+  RegisterMetalIdentityKernels();
+  RegisterMetalElementwiseKernels();
+  RegisterMetalMatMulKernels();
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/kernels/metal_matmul_op.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_matmul_op.mm
@@ -1,0 +1,259 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernels.h"
+
+#import <Metal/Metal.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/log/log.h"
+#include "tensorflow/c/kernels.h"
+#include "tensorflow/c/tf_datatype.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/c/tf_tensor.h"
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.h"
+#include "tensorflow/core/common_runtime/metal/metal_platform.h"
+#include "tensorflow/core/common_runtime/metal/metal_stream.h"
+
+namespace tensorflow {
+namespace metal {
+namespace {
+
+// MPSMatrixMultiplication rather than a hand-written tiled shader: MPS ships
+// kernels tuned per GPU generation, which no reasonable amount of shader work
+// would match.
+//
+// MPSMatrix rather than MPSGraph is now only a matter of directness. An
+// earlier version of this file justified the choice by claiming MPSGraph could
+// not address a tensor at an offset inside its allocation; that was wrong.
+// MPSNDArray's initWithBuffer:offset:descriptor: does exactly that, and
+// metal_mps_graph.h builds the whole MPSGraph path on it. A 2-D matrix
+// multiply maps onto MPSMatrix with less machinery, so it stays here, but
+// either would work.
+
+struct MatMulOp {
+  bool transpose_a = false;
+  bool transpose_b = false;
+  TF_DataType dtype = TF_FLOAT;
+};
+
+void* MatMulOp_Create(TF_OpKernelConstruction* ctx) {
+  TF_Status* status = TF_NewStatus();
+  auto* op = new MatMulOp();
+
+  TF_Bool transpose_a = 0;
+  TF_Bool transpose_b = 0;
+  TF_OpKernelConstruction_GetAttrBool(ctx, "transpose_a", &transpose_a, status);
+  if (TF_GetCode(status) == TF_OK) {
+    TF_OpKernelConstruction_GetAttrBool(ctx, "transpose_b", &transpose_b,
+                                        status);
+  }
+  if (TF_GetCode(status) == TF_OK) {
+    TF_OpKernelConstruction_GetAttrType(ctx, "T", &op->dtype, status);
+  }
+  if (TF_GetCode(status) != TF_OK) {
+    TF_OpKernelConstruction_Failure(ctx, status);
+    TF_DeleteStatus(status);
+    delete op;
+    return nullptr;
+  }
+
+  op->transpose_a = transpose_a != 0;
+  op->transpose_b = transpose_b != 0;
+  TF_DeleteStatus(status);
+  return op;
+}
+
+void MatMulOp_Delete(void* kernel) { delete static_cast<MatMulOp*>(kernel); }
+
+MPSDataType MPSTypeOf(TF_DataType dtype) {
+  return dtype == TF_HALF ? MPSDataTypeFloat16 : MPSDataTypeFloat32;
+}
+
+// Wraps a densely packed 2-D tensor slice as an MPSMatrix.
+//
+// rowBytes is the exact packed stride, not the padded stride
+// rowBytesFromColumns: recommends: TF tensors have no row padding, and a
+// padded stride would make MPS read the wrong elements.
+MPSMatrix* MatrixFor(const BufferSlice& slice, int64_t rows, int64_t columns,
+                     TF_DataType dtype, const char* what, TF_Status* status) {
+  const size_t element_size = TF_DataTypeSize(dtype);
+  const size_t row_bytes = static_cast<size_t>(columns) * element_size;
+
+  // MPS requires the row stride and the buffer offset to be 4-byte aligned.
+  // The offset always is, since core's allocator aligns well past that, but a
+  // float16 matrix with an odd column count has a 2 mod 4 stride. Repacking
+  // such a matrix is possible and belongs with the wider op coverage; until
+  // then, say so rather than let MPS trap.
+  if (row_bytes % 4 != 0) {
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 (std::string("Metal: MatMul on ") + what + " with " +
+                  std::to_string(columns) +
+                  " columns of this dtype gives a row stride that MPS cannot "
+                  "use; an even column count is required for float16.")
+                     .c_str());
+    return nil;
+  }
+  if (slice.offset % 4 != 0) {
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 (std::string("Metal: MatMul ") + what +
+                  " is at an unaligned offset within its allocation.")
+                     .c_str());
+    return nil;
+  }
+
+  MPSMatrixDescriptor* descriptor =
+      [MPSMatrixDescriptor matrixDescriptorWithRows:rows
+                                            columns:columns
+                                           rowBytes:row_bytes
+                                           dataType:MPSTypeOf(dtype)];
+  return [[[MPSMatrix alloc] initWithBuffer:slice.buffer
+                                     offset:slice.offset
+                                 descriptor:descriptor] autorelease];
+}
+
+void MatMulOp_ComputeImpl(MatMulOp* op, TF_OpKernelContext* ctx,
+                          TF_Status* status) {
+  if (op == nullptr) {
+    TF_SetStatus(status, TF_INTERNAL,
+                 "Metal: MatMul kernel has no state; construction failed.");
+    return;
+  }
+
+  ScopedTensor lhs;
+  ScopedTensor rhs;
+  TF_GetInput(ctx, 0, lhs.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+  TF_GetInput(ctx, 1, rhs.address(), status);
+  if (TF_GetCode(status) != TF_OK) return;
+
+  if (TF_NumDims(lhs.get()) != 2 || TF_NumDims(rhs.get()) != 2) {
+    TF_SetStatus(status, TF_INVALID_ARGUMENT,
+                 "Metal: MatMul expects two rank-2 tensors.");
+    return;
+  }
+
+  // Logical dimensions after the transpose attributes are applied. MPS is told
+  // about the transposes and reads the operands in their stored layout, so
+  // nothing is transposed in memory.
+  const int64_t m = op->transpose_a ? TF_Dim(lhs.get(), 1) : TF_Dim(lhs.get(), 0);
+  const int64_t k = op->transpose_a ? TF_Dim(lhs.get(), 0) : TF_Dim(lhs.get(), 1);
+  const int64_t k_rhs =
+      op->transpose_b ? TF_Dim(rhs.get(), 1) : TF_Dim(rhs.get(), 0);
+  const int64_t n = op->transpose_b ? TF_Dim(rhs.get(), 0) : TF_Dim(rhs.get(), 1);
+
+  if (k != k_rhs) {
+    TF_SetStatus(status, TF_INVALID_ARGUMENT,
+                 ("Metal: MatMul inner dimensions do not match: " +
+                  std::to_string(k) + " against " + std::to_string(k_rhs) + ".")
+                     .c_str());
+    return;
+  }
+
+  const int64_t out_dims[2] = {m, n};
+  ScopedTensor output;
+  output.reset(TF_AllocateOutput(
+      ctx, 0, op->dtype, out_dims, 2,
+      static_cast<size_t>(m) * n * TF_DataTypeSize(op->dtype), status));
+  if (TF_GetCode(status) != TF_OK) return;
+  if (m == 0 || n == 0) return;
+
+  SP_Stream stream = StreamForContext(ctx, status);
+  if (TF_GetCode(status) != TF_OK) return;
+
+  BufferSlice lhs_slice;
+  BufferSlice rhs_slice;
+  BufferSlice out_slice;
+  if (!SliceForTensor(lhs.get(), &lhs_slice, status)) return;
+  if (!SliceForTensor(rhs.get(), &rhs_slice, status)) return;
+  if (!SliceForTensor(output.get(), &out_slice, status)) return;
+
+  // Rows and columns as stored, which is the transpose of the logical shape
+  // when the corresponding transpose attribute is set.
+  MPSMatrix* left =
+      MatrixFor(lhs_slice, TF_Dim(lhs.get(), 0), TF_Dim(lhs.get(), 1),
+                op->dtype, "the left operand", status);
+  if (left == nil) return;
+  MPSMatrix* right =
+      MatrixFor(rhs_slice, TF_Dim(rhs.get(), 0), TF_Dim(rhs.get(), 1),
+                op->dtype, "the right operand", status);
+  if (right == nil) return;
+  MPSMatrix* result =
+      MatrixFor(out_slice, m, n, op->dtype, "the result", status);
+  if (result == nil) return;
+
+  OrderedCommandBuffer command_buffer(stream);
+  if (!command_buffer.ok()) {
+    TF_SetStatus(status, TF_RESOURCE_EXHAUSTED,
+                 "Metal: could not create a command buffer for MatMul.");
+    return;
+  }
+
+  MPSMatrixMultiplication* multiply = [[[MPSMatrixMultiplication alloc]
+       initWithDevice:DeviceForStream(stream)
+        transposeLeft:op->transpose_a
+       transposeRight:op->transpose_b
+           resultRows:m
+        resultColumns:n
+      interiorColumns:k
+                alpha:1.0
+                 beta:0.0] autorelease];
+
+  [multiply encodeToCommandBuffer:command_buffer.get()
+                       leftMatrix:left
+                      rightMatrix:right
+                     resultMatrix:result];
+  command_buffer.Commit();
+}
+
+void MatMulOp_Compute(void* kernel, TF_OpKernelContext* ctx) {
+  ScopedAutoreleasePool pool;
+  TF_Status* status = TF_NewStatus();
+  MatMulOp_ComputeImpl(static_cast<MatMulOp*>(kernel), ctx, status);
+  if (TF_GetCode(status) != TF_OK) TF_OpKernelContext_Failure(ctx, status);
+  TF_DeleteStatus(status);
+}
+
+void RegisterMatMul(TF_DataType dtype, const char* kernel_name) {
+  TF_Status* status = TF_NewStatus();
+  TF_KernelBuilder* builder =
+      TF_NewKernelBuilder("MatMul", kMetalDeviceType, &MatMulOp_Create,
+                          &MatMulOp_Compute, &MatMulOp_Delete);
+  TF_KernelBuilder_TypeConstraint(builder, "T", dtype, status);
+  if (TF_GetCode(status) == TF_OK) {
+    TF_RegisterKernelBuilder(kernel_name, builder, status);
+  } else {
+    TF_DeleteKernelBuilder(builder);
+  }
+  if (TF_GetCode(status) != TF_OK) {
+    LOG(ERROR) << "Metal: could not register kernel " << kernel_name << ": "
+               << TF_Message(status);
+  }
+  TF_DeleteStatus(status);
+}
+
+}  // namespace
+
+void RegisterMetalMatMulKernels() {
+  RegisterMatMul(TF_FLOAT, "MetalMatMulFloat");
+  RegisterMatMul(TF_HALF, "MetalMatMulHalf");
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/kernels/metal_matmul_op.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_matmul_op.mm
@@ -236,6 +236,11 @@ void RegisterMatMul(TF_DataType dtype, const char* kernel_name) {
       TF_NewKernelBuilder("MatMul", kMetalDeviceType, &MatMulOp_Create,
                           &MatMulOp_Compute, &MatMulOp_Delete);
   TF_KernelBuilder_TypeConstraint(builder, "T", dtype, status);
+  // The builder is deleted here and only here. TF_RegisterKernelBuilder hands
+  // it to an OpKernelRegistrar, which owns it from then on, and sets the
+  // status to OK unconditionally: with no serialized KernelDef there is
+  // nothing for it to fail on. So the only way to still hold the builder is
+  // for a type constraint to have failed before the call.
   if (TF_GetCode(status) == TF_OK) {
     TF_RegisterKernelBuilder(kernel_name, builder, status);
   } else {

--- a/tensorflow/core/common_runtime/metal/kernels/metal_mps_graph.h
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_mps_graph.h
@@ -1,0 +1,111 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_MPS_GRAPH_H_
+#define TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_MPS_GRAPH_H_
+
+// Objective-C++ only.
+
+#import <Metal/Metal.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#import <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "tensorflow/c/tf_datatype.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernel_util.h"
+#include "tensorflow/core/common_runtime/metal/metal_stream.h"
+
+namespace tensorflow {
+namespace metal {
+
+// Bridge from this backend's tensors to MPSGraph.
+//
+// MPSGraph is what makes convolutions, pooling, normalisation, reductions and
+// their gradients tractable: Apple ships kernels tuned per GPU generation for
+// all of them, and reimplementing that by hand would be both enormous and
+// slower.
+//
+// The reason it is usable at all is MPSNDArray's
+// initWithBuffer:offset:descriptor:, which aliases an existing MTLBuffer at a
+// byte offset. Core's BFC allocator places tensors at arbitrary offsets inside
+// a shared allocation, so an interface that assumed a tensor started at the
+// beginning of its buffer would force a copy of every operand. Going through
+// MPSNDArray keeps the whole path zero-copy, in both directions: results are
+// written straight into the output tensor's storage.
+
+// Maps a TF dtype to its MPSGraph equivalent. Fails `status` for dtypes this
+// backend does not handle.
+bool MPSTypeFor(TF_DataType dtype, MPSDataType* out, TF_Status* status);
+
+// Shape in the form MPSGraph expects. Autoreleased.
+NSArray<NSNumber*>* MPSShape(const std::vector<int64_t>& shape);
+
+// Zero-copy view of a tensor's storage as MPSGraph input or output data.
+// Autoreleased; nil on failure, with `status` set.
+MPSGraphTensorData* TensorDataFor(const BufferSlice& slice,
+                                  const std::vector<int64_t>& shape,
+                                  TF_DataType dtype, id<MTLDevice> device,
+                                  TF_Status* status);
+
+// Convenience: resolve a TF_Tensor and wrap it in one step.
+MPSGraphTensorData* TensorDataForTensor(TF_Tensor* tensor, TF_DataType dtype,
+                                        id<MTLDevice> device,
+                                        TF_Status* status);
+
+// A compiled graph plus the placeholders to feed and the tensors to read.
+//
+// Building an MPSGraph is expensive relative to running one, and a kernel runs
+// the same shape over and over across training steps, so graphs are cached by
+// a key the caller derives from everything that changes their structure
+// (shapes, dtype, strides, padding, and so on).
+struct CachedGraph {
+  MPSGraph* graph = nil;
+  // Placeholders, in the order the caller feeds them.
+  NSMutableArray<MPSGraphTensor*>* inputs = nil;
+  // Results, in the order the caller supplies output storage.
+  NSMutableArray<MPSGraphTensor*>* outputs = nil;
+};
+
+// Returns the cached graph for `key`, building it with `builder` on first use.
+// `builder` receives a fresh graph and must fill in `inputs` and `outputs`.
+// Returns nullptr with `status` set if the builder failed.
+//
+// The returned pointer is owned by the cache and lives for the process.
+const CachedGraph* LookupOrBuildGraph(const std::string& key,
+                                      void (^builder)(CachedGraph* out),
+                                      TF_Status* status);
+
+// Encodes `cached` onto `stream`, feeding `input_data` and writing results
+// directly into `output_data`.
+//
+// Handles the interaction between MPSGraph and this backend's stream ordering:
+// MPSGraph may call commitAndContinue and replace the underlying command
+// buffer, so the ordering signal is attached to whichever buffer is live at
+// the end rather than the one we started with.
+bool RunGraph(SP_Stream stream, const CachedGraph& cached,
+              NSArray<MPSGraphTensorData*>* input_data,
+              NSArray<MPSGraphTensorData*>* output_data, TF_Status* status);
+
+// Appends a shape to a cache key, for callers building keys by hand.
+void AppendShapeToKey(const std::vector<int64_t>& shape, std::string* key);
+
+}  // namespace metal
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_COMMON_RUNTIME_METAL_KERNELS_METAL_MPS_GRAPH_H_

--- a/tensorflow/core/common_runtime/metal/kernels/metal_mps_graph.mm
+++ b/tensorflow/core/common_runtime/metal/kernels/metal_mps_graph.mm
@@ -1,0 +1,301 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/kernels/metal_mps_graph.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
+#include "tensorflow/c/tf_tensor.h"
+
+namespace tensorflow {
+namespace metal {
+namespace {
+
+// Cache of built graphs, keyed by the caller's configuration string.
+//
+// Entries are never evicted. A kernel builds one graph per distinct shape and
+// configuration, and a training loop repeats the same handful of shapes for
+// its whole run, so the cache reaches a small fixed size and stays there. An
+// eviction policy would cost more than it saves.
+class GraphCache {
+ public:
+  static GraphCache& Global() {
+    static GraphCache* cache = new GraphCache();
+    return *cache;
+  }
+
+  const CachedGraph* LookupOrBuild(const std::string& key,
+                                   void (^builder)(CachedGraph* out),
+                                   TF_Status* status) {
+    {
+      absl::MutexLock lock(&mu_);
+      auto it = entries_.find(key);
+      if (it != entries_.end()) return it->second;
+    }
+
+    // Built outside the lock: graph construction is slow and calls into MPS,
+    // and two threads racing on the same key simply build twice, with one
+    // result discarded. That is cheaper than serialising every first use.
+    auto* built = new CachedGraph();
+    built->graph = [[MPSGraph alloc] init];
+    built->inputs = [[NSMutableArray alloc] init];
+    built->outputs = [[NSMutableArray alloc] init];
+    builder(built);
+
+    // Every result goes through an identity before it is published.
+    //
+    // MPSGraph can answer for a tensor that is a pure view of an input, a
+    // transpose or a reshape among them, without doing any work: the value is
+    // already in memory, just read differently. encodeToCommandBuffer is then
+    // asked to deliver that view into a caller-supplied MPSGraphTensorData and
+    // encodes nothing at all, so the output tensor keeps whatever it was
+    // allocated with, which is zeros. Transpose returned zeros for every
+    // permutation but the identity, and the identity was right for exactly the
+    // reason the others were wrong.
+    //
+    // An identity gives the result a producing operation, so there is
+    // something to encode into the destination. When the result already had
+    // one, this is folded away and costs nothing.
+    for (NSUInteger i = 0; i < [built->outputs count]; ++i) {
+      built->outputs[i] = [built->graph identityWithTensor:built->outputs[i]
+                                                      name:nil];
+    }
+
+    if (built->graph == nil || [built->inputs count] == 0 ||
+        [built->outputs count] == 0) {
+      TF_SetStatus(status, TF_INTERNAL,
+                   ("Metal: failed to build an MPSGraph for " + key).c_str());
+      [built->graph release];
+      [built->inputs release];
+      [built->outputs release];
+      delete built;
+      return nullptr;
+    }
+
+    absl::MutexLock lock(&mu_);
+    auto [it, inserted] = entries_.emplace(key, built);
+    if (!inserted) {
+      // Lost the race; keep the entry already published so every caller sees
+      // the same graph object.
+      [built->graph release];
+      [built->inputs release];
+      [built->outputs release];
+      delete built;
+    }
+    return it->second;
+  }
+
+ private:
+  GraphCache() = default;
+
+  absl::Mutex mu_;
+  absl::flat_hash_map<std::string, CachedGraph*> entries_ ABSL_GUARDED_BY(mu_);
+};
+
+}  // namespace
+
+bool MPSTypeFor(TF_DataType dtype, MPSDataType* out, TF_Status* status) {
+  switch (dtype) {
+    case TF_FLOAT:
+      *out = MPSDataTypeFloat32;
+      return true;
+    case TF_HALF:
+      *out = MPSDataTypeFloat16;
+      return true;
+    case TF_BFLOAT16:
+      *out = MPSDataTypeBFloat16;
+      return true;
+    case TF_INT32:
+      *out = MPSDataTypeInt32;
+      return true;
+    case TF_INT64:
+      *out = MPSDataTypeInt64;
+      return true;
+    case TF_BOOL:
+      *out = MPSDataTypeBool;
+      return true;
+    case TF_UINT8:
+      *out = MPSDataTypeUInt8;
+      return true;
+    case TF_INT8:
+      *out = MPSDataTypeInt8;
+      return true;
+    default:
+      TF_SetStatus(status, TF_UNIMPLEMENTED,
+                   ("Metal: dtype " + std::to_string(static_cast<int>(dtype)) +
+                    " is not supported by the MPSGraph path.")
+                       .c_str());
+      return false;
+  }
+}
+
+NSArray<NSNumber*>* MPSShape(const std::vector<int64_t>& shape) {
+  NSMutableArray<NSNumber*>* result =
+      [NSMutableArray arrayWithCapacity:shape.size()];
+  for (int64_t dim : shape) {
+    [result addObject:@(static_cast<NSInteger>(dim))];
+  }
+  return result;
+}
+
+MPSGraphTensorData* TensorDataFor(const BufferSlice& slice,
+                                  const std::vector<int64_t>& shape,
+                                  TF_DataType dtype, id<MTLDevice> device,
+                                  TF_Status* status) {
+  MPSDataType mps_dtype;
+  if (!MPSTypeFor(dtype, &mps_dtype, status)) return nil;
+
+  MPSNDArrayDescriptor* descriptor =
+      [MPSNDArrayDescriptor descriptorWithDataType:mps_dtype
+                                             shape:MPSShape(shape)];
+  if (descriptor == nil) {
+    TF_SetStatus(status, TF_INTERNAL,
+                 "Metal: could not describe a tensor for MPSGraph.");
+    return nil;
+  }
+
+  // By default MPSNDArray rounds the innermost dimension's row up to a
+  // multiple of 16 bytes and then rejects a tightly packed buffer as too
+  // small, with an assertion that takes the process down rather than an error
+  // that can be reported. TensorFlow tensors are always tightly packed, and
+  // three float32 channels is 12 bytes, so the very common RGB case would hit
+  // this on the first convolution. preferPackedRows tells MPS to use the tight
+  // stride, which is what keeps the alias valid and the path zero-copy.
+  const size_t element_size = TF_DataTypeSize(dtype);
+  const size_t innermost = shape.empty() ? 1 : static_cast<size_t>(shape.back());
+  const size_t row_bytes = innermost * element_size;
+  if ([descriptor respondsToSelector:@selector(setPreferPackedRows:)]) {
+    descriptor.preferPackedRows = YES;
+  } else if (row_bytes % 16 != 0) {
+    // preferPackedRows arrived in macOS 15. Older systems would assert inside
+    // MPS, so refuse here with something a user can act on.
+    TF_SetStatus(
+        status, TF_UNIMPLEMENTED,
+        ("Metal: a tensor whose innermost dimension is " +
+         std::to_string(innermost) + " elements (" + std::to_string(row_bytes) +
+         " bytes) cannot be aliased for MPSGraph on this macOS version; "
+         "packed MPSNDArray rows require macOS 15 or later.")
+            .c_str());
+    return nil;
+  }
+
+  // The alias that makes the whole path zero-copy: the array points into the
+  // existing allocation at the tensor's own offset, so neither inputs nor
+  // outputs are ever staged through a separate buffer.
+  MPSNDArray* array = [[[MPSNDArray alloc] initWithBuffer:slice.buffer
+                                                   offset:slice.offset
+                                               descriptor:descriptor]
+      autorelease];
+  if (array == nil) {
+    TF_SetStatus(status, TF_INTERNAL,
+                 "Metal: could not alias a tensor as an MPSNDArray.");
+    return nil;
+  }
+
+  MPSGraphTensorData* data =
+      [[[MPSGraphTensorData alloc] initWithMPSNDArray:array] autorelease];
+  if (data == nil) {
+    TF_SetStatus(status, TF_INTERNAL,
+                 "Metal: could not wrap an MPSNDArray for MPSGraph.");
+    return nil;
+  }
+  return data;
+}
+
+MPSGraphTensorData* TensorDataForTensor(TF_Tensor* tensor, TF_DataType dtype,
+                                        id<MTLDevice> device,
+                                        TF_Status* status) {
+  BufferSlice slice;
+  if (!SliceForTensor(tensor, &slice, status)) return nil;
+  return TensorDataFor(slice, ShapeOf(tensor), dtype, device, status);
+}
+
+const CachedGraph* LookupOrBuildGraph(const std::string& key,
+                                      void (^builder)(CachedGraph* out),
+                                      TF_Status* status) {
+  return GraphCache::Global().LookupOrBuild(key, builder, status);
+}
+
+bool RunGraph(SP_Stream stream, const CachedGraph& cached,
+              NSArray<MPSGraphTensorData*>* input_data,
+              NSArray<MPSGraphTensorData*>* output_data, TF_Status* status) {
+  if ([input_data count] != [cached.inputs count] ||
+      [output_data count] != [cached.outputs count]) {
+    TF_SetStatus(status, TF_INTERNAL,
+                 "Metal: MPSGraph feed or result count does not match the "
+                 "cached graph.");
+    return false;
+  }
+
+  MPSGraphTensorDataDictionary* feeds = [NSMutableDictionary dictionary];
+  for (NSUInteger i = 0; i < [cached.inputs count]; ++i) {
+    [(NSMutableDictionary*)feeds setObject:input_data[i]
+                                    forKey:cached.inputs[i]];
+  }
+  // Results are written straight into the output tensors' own storage, so no
+  // copy happens on the way out either.
+  MPSGraphTensorDataDictionary* results = [NSMutableDictionary dictionary];
+  for (NSUInteger i = 0; i < [cached.outputs count]; ++i) {
+    [(NSMutableDictionary*)results setObject:output_data[i]
+                                      forKey:cached.outputs[i]];
+  }
+
+  OrderedCommandBuffer command_buffer(stream);
+  if (!command_buffer.ok()) {
+    TF_SetStatus(status, TF_RESOURCE_EXHAUSTED,
+                 "Metal: could not create a command buffer for an MPSGraph "
+                 "operation.");
+    return false;
+  }
+
+  MPSCommandBuffer* mps_buffer =
+      [MPSCommandBuffer commandBufferWithCommandBuffer:command_buffer.get()];
+
+  // From here the command buffer belongs to MPS: encodeToCommandBuffer may
+  // call commitAndContinue, committing the buffer we started with and moving
+  // to a fresh one. So the ordering signal cannot go on the buffer we opened.
+  const OrderedCommandBuffer::ExternalCommit commit =
+      command_buffer.ReleaseForExternalCommit();
+
+  [cached.graph encodeToCommandBuffer:mps_buffer
+                                feeds:feeds
+                     targetOperations:nil
+                    resultsDictionary:results
+                  executionDescriptor:nil];
+
+  // rootCommandBuffer is whichever MTLCommandBuffer is live now, which is not
+  // necessarily the one handed to MPS above.
+  id<MTLCommandBuffer> live = mps_buffer.rootCommandBuffer;
+  [live encodeSignalEvent:commit.stream->order_event value:commit.signal_value];
+  [mps_buffer commit];
+  return true;
+}
+
+void AppendShapeToKey(const std::vector<int64_t>& shape, std::string* key) {
+  key->push_back('[');
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (i > 0) key->push_back(',');
+    key->append(std::to_string(shape[i]));
+  }
+  key->push_back(']');
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/metal_buffer_registry.h
+++ b/tensorflow/core/common_runtime/metal/metal_buffer_registry.h
@@ -1,0 +1,103 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_BUFFER_REGISTRY_H_
+#define TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_BUFFER_REGISTRY_H_
+
+// This header is Objective-C++ only: it names `id<MTLBuffer>` directly and can
+// only be included from a .mm translation unit.
+
+#import <Metal/Metal.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+
+namespace tensorflow {
+namespace metal {
+
+// Maps device addresses back to the MTLBuffer that backs them.
+//
+// TensorFlow hands plugins an opaque `void*` in SP_DeviceMemoryBase and then
+// treats it as a real address: the BFC allocator carves sub-allocations out of
+// a region by pointer arithmetic, and kernels receive interior pointers. A
+// plugin that returned an `id<MTLBuffer>` in that field would break the moment
+// core added an offset to it.
+//
+// Apple Silicon is a unified memory architecture, so we can satisfy both
+// contracts at once: allocate with MTLResourceStorageModeShared and hand core
+// the buffer's `contents` pointer, which is a genuine CPU-addressable address
+// in the same physical memory the GPU reads. Pointer arithmetic on it is valid.
+// This registry is what lets us go the other way, recovering the (buffer,
+// offset) pair a Metal encoder needs from an arbitrary interior pointer.
+//
+// A side effect worth naming: because the address is host-visible, host/device
+// transfers degenerate into memcpy. That removes the copy overhead that
+// dominates small-model performance on Mac, rather than merely amortizing it.
+//
+// All methods are thread-safe.
+class MetalBufferRegistry {
+ public:
+  static MetalBufferRegistry& Global();
+
+  // Takes ownership of one reference on `buffer` and returns the address core
+  // should see. Returns nullptr if `buffer` is nil or not host-visible.
+  void* Register(id<MTLBuffer> buffer);
+
+  // Resolves an arbitrary address inside a registered allocation. On success
+  // sets `*buffer` to the owning buffer (not retained, valid until the
+  // matching Unregister) and `*offset` to the byte offset of `address` within
+  // it. Returns false if `address` belongs to no live allocation.
+  bool Lookup(const void* address, id<MTLBuffer>* buffer,
+              size_t* offset) const;
+
+  // Releases the allocation whose base address is exactly `address`. Returns
+  // false if there is no such allocation. Interior pointers are rejected:
+  // core always deallocates with the base address it was given.
+  bool Unregister(void* address);
+
+  // Snapshot of the counters SP_StreamExecutor::get_allocator_stats reports.
+  struct Stats {
+    int64_t num_allocs = 0;
+    int64_t bytes_in_use = 0;
+    int64_t peak_bytes_in_use = 0;
+    int64_t largest_alloc_size = 0;
+  };
+  Stats GetStats() const;
+
+ private:
+  MetalBufferRegistry() = default;
+  MetalBufferRegistry(const MetalBufferRegistry&) = delete;
+  MetalBufferRegistry& operator=(const MetalBufferRegistry&) = delete;
+
+  struct Entry {
+    id<MTLBuffer> buffer;
+    size_t size;
+  };
+
+  mutable absl::Mutex mu_;
+  // Keyed by base address so that Lookup can binary-search for the allocation
+  // containing an interior pointer.
+  std::map<uintptr_t, Entry> allocations_ ABSL_GUARDED_BY(mu_);
+  Stats stats_ ABSL_GUARDED_BY(mu_);
+};
+
+}  // namespace metal
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_BUFFER_REGISTRY_H_

--- a/tensorflow/core/common_runtime/metal/metal_buffer_registry.mm
+++ b/tensorflow/core/common_runtime/metal/metal_buffer_registry.mm
@@ -1,0 +1,118 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/metal_buffer_registry.h"
+
+#include <cstddef>
+#include <cstdint>
+
+#include "absl/log/log.h"
+#include "absl/synchronization/mutex.h"
+
+namespace tensorflow {
+namespace metal {
+
+MetalBufferRegistry& MetalBufferRegistry::Global() {
+  static MetalBufferRegistry* registry = new MetalBufferRegistry();
+  return *registry;
+}
+
+void* MetalBufferRegistry::Register(id<MTLBuffer> buffer) {
+  if (buffer == nil) return nullptr;
+
+  // `contents` is null for MTLResourceStorageModePrivate buffers. Refusing
+  // them here keeps the invariant the whole backend relies on: every address
+  // core sees is host-addressable, so pointer arithmetic on it is meaningful.
+  void* address = [buffer contents];
+  if (address == nullptr) {
+    LOG(ERROR) << "Metal: refusing to register a buffer with no host-visible "
+                  "contents; the Metal backend requires "
+                  "MTLResourceStorageModeShared allocations.";
+    return nullptr;
+  }
+
+  const size_t size = [buffer length];
+  [buffer retain];
+
+  absl::MutexLock lock(&mu_);
+  auto [it, inserted] =
+      allocations_.emplace(reinterpret_cast<uintptr_t>(address),
+                           Entry{buffer, size});
+  if (!inserted) {
+    // Metal must not hand back an address that is still live; if it does, our
+    // model of the address space is wrong and silently overwriting the entry
+    // would leak the previous buffer and corrupt later lookups.
+    LOG(ERROR) << "Metal: duplicate registration for address " << address;
+    [buffer release];
+    return nullptr;
+  }
+
+  stats_.num_allocs++;
+  stats_.bytes_in_use += static_cast<int64_t>(size);
+  if (stats_.bytes_in_use > stats_.peak_bytes_in_use) {
+    stats_.peak_bytes_in_use = stats_.bytes_in_use;
+  }
+  if (static_cast<int64_t>(size) > stats_.largest_alloc_size) {
+    stats_.largest_alloc_size = static_cast<int64_t>(size);
+  }
+  return address;
+}
+
+bool MetalBufferRegistry::Lookup(const void* address, id<MTLBuffer>* buffer,
+                                 size_t* offset) const {
+  if (address == nullptr) return false;
+  const uintptr_t key = reinterpret_cast<uintptr_t>(address);
+
+  absl::MutexLock lock(&mu_);
+  // Greatest base address <= key, then a range check. This is what makes
+  // interior pointers, the ones the BFC allocator and kernels actually pass
+  // around, resolvable back to a buffer.
+  auto it = allocations_.upper_bound(key);
+  if (it == allocations_.begin()) return false;
+  --it;
+
+  const uintptr_t base = it->first;
+  if (key - base >= it->second.size) return false;
+
+  if (buffer != nullptr) *buffer = it->second.buffer;
+  if (offset != nullptr) *offset = static_cast<size_t>(key - base);
+  return true;
+}
+
+bool MetalBufferRegistry::Unregister(void* address) {
+  if (address == nullptr) return false;
+
+  id<MTLBuffer> buffer = nil;
+  {
+    absl::MutexLock lock(&mu_);
+    auto it = allocations_.find(reinterpret_cast<uintptr_t>(address));
+    if (it == allocations_.end()) return false;
+    buffer = it->second.buffer;
+    stats_.bytes_in_use -= static_cast<int64_t>(it->second.size);
+    allocations_.erase(it);
+  }
+  // Released outside the lock: -release can run arbitrary teardown and we do
+  // not want it holding up concurrent allocations.
+  [buffer release];
+  return true;
+}
+
+MetalBufferRegistry::Stats MetalBufferRegistry::GetStats() const {
+  absl::MutexLock lock(&mu_);
+  return stats_;
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/metal_buffer_registry_test.mm
+++ b/tensorflow/core/common_runtime/metal/metal_buffer_registry_test.mm
@@ -1,0 +1,173 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/metal_buffer_registry.h"
+
+#import <Metal/Metal.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+namespace tensorflow {
+namespace metal {
+namespace {
+
+id<MTLDevice> DefaultDeviceOrNil() { return MTLCreateSystemDefaultDevice(); }
+
+id<MTLBuffer> NewSharedBuffer(id<MTLDevice> device, size_t size) {
+  return [device newBufferWithLength:size
+                             options:MTLResourceStorageModeShared];
+}
+
+class MetalBufferRegistryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    device_ = DefaultDeviceOrNil();
+    if (device_ == nil) {
+      GTEST_SKIP() << "No Metal device available on this machine.";
+    }
+  }
+  id<MTLDevice> device_ = nil;
+};
+
+TEST_F(MetalBufferRegistryTest, RegisterReturnsHostVisibleContents) {
+  id<MTLBuffer> buffer = NewSharedBuffer(device_, 1024);
+  ASSERT_NE(buffer, nil);
+
+  void* address = MetalBufferRegistry::Global().Register(buffer);
+  ASSERT_NE(address, nullptr);
+  // The address core sees must be the buffer's own contents pointer, which is
+  // what makes it safe for core to do pointer arithmetic on it.
+  EXPECT_EQ(address, [buffer contents]);
+
+  EXPECT_TRUE(MetalBufferRegistry::Global().Unregister(address));
+  [buffer release];
+}
+
+TEST_F(MetalBufferRegistryTest, LookupResolvesBaseAddress) {
+  id<MTLBuffer> buffer = NewSharedBuffer(device_, 4096);
+  void* address = MetalBufferRegistry::Global().Register(buffer);
+  ASSERT_NE(address, nullptr);
+
+  id<MTLBuffer> found = nil;
+  size_t offset = 12345;
+  ASSERT_TRUE(MetalBufferRegistry::Global().Lookup(address, &found, &offset));
+  EXPECT_EQ(found, buffer);
+  EXPECT_EQ(offset, 0u);
+
+  MetalBufferRegistry::Global().Unregister(address);
+  [buffer release];
+}
+
+TEST_F(MetalBufferRegistryTest, LookupResolvesInteriorPointer) {
+  constexpr size_t kSize = 4096;
+  constexpr size_t kOffset = 1728;
+  id<MTLBuffer> buffer = NewSharedBuffer(device_, kSize);
+  void* address = MetalBufferRegistry::Global().Register(buffer);
+  ASSERT_NE(address, nullptr);
+
+  // This is the case the registry exists for: the BFC allocator sub-divides
+  // an allocation and kernels see pointers into the middle of it.
+  void* interior = static_cast<char*>(address) + kOffset;
+  id<MTLBuffer> found = nil;
+  size_t offset = 0;
+  ASSERT_TRUE(MetalBufferRegistry::Global().Lookup(interior, &found, &offset));
+  EXPECT_EQ(found, buffer);
+  EXPECT_EQ(offset, kOffset);
+
+  MetalBufferRegistry::Global().Unregister(address);
+  [buffer release];
+}
+
+TEST_F(MetalBufferRegistryTest, LookupRejectsOnePastTheEnd) {
+  constexpr size_t kSize = 2048;
+  id<MTLBuffer> buffer = NewSharedBuffer(device_, kSize);
+  void* address = MetalBufferRegistry::Global().Register(buffer);
+  ASSERT_NE(address, nullptr);
+
+  void* past_end = static_cast<char*>(address) + kSize;
+  EXPECT_FALSE(MetalBufferRegistry::Global().Lookup(past_end, nullptr,
+                                                    nullptr));
+
+  MetalBufferRegistry::Global().Unregister(address);
+  [buffer release];
+}
+
+TEST_F(MetalBufferRegistryTest, LookupFailsAfterUnregister) {
+  id<MTLBuffer> buffer = NewSharedBuffer(device_, 512);
+  void* address = MetalBufferRegistry::Global().Register(buffer);
+  ASSERT_NE(address, nullptr);
+  ASSERT_TRUE(MetalBufferRegistry::Global().Unregister(address));
+
+  EXPECT_FALSE(MetalBufferRegistry::Global().Lookup(address, nullptr, nullptr));
+  // Unregistering twice must not double-release the buffer.
+  EXPECT_FALSE(MetalBufferRegistry::Global().Unregister(address));
+  [buffer release];
+}
+
+TEST_F(MetalBufferRegistryTest, UnregisterRejectsInteriorPointer) {
+  id<MTLBuffer> buffer = NewSharedBuffer(device_, 1024);
+  void* address = MetalBufferRegistry::Global().Register(buffer);
+  ASSERT_NE(address, nullptr);
+
+  void* interior = static_cast<char*>(address) + 8;
+  EXPECT_FALSE(MetalBufferRegistry::Global().Unregister(interior));
+  EXPECT_TRUE(MetalBufferRegistry::Global().Unregister(address));
+  [buffer release];
+}
+
+TEST_F(MetalBufferRegistryTest, StatsTrackBytesInUse) {
+  constexpr size_t kSize = 8192;
+  const auto before = MetalBufferRegistry::Global().GetStats();
+
+  id<MTLBuffer> buffer = NewSharedBuffer(device_, kSize);
+  void* address = MetalBufferRegistry::Global().Register(buffer);
+  ASSERT_NE(address, nullptr);
+
+  const auto during = MetalBufferRegistry::Global().GetStats();
+  EXPECT_EQ(during.num_allocs, before.num_allocs + 1);
+  EXPECT_EQ(during.bytes_in_use,
+            before.bytes_in_use + static_cast<int64_t>(kSize));
+  EXPECT_GE(during.peak_bytes_in_use, during.bytes_in_use);
+  EXPECT_GE(during.largest_alloc_size, static_cast<int64_t>(kSize));
+
+  MetalBufferRegistry::Global().Unregister(address);
+  const auto after = MetalBufferRegistry::Global().GetStats();
+  EXPECT_EQ(after.bytes_in_use, before.bytes_in_use);
+  // Peak is a high-water mark and must not fall back on deallocation.
+  EXPECT_EQ(after.peak_bytes_in_use, during.peak_bytes_in_use);
+  [buffer release];
+}
+
+TEST_F(MetalBufferRegistryTest, RegisterRejectsNil) {
+  EXPECT_EQ(MetalBufferRegistry::Global().Register(nil), nullptr);
+}
+
+TEST_F(MetalBufferRegistryTest, RegisterRejectsPrivateStorage) {
+  // Private buffers have no host-visible contents, so registering one would
+  // hand core an address it cannot legally offset.
+  id<MTLBuffer> buffer =
+      [device_ newBufferWithLength:256
+                           options:MTLResourceStorageModePrivate];
+  ASSERT_NE(buffer, nil);
+  EXPECT_EQ(MetalBufferRegistry::Global().Register(buffer), nullptr);
+  [buffer release];
+}
+
+}  // namespace
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/metal_platform.h
+++ b/tensorflow/core/common_runtime/metal/metal_platform.h
@@ -1,0 +1,51 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_PLATFORM_H_
+#define TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_PLATFORM_H_
+
+// Names no Objective-C types; includable from plain C++.
+
+#include "tensorflow/c/experimental/stream_executor/stream_executor.h"
+#include "tensorflow/c/tf_status.h"
+
+namespace tensorflow {
+namespace metal {
+
+// Device type reported to TensorFlow.
+//
+// "GPU" rather than a new type such as "METAL", so that Metal devices show up
+// as /device:GPU:0 and existing user code, Keras, tf.distribute and the
+// placement rules all work unmodified. There is no clash with the CUDA GPU
+// device: CUDA is never built on macOS.
+inline constexpr char kMetalDeviceType[] = "GPU";
+
+// Platform (subtype) name, which is what distinguishes this backend from any
+// other registered under the GPU device type.
+inline constexpr char kMetalPlatformName[] = "METAL";
+
+// StreamExecutor C API plugin entry point.
+//
+// Has the shape of SE_InitPlugin but is not exported under that name: this
+// backend is linked into TensorFlow rather than dlopen'd, so it is registered
+// by passing this function pointer to RegisterPluggableDevicePlugin. Keeping
+// the symbol namespaced also avoids colliding with an out-of-tree plugin's
+// SE_InitPlugin in the same process.
+void MetalInitPlugin(SE_PlatformRegistrationParams* params, TF_Status* status);
+
+}  // namespace metal
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_PLATFORM_H_

--- a/tensorflow/core/common_runtime/metal/metal_platform.mm
+++ b/tensorflow/core/common_runtime/metal/metal_platform.mm
@@ -1,0 +1,205 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/metal_platform.h"
+
+#import <Metal/Metal.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/log/log.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/core/common_runtime/metal/metal_stream.h"
+#include "tensorflow/core/common_runtime/metal/metal_stream_executor.h"
+
+namespace tensorflow {
+namespace metal {
+namespace {
+
+// One usable Metal device, discovered once at startup.
+struct DeviceEntry {
+  id<MTLDevice> device;  // Retained for the lifetime of the process.
+  std::string name;      // Stable storage for SP_Device::hardware_name.
+};
+
+// Metal devices this backend is willing to drive.
+//
+// Only devices reporting hasUnifiedMemory are accepted, and that is a
+// correctness gate rather than a preference. The backend hands core the
+// `contents` pointer of MTLResourceStorageModeShared buffers and treats host
+// and device views of that memory as coherent. On a unified memory device
+// (every Apple silicon Mac) they are. On a discrete GPU they are not: shared
+// buffers are host-side staging that needs explicit didModifyRange: and
+// synchronizeResource: calls, so the zero-copy transfers would silently read
+// stale data. Refusing such devices is the honest outcome.
+const std::vector<DeviceEntry>& UsableDevices() {
+  static const std::vector<DeviceEntry>* devices = [] {
+    ScopedAutoreleasePool pool;
+    auto* result = new std::vector<DeviceEntry>();
+    NSArray<id<MTLDevice>>* all = MTLCopyAllDevices();
+    for (id<MTLDevice> device in all) {
+      const char* name = device.name.UTF8String;
+      if (!device.hasUnifiedMemory) {
+        LOG(INFO) << "Metal: skipping device '" << (name ? name : "?")
+                  << "': the Metal backend requires unified memory.";
+        continue;
+      }
+      result->push_back(
+          DeviceEntry{[device retain], name != nullptr ? name : "Metal GPU"});
+    }
+    [all release];
+    return result;
+  }();
+  return *devices;
+}
+
+void Ok(TF_Status* status) { TF_SetStatus(status, TF_OK, ""); }
+
+/*** DEVICE ***/
+
+void GetDeviceCount(const SP_Platform* platform, int* device_count,
+                    TF_Status* status) {
+  *device_count = static_cast<int>(UsableDevices().size());
+  Ok(status);
+}
+
+void CreateDevice(const SP_Platform* platform, SE_CreateDeviceParams* params,
+                  TF_Status* status) {
+  const std::vector<DeviceEntry>& devices = UsableDevices();
+  const int ordinal = params->ordinal;
+  if (ordinal < 0 || ordinal >= static_cast<int>(devices.size())) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE,
+                 "Metal: requested device ordinal is out of range.");
+    return;
+  }
+  const DeviceEntry& entry = devices[ordinal];
+
+  params->device->struct_size = SP_DEVICE_STRUCT_SIZE;
+  params->device->ordinal = ordinal;
+  params->device->device_handle = static_cast<void*>(entry.device);
+  // Points into the process-lifetime DeviceEntry, satisfying the C API's
+  // requirement that these strings outlive the call.
+  params->device->hardware_name = entry.name.c_str();
+  params->device->device_vendor = "Apple";
+  // Optional, and meaningless for an integrated GPU with no PCI address.
+  params->device->pci_bus_id = nullptr;
+  params->device->ext = new MetalDeviceState(entry.device);
+  Ok(status);
+}
+
+void DestroyDevice(const SP_Platform* platform, SP_Device* device) {
+  delete StateOf(device);
+  device->ext = nullptr;
+  device->device_handle = nullptr;
+}
+
+int32_t GetNumaNode(const SP_Device* device) {
+  // Apple silicon presents a single memory domain, so there is no NUMA node
+  // to report and core should treat locality as unset.
+  return -1;
+}
+
+int64_t GetMemoryBandwidth(const SP_Device* device) {
+  // Metal exposes no bandwidth figure, and it differs by an order of magnitude
+  // across the M-series range. Reporting a made-up number would skew the cost
+  // model, so leave it unset.
+  return -1;
+}
+
+double GetGflops(const SP_Device* device) { return -1.0; }
+
+void CreateDeviceFns(const SP_Platform* platform,
+                     SE_CreateDeviceFnsParams* params, TF_Status* status) {
+  params->device_fns->struct_size = SP_DEVICE_FNS_STRUCT_SIZE;
+  params->device_fns->ext = nullptr;
+  params->device_fns->get_numa_node = GetNumaNode;
+  params->device_fns->get_memory_bandwidth = GetMemoryBandwidth;
+  params->device_fns->get_gflops = GetGflops;
+  Ok(status);
+}
+
+void DestroyDeviceFns(const SP_Platform* platform, SP_DeviceFns* device_fns) {}
+
+/*** STREAM EXECUTOR ***/
+
+void CreateStreamExecutor(const SP_Platform* platform,
+                          SE_CreateStreamExecutorParams* params,
+                          TF_Status* status) {
+  PopulateStreamExecutor(params->stream_executor);
+  Ok(status);
+}
+
+void DestroyStreamExecutor(const SP_Platform* platform,
+                           SP_StreamExecutor* stream_executor) {}
+
+/*** TIMER ***/
+
+void CreateTimerFns(const SP_Platform* platform, SP_TimerFns* timer_fns,
+                    TF_Status* status) {
+  PopulateTimerFns(timer_fns);
+  Ok(status);
+}
+
+void DestroyTimerFns(const SP_Platform* platform, SP_TimerFns* timer_fns) {}
+
+/*** PLATFORM ***/
+
+void DestroyPlatform(SP_Platform* platform) {}
+
+void DestroyPlatformFns(SP_PlatformFns* platform_fns) {}
+
+}  // namespace
+
+void MetalInitPlugin(SE_PlatformRegistrationParams* params, TF_Status* status) {
+  params->platform->struct_size = SP_PLATFORM_STRUCT_SIZE;
+  params->platform->ext = nullptr;
+  // Both are string literals with static storage duration, as the C API
+  // requires them to outlive this call.
+  params->platform->name = kMetalPlatformName;
+  params->platform->type = kMetalDeviceType;
+  // True on every device we accept, by construction: UsableDevices() filters
+  // out anything without unified memory.
+  params->platform->supports_unified_memory = true;
+  // Let core put its BFC allocator in front of us. Metal's own allocator is
+  // not cheap enough to call per tensor, and BFC also gives the backend the
+  // sub-allocation behaviour the buffer registry was designed to support.
+  params->platform->use_bfc_allocator = true;
+  // On a unified memory system, device memory is the machine's RAM. Reserving
+  // a large fraction of it up front, as the CUDA default does, would starve
+  // everything else running on the Mac.
+  params->platform->force_memory_growth = true;
+
+  params->platform_fns->struct_size = SP_PLATFORM_FNS_STRUCT_SIZE;
+  params->platform_fns->ext = nullptr;
+  params->platform_fns->get_device_count = GetDeviceCount;
+  params->platform_fns->create_device = CreateDevice;
+  params->platform_fns->destroy_device = DestroyDevice;
+  params->platform_fns->create_device_fns = CreateDeviceFns;
+  params->platform_fns->destroy_device_fns = DestroyDeviceFns;
+  params->platform_fns->create_stream_executor = CreateStreamExecutor;
+  params->platform_fns->destroy_stream_executor = DestroyStreamExecutor;
+  params->platform_fns->create_timer_fns = CreateTimerFns;
+  params->platform_fns->destroy_timer_fns = DestroyTimerFns;
+
+  params->destroy_platform = DestroyPlatform;
+  params->destroy_platform_fns = DestroyPlatformFns;
+
+  TF_SetStatus(status, TF_OK, "");
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/metal_plugin_registrar.cc
+++ b/tensorflow/core/common_runtime/metal/metal_plugin_registrar.cc
@@ -1,0 +1,88 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdlib>
+#include <cstring>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "tensorflow/core/common_runtime/metal/kernels/metal_kernels.h"
+#include "tensorflow/core/common_runtime/metal/metal_platform.h"
+#include "tensorflow/core/common_runtime/pluggable_device/pluggable_device_plugin_init.h"
+
+namespace tensorflow {
+namespace metal {
+namespace {
+
+// Set TF_DISABLE_METAL=1 to keep the backend out of the process entirely.
+//
+// Worth having for a device backend that is new in this release: it lets a
+// user fall back to CPU without reinstalling, and lets a bug report separate
+// "Metal is involved" from "Metal is the cause" in one run.
+bool MetalDisabledByEnvironment() {
+  const char* value = std::getenv("TF_DISABLE_METAL");
+  if (value == nullptr) return false;
+  return std::strcmp(value, "0") != 0 && value[0] != '\0';
+}
+
+absl::Status RegisterMetalPlugin() {
+  if (MetalDisabledByEnvironment()) {
+    LOG(INFO) << "Metal: backend disabled by TF_DISABLE_METAL.";
+    return absl::OkStatus();
+  }
+
+  // The in-process form of plugin registration. The dlopen path resolves
+  // SE_InitPlugin and friends out of a shared object; here the backend is
+  // linked in, so the same struct is filled with a direct function pointer and
+  // core does the identical work: register a PluggableDeviceFactory for the
+  // device type and wire up device-to-device tensor copies.
+  //
+  // Device and kernel modules. The graph optimizer and profiler modules are
+  // not implemented yet, which core treats as absent rather than as an error.
+  //
+  // Kernels go through the api struct rather than through static initialisers
+  // of their own so that core orders kernel registration against device
+  // registration, instead of that order falling out of link order.
+  PluggableDeviceInit_Api api;
+  api.init_plugin_fn = MetalInitPlugin;
+  api.init_kernel_fn = RegisterAllMetalKernels;
+  return RegisterPluggableDevicePlugin(&api);
+}
+
+// Registered from a static initializer, the same mechanism
+// REGISTER_LOCAL_DEVICE_FACTORY uses for the built-in CPU and CUDA devices,
+// so the Metal device exists as soon as the framework is loaded rather than
+// only after some later explicit call. MetalInitPlugin itself only fills
+// function tables; no Metal API is touched until core asks for the device
+// count, so this does not pull the Metal framework into process startup.
+//
+// The target is alwayslink so the linker keeps this translation unit even
+// though nothing references it.
+const bool kMetalPluginRegistered = [] {
+  const absl::Status status = RegisterMetalPlugin();
+  if (!status.ok()) {
+    // Deliberately not fatal. A machine with no usable Metal device, or a
+    // registration clash with another GPU plugin, should degrade to CPU rather
+    // than make `import tensorflow` fail.
+    LOG(ERROR) << "Metal: could not register the Metal PluggableDevice: "
+               << status.message() << ". Falling back to CPU.";
+    return false;
+  }
+  return true;
+}();
+
+}  // namespace
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/metal_stream.h
+++ b/tensorflow/core/common_runtime/metal/metal_stream.h
@@ -1,0 +1,209 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_STREAM_H_
+#define TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_STREAM_H_
+
+// This header is Objective-C++ only and can only be included from a .mm
+// translation unit.
+
+#import <Metal/Metal.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "tensorflow/c/experimental/stream_executor/stream_executor.h"
+
+// StreamExecutor's stream is a strictly ordered queue of work: everything
+// enqueued on a stream runs after everything enqueued before it. Metal does
+// not give that for free. An MTLCommandQueue guarantees command buffers are
+// *scheduled* in commit order, but their execution may overlap, so committing
+// each operation as its own command buffer would let two supposedly ordered
+// kernels run concurrently.
+//
+// We restore the contract with a per-stream MTLSharedEvent used as a sequence
+// counter: command buffer N waits for the event to reach N-1 and signals N on
+// completion. That serialises the stream without serialising the device, so
+// independent streams still overlap.
+struct SP_Stream_st {
+  SP_Stream_st(id<MTLCommandQueue> command_queue, id<MTLSharedEvent> event);
+  ~SP_Stream_st();
+
+  SP_Stream_st(const SP_Stream_st&) = delete;
+  SP_Stream_st& operator=(const SP_Stream_st&) = delete;
+
+  id<MTLCommandQueue> queue;
+  id<MTLSharedEvent> order_event;
+
+  mutable absl::Mutex mu;
+  // Sequence number of the last command buffer handed out for this stream.
+  uint64_t last_enqueued ABSL_GUARDED_BY(mu) = 0;
+  // Sticky: set by a command buffer that failed, reported by
+  // SP_StreamExecutor::get_stream_status until the stream is destroyed.
+  bool failed ABSL_GUARDED_BY(mu) = false;
+  std::string failure_message ABSL_GUARDED_BY(mu);
+};
+
+// An event is a point in a stream's sequence. Recording it captures the
+// sequence number the stream had reached; waiting on it blocks until the
+// stream's event counter passes that number.
+struct SP_Event_st {
+  explicit SP_Event_st(id<MTLSharedEvent> event);
+  ~SP_Event_st();
+
+  SP_Event_st(const SP_Event_st&) = delete;
+  SP_Event_st& operator=(const SP_Event_st&) = delete;
+
+  // Owned by this event, distinct from any stream's ordering event so that
+  // recording the same event on two streams is well defined.
+  id<MTLSharedEvent> event;
+
+  mutable absl::Mutex mu;
+  // 0 means "never recorded", which core treats as already complete.
+  uint64_t target ABSL_GUARDED_BY(mu) = 0;
+};
+
+// Metal reports GPU timings on the command buffer, not on a timer object, so
+// a timer is just the pair of timestamps harvested from the empty command
+// buffers that start_timer and stop_timer enqueue.
+struct SP_Timer_st {
+  mutable absl::Mutex mu;
+  double start_seconds ABSL_GUARDED_BY(mu) = 0.0;
+  double end_seconds ABSL_GUARDED_BY(mu) = 0.0;
+  bool started ABSL_GUARDED_BY(mu) = false;
+  bool stopped ABSL_GUARDED_BY(mu) = false;
+};
+
+namespace tensorflow {
+namespace metal {
+
+// Per-device state hanging off SP_Device::ext.
+//
+// SP_StreamExecutor's synchronous memcpy and synchronize_all_activity
+// callbacks take a device but no stream, so the device has to know which
+// streams are live in order to drain them.
+struct MetalDeviceState {
+  explicit MetalDeviceState(id<MTLDevice> mtl_device);
+  ~MetalDeviceState();
+
+  MetalDeviceState(const MetalDeviceState&) = delete;
+  MetalDeviceState& operator=(const MetalDeviceState&) = delete;
+
+  void AddStream(SP_Stream stream);
+  void RemoveStream(SP_Stream stream);
+  // Blocks until every live stream has drained.
+  void BlockUntilIdle();
+
+  id<MTLDevice> device;
+
+  mutable absl::Mutex mu;
+  std::vector<SP_Stream> streams ABSL_GUARDED_BY(mu);
+};
+
+// Recovers the state attached to an SP_Device. Never null for a device the
+// platform created.
+MetalDeviceState* StateOf(const SP_Device* device);
+
+// Drains autoreleased Objective-C objects at scope exit.
+//
+// TensorFlow executor threads are plain pthreads with no top-level autorelease
+// pool. Metal hands back autoreleased objects from routine calls
+// (-commandBuffer, -blitCommandEncoder, -computeCommandEncoder, and everything
+// MPS returns), so without a pool of our own those objects leak on every op.
+// Every entry point into this backend that touches Metal declares one of
+// these as its first statement.
+class ScopedAutoreleasePool {
+ public:
+  ScopedAutoreleasePool();
+  ~ScopedAutoreleasePool();
+
+  ScopedAutoreleasePool(const ScopedAutoreleasePool&) = delete;
+  ScopedAutoreleasePool& operator=(const ScopedAutoreleasePool&) = delete;
+
+ private:
+  void* pool_;
+};
+
+// A command buffer that participates in its stream's ordering.
+//
+// Construction reserves the next sequence number and encodes the wait for the
+// previous one; Commit() encodes the matching signal. Callers encode their own
+// work in between. Destroying one without committing cancels the reservation,
+// so a failed encode does not wedge the stream forever.
+class OrderedCommandBuffer {
+ public:
+  explicit OrderedCommandBuffer(SP_Stream stream);
+  ~OrderedCommandBuffer();
+
+  OrderedCommandBuffer(const OrderedCommandBuffer&) = delete;
+  OrderedCommandBuffer& operator=(const OrderedCommandBuffer&) = delete;
+
+  // Nil if the command queue could not produce a buffer.
+  id<MTLCommandBuffer> get() const { return buffer_; }
+  bool ok() const { return buffer_ != nil; }
+
+  // Sequence number this buffer signals once complete.
+  uint64_t signal_value() const { return signal_value_; }
+
+  // Encodes the ordering signal and commits. Further work must not be encoded
+  // afterwards.
+  void Commit();
+  // Commit() followed by waiting for the GPU to finish this buffer.
+  void CommitAndWait();
+
+  // Hands responsibility for committing to the caller.
+  //
+  // Needed by the MPSGraph path. MPSGraph may call commitAndContinue, which
+  // commits the buffer we started with and carries on with a fresh one, so the
+  // ordering signal has to be encoded on whichever buffer is live at the end
+  // rather than the one this object was constructed with. The caller must
+  // encode a signal of `signal_value` on the stream's order_event and commit,
+  // exactly once, or the stream stalls forever.
+  struct ExternalCommit {
+    SP_Stream stream;
+    uint64_t signal_value;
+  };
+  ExternalCommit ReleaseForExternalCommit();
+
+  // Commits without encoding the GPU-side ordering signal. Instead, once the
+  // GPU work finishes, `on_complete` runs on a Metal callback thread and the
+  // sequence is signalled from the host afterwards.
+  //
+  // This is what lets host-side copies take part in stream order. On a unified
+  // memory architecture the fastest host/device copy is a plain memcpy, but a
+  // memcpy issued from an ordinary completion handler would race the next
+  // command buffer: the GPU signal would already have released it. Signalling
+  // from the host after the copy closes that window.
+  //
+  // The sequence is signalled even if the command buffer failed, since leaving
+  // it unsignalled would wedge every later buffer on the stream.
+  void CommitWithHostCompletion(void (^on_complete)());
+
+ private:
+  void EncodeSignal();
+
+  SP_Stream stream_;
+  id<MTLCommandBuffer> buffer_ = nil;
+  uint64_t signal_value_ = 0;
+  bool committed_ = false;
+};
+
+}  // namespace metal
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_STREAM_H_

--- a/tensorflow/core/common_runtime/metal/metal_stream.mm
+++ b/tensorflow/core/common_runtime/metal/metal_stream.mm
@@ -1,0 +1,201 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/metal_stream.h"
+
+#import <Foundation/Foundation.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "absl/log/log.h"
+#include "absl/synchronization/mutex.h"
+
+SP_Stream_st::SP_Stream_st(id<MTLCommandQueue> command_queue,
+                           id<MTLSharedEvent> event)
+    : queue([command_queue retain]), order_event([event retain]) {}
+
+SP_Stream_st::~SP_Stream_st() {
+  [queue release];
+  [order_event release];
+}
+
+SP_Event_st::SP_Event_st(id<MTLSharedEvent> e) : event([e retain]) {}
+
+SP_Event_st::~SP_Event_st() { [event release]; }
+
+namespace tensorflow {
+namespace metal {
+
+namespace {
+
+// Records the first command buffer failure on the stream, if any.
+void NoteFailure(SP_Stream stream, id<MTLCommandBuffer> completed) {
+  if (completed.error == nil) return;
+  absl::MutexLock lock(&stream->mu);
+  if (stream->failed) return;  // Keep the first failure, it is the useful one.
+  stream->failed = true;
+  const char* message = completed.error.localizedDescription.UTF8String;
+  stream->failure_message =
+      message != nullptr ? message : "unknown Metal command buffer error";
+}
+
+}  // namespace
+
+MetalDeviceState::MetalDeviceState(id<MTLDevice> mtl_device)
+    : device([mtl_device retain]) {}
+
+MetalDeviceState::~MetalDeviceState() { [device release]; }
+
+void MetalDeviceState::AddStream(SP_Stream stream) {
+  absl::MutexLock lock(&mu);
+  streams.push_back(stream);
+}
+
+void MetalDeviceState::RemoveStream(SP_Stream stream) {
+  absl::MutexLock lock(&mu);
+  streams.erase(std::remove(streams.begin(), streams.end(), stream),
+                streams.end());
+}
+
+void MetalDeviceState::BlockUntilIdle() {
+  // Snapshot under the lock, then wait outside it: waiting can take
+  // arbitrarily long and must not block stream creation or teardown.
+  std::vector<SP_Stream> snapshot;
+  {
+    absl::MutexLock lock(&mu);
+    snapshot = streams;
+  }
+  for (SP_Stream stream : snapshot) {
+    uint64_t target = 0;
+    {
+      absl::MutexLock lock(&stream->mu);
+      target = stream->last_enqueued;
+    }
+    if (target == 0) continue;  // Nothing was ever enqueued on this stream.
+    [stream->order_event waitUntilSignaledValue:target timeoutMS:UINT64_MAX];
+  }
+}
+
+MetalDeviceState* StateOf(const SP_Device* device) {
+  return static_cast<MetalDeviceState*>(device->ext);
+}
+
+ScopedAutoreleasePool::ScopedAutoreleasePool()
+    : pool_([[NSAutoreleasePool alloc] init]) {}
+
+ScopedAutoreleasePool::~ScopedAutoreleasePool() {
+  [static_cast<NSAutoreleasePool*>(pool_) drain];
+}
+
+OrderedCommandBuffer::OrderedCommandBuffer(SP_Stream stream)
+    : stream_(stream) {
+  uint64_t wait_value = 0;
+  {
+    absl::MutexLock lock(&stream_->mu);
+    wait_value = stream_->last_enqueued;
+    signal_value_ = wait_value + 1;
+    stream_->last_enqueued = signal_value_;
+  }
+
+  buffer_ = [[stream_->queue commandBuffer] retain];
+  if (buffer_ == nil) {
+    // Give the sequence number back so the stream is not permanently stuck
+    // waiting for a value that will never be signalled.
+    absl::MutexLock lock(&stream_->mu);
+    if (stream_->last_enqueued == signal_value_) {
+      stream_->last_enqueued = wait_value;
+    }
+    LOG(ERROR) << "Metal: MTLCommandQueue returned no command buffer.";
+    return;
+  }
+
+  // Value 0 is the event's initial state, so a wait on it is trivially
+  // satisfied; skipping it avoids an encode on the very first buffer.
+  if (wait_value > 0) {
+    [buffer_ encodeWaitForEvent:stream_->order_event value:wait_value];
+  }
+}
+
+OrderedCommandBuffer::~OrderedCommandBuffer() {
+  if (buffer_ == nil) return;
+  if (!committed_) {
+    // Nothing was committed, so the GPU will never signal our value. Commit an
+    // otherwise empty buffer purely to advance the sequence, rather than
+    // leaving every later buffer on this stream blocked forever.
+    LOG(WARNING) << "Metal: command buffer dropped without commit; committing "
+                    "an empty buffer to keep the stream ordered.";
+    Commit();
+  }
+  [buffer_ release];
+}
+
+void OrderedCommandBuffer::EncodeSignal() {
+  [buffer_ encodeSignalEvent:stream_->order_event value:signal_value_];
+}
+
+void OrderedCommandBuffer::Commit() {
+  if (buffer_ == nil || committed_) return;
+  committed_ = true;
+  EncodeSignal();
+
+  // Captured by value; the block outlives this object.
+  SP_Stream stream = stream_;
+  [buffer_ addCompletedHandler:^(id<MTLCommandBuffer> completed) {
+    NoteFailure(stream, completed);
+  }];
+
+  [buffer_ commit];
+}
+
+OrderedCommandBuffer::ExternalCommit
+OrderedCommandBuffer::ReleaseForExternalCommit() {
+  // Marked committed so the destructor neither commits nor warns; the caller
+  // owns the signal from here.
+  committed_ = true;
+  return ExternalCommit{stream_, signal_value_};
+}
+
+void OrderedCommandBuffer::CommitWithHostCompletion(void (^on_complete)()) {
+  if (buffer_ == nil || committed_) return;
+  committed_ = true;
+
+  SP_Stream stream = stream_;
+  const uint64_t signal_value = signal_value_;
+  // The block outlives this scope, so it has to be moved off the stack.
+  void (^work)() = [on_complete copy];
+
+  [buffer_ addCompletedHandler:^(id<MTLCommandBuffer> completed) {
+    NoteFailure(stream, completed);
+    if (completed.error == nil && work != nil) work();
+    // Signalled last, and unconditionally: the next command buffer on this
+    // stream is waiting on this value and must not start before the host work
+    // above has finished, nor stall forever if that work was skipped.
+    stream->order_event.signaledValue = signal_value;
+    [work release];
+  }];
+
+  [buffer_ commit];
+}
+
+void OrderedCommandBuffer::CommitAndWait() {
+  if (buffer_ == nil) return;
+  Commit();
+  [buffer_ waitUntilCompleted];
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/core/common_runtime/metal/metal_stream_executor.h
+++ b/tensorflow/core/common_runtime/metal/metal_stream_executor.h
@@ -1,0 +1,40 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_STREAM_EXECUTOR_H_
+#define TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_STREAM_EXECUTOR_H_
+
+// Unlike the other headers in this directory, this one names no Objective-C
+// types and can be included from plain C++.
+
+#include "tensorflow/c/experimental/stream_executor/stream_executor.h"
+
+namespace tensorflow {
+namespace metal {
+
+// Fills `se` with the Metal implementations of the StreamExecutor C API
+// memory, stream, event, timer and transfer callbacks. Every function pointer
+// in the struct is set; none is left optional.
+void PopulateStreamExecutor(SP_StreamExecutor* se);
+
+// Fills `timer_fns` with the Metal timer accessor. Split out because the
+// platform owns the SP_TimerFns lifetime while the stream executor owns the
+// SP_Timer objects themselves.
+void PopulateTimerFns(SP_TimerFns* timer_fns);
+
+}  // namespace metal
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_COMMON_RUNTIME_METAL_METAL_STREAM_EXECUTOR_H_

--- a/tensorflow/core/common_runtime/metal/metal_stream_executor.mm
+++ b/tensorflow/core/common_runtime/metal/metal_stream_executor.mm
@@ -1,0 +1,693 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/metal/metal_stream_executor.h"
+
+#import <Metal/Metal.h>
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include "absl/log/log.h"
+#include "absl/synchronization/mutex.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/core/common_runtime/metal/metal_buffer_registry.h"
+#include "tensorflow/core/common_runtime/metal/metal_stream.h"
+
+namespace tensorflow {
+namespace metal {
+namespace {
+
+id<MTLDevice> MTLDeviceOf(const SP_Device* device) {
+  return static_cast<id<MTLDevice>>(device->device_handle);
+}
+
+void Ok(TF_Status* status) { TF_SetStatus(status, TF_OK, ""); }
+
+void Fail(TF_Status* status, TF_Code code, const std::string& message) {
+  TF_SetStatus(status, code, message.c_str());
+}
+
+// Resolves a device address to the buffer that backs it, failing `status` with
+// a diagnosable message rather than crashing if the address is not one we
+// handed out.
+bool ResolveOrFail(const void* address, const char* what, id<MTLBuffer>* buffer,
+                   size_t* offset, TF_Status* status) {
+  if (MetalBufferRegistry::Global().Lookup(address, buffer, offset)) return true;
+  Fail(status, TF_INVALID_ARGUMENT,
+       std::string("Metal: ") + what +
+           " does not belong to any live Metal allocation.");
+  return false;
+}
+
+// Reports a stream that a previous command buffer left in a failed state. Once
+// a stream has failed, every later operation on it is unreliable, so callbacks
+// surface the original error instead of appearing to succeed.
+bool StreamAlreadyFailed(SP_Stream stream, TF_Status* status) {
+  absl::MutexLock lock(&stream->mu);
+  if (!stream->failed) return false;
+  TF_SetStatus(status, TF_INTERNAL,
+               ("Metal: stream previously failed: " + stream->failure_message)
+                   .c_str());
+  return true;
+}
+
+/*** ALLOCATION ***/
+
+void Allocate(const SP_Device* device, uint64_t size, int64_t memory_space,
+              SP_DeviceMemoryBase* mem) {
+  mem->struct_size = SP_DEVICE_MEMORY_BASE_STRUCT_SIZE;
+  mem->ext = nullptr;
+  mem->opaque = nullptr;
+  mem->size = 0;
+  mem->payload = 0;
+
+  // Metal returns nil for a zero-length buffer, but core does request
+  // zero-byte allocations. Rounding up to one byte keeps a successful
+  // zero-byte allocation distinguishable from an out-of-memory failure, which
+  // core detects by a null opaque.
+  const uint64_t bytes = std::max<uint64_t>(size, 1);
+
+  // Shared storage, never private: the whole backend depends on device
+  // addresses being host-addressable. See MetalBufferRegistry.
+  id<MTLBuffer> buffer =
+      [MTLDeviceOf(device) newBufferWithLength:bytes
+                                       options:MTLResourceStorageModeShared];
+  if (buffer == nil) return;
+
+  void* address = MetalBufferRegistry::Global().Register(buffer);
+  // The registry took its own reference; drop the one newBuffer gave us.
+  [buffer release];
+  if (address == nullptr) return;
+
+  mem->opaque = address;
+  mem->size = size;
+}
+
+void Deallocate(const SP_Device* device, SP_DeviceMemoryBase* mem) {
+  if (mem == nullptr || mem->opaque == nullptr) return;
+  MetalBufferRegistry::Global().Unregister(mem->opaque);
+  mem->opaque = nullptr;
+  mem->size = 0;
+}
+
+void* HostMemoryAllocate(const SP_Device* device, uint64_t size) {
+  if (size == 0) return nullptr;
+  // Page aligned so the result can be wrapped with newBufferWithBytesNoCopy:
+  // without an intermediate staging copy, should a future kernel need it.
+  const size_t alignment = static_cast<size_t>(getpagesize());
+  const size_t rounded = ((size + alignment - 1) / alignment) * alignment;
+  void* ptr = nullptr;
+  if (posix_memalign(&ptr, alignment, rounded) != 0) return nullptr;
+  return ptr;
+}
+
+void HostMemoryDeallocate(const SP_Device* device, void* mem) { free(mem); }
+
+void* UnifiedMemoryAllocate(const SP_Device* device, uint64_t bytes) {
+  SP_DeviceMemoryBase mem{SP_DEVICE_MEMORY_BASE_STRUCT_SIZE};
+  Allocate(device, bytes, /*memory_space=*/0, &mem);
+  return mem.opaque;
+}
+
+void UnifiedMemoryDeallocate(const SP_Device* device, void* location) {
+  MetalBufferRegistry::Global().Unregister(location);
+}
+
+TF_Bool GetAllocatorStats(const SP_Device* device, SP_AllocatorStats* stats) {
+  const MetalBufferRegistry::Stats snapshot =
+      MetalBufferRegistry::Global().GetStats();
+  stats->struct_size = SP_ALLOCATORSTATS_STRUCT_SIZE;
+  stats->num_allocs = snapshot.num_allocs;
+  stats->bytes_in_use = snapshot.bytes_in_use;
+  stats->peak_bytes_in_use = snapshot.peak_bytes_in_use;
+  stats->largest_alloc_size = snapshot.largest_alloc_size;
+  // Metal imposes no fixed per-process budget, so there is no limit to report.
+  stats->has_bytes_limit = 0;
+  stats->bytes_limit = 0;
+  stats->bytes_reserved = 0;
+  stats->peak_bytes_reserved = 0;
+  stats->has_bytes_reservable_limit = 0;
+  stats->bytes_reservable_limit = 0;
+  stats->largest_free_block_bytes = 0;
+  return true;
+}
+
+TF_Bool DeviceMemoryUsage(const SP_Device* device, int64_t* free,
+                          int64_t* total) {
+  id<MTLDevice> mtl = MTLDeviceOf(device);
+  // recommendedMaxWorkingSetSize is the budget Metal will let this process use
+  // before it starts paging, which is the closest analogue to "total device
+  // memory" on a unified memory system, where physical RAM is shared with the
+  // rest of the machine.
+  const int64_t budget = static_cast<int64_t>([mtl recommendedMaxWorkingSetSize]);
+  const int64_t used = static_cast<int64_t>([mtl currentAllocatedSize]);
+  *total = budget;
+  *free = std::max<int64_t>(budget - used, 0);
+  return true;
+}
+
+/*** STREAMS ***/
+
+void CreateStream(const SP_Device* device, SP_Stream* stream,
+                  TF_Status* status) {
+  id<MTLDevice> mtl = MTLDeviceOf(device);
+  id<MTLCommandQueue> queue = [mtl newCommandQueue];
+  if (queue == nil) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create an MTLCommandQueue.");
+    return;
+  }
+  id<MTLSharedEvent> event = [mtl newSharedEvent];
+  if (event == nil) {
+    [queue release];
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create an MTLSharedEvent for stream ordering.");
+    return;
+  }
+
+  *stream = new SP_Stream_st(queue, event);
+  // SP_Stream_st retained both; drop the references the new* calls gave us.
+  [queue release];
+  [event release];
+
+  StateOf(device)->AddStream(*stream);
+  Ok(status);
+}
+
+void DestroyStream(const SP_Device* device, SP_Stream stream) {
+  if (stream == nullptr) return;
+  // Outstanding command buffers hold references to the queue and the event,
+  // but their completion handlers touch the stream itself, so it must outlive
+  // them. Drain before freeing.
+  uint64_t target = 0;
+  {
+    absl::MutexLock lock(&stream->mu);
+    target = stream->last_enqueued;
+  }
+  if (target > 0) {
+    [stream->order_event waitUntilSignaledValue:target timeoutMS:UINT64_MAX];
+  }
+  StateOf(device)->RemoveStream(stream);
+  delete stream;
+}
+
+void CreateStreamDependency(const SP_Device* device, SP_Stream dependent,
+                            SP_Stream other, TF_Status* status) {
+  ScopedAutoreleasePool pool;
+  if (StreamAlreadyFailed(other, status)) return;
+
+  uint64_t other_value = 0;
+  {
+    absl::MutexLock lock(&other->mu);
+    other_value = other->last_enqueued;
+  }
+  // Nothing has ever been enqueued on `other`, so there is nothing to wait for.
+  if (other_value == 0) {
+    Ok(status);
+    return;
+  }
+
+  OrderedCommandBuffer buffer(dependent);
+  if (!buffer.ok()) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create a command buffer for the stream dependency.");
+    return;
+  }
+  [buffer.get() encodeWaitForEvent:other->order_event value:other_value];
+  buffer.Commit();
+  Ok(status);
+}
+
+void GetStreamStatus(const SP_Device* device, SP_Stream stream,
+                     TF_Status* status) {
+  if (StreamAlreadyFailed(stream, status)) return;
+  Ok(status);
+}
+
+// SP_StreamOptions and the callback that takes it were added to the
+// StreamExecutor C API after the last TensorFlow release. An in-tree build
+// always has them. A build against an installed TensorFlow may not, which is
+// what TF_METAL_NO_STREAM_OPTIONS says; the plugin then simply offers one
+// fewer callback, and core falls back to create_stream.
+#if !defined(TF_METAL_NO_STREAM_OPTIONS)
+void CreateStreamWithOptions(const SP_Device* device,
+                             const SP_StreamOptions* options, SP_Stream* stream,
+                             TF_Status* status) {
+  // Metal command queues have no priority control, so the priority hint in
+  // `options` has nothing to map onto and is deliberately ignored.
+  CreateStream(device, stream, status);
+}
+#endif  // TF_METAL_NO_STREAM_OPTIONS
+
+/*** EVENTS ***/
+
+void CreateEvent(const SP_Device* device, SP_Event* event, TF_Status* status) {
+  id<MTLSharedEvent> shared_event = [MTLDeviceOf(device) newSharedEvent];
+  if (shared_event == nil) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create an MTLSharedEvent.");
+    return;
+  }
+  *event = new SP_Event_st(shared_event);
+  [shared_event release];
+  Ok(status);
+}
+
+void DestroyEvent(const SP_Device* device, SP_Event event) { delete event; }
+
+SE_EventStatus GetEventStatus(const SP_Device* device, SP_Event event) {
+  uint64_t target = 0;
+  {
+    absl::MutexLock lock(&event->mu);
+    target = event->target;
+  }
+  // Never recorded: core treats an unrecorded event as already complete.
+  if (target == 0) return SE_EVENT_COMPLETE;
+  return event->event.signaledValue >= target ? SE_EVENT_COMPLETE
+                                              : SE_EVENT_PENDING;
+}
+
+void RecordEvent(const SP_Device* device, SP_Stream stream, SP_Event event,
+                 TF_Status* status) {
+  ScopedAutoreleasePool pool;
+  if (StreamAlreadyFailed(stream, status)) return;
+
+  uint64_t value = 0;
+  {
+    absl::MutexLock lock(&event->mu);
+    value = ++event->target;
+  }
+
+  OrderedCommandBuffer buffer(stream);
+  if (!buffer.ok()) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create a command buffer to record the event.");
+    return;
+  }
+  [buffer.get() encodeSignalEvent:event->event value:value];
+  buffer.Commit();
+  Ok(status);
+}
+
+void WaitForEvent(const SP_Device* const device, SP_Stream stream,
+                  SP_Event event, TF_Status* const status) {
+  ScopedAutoreleasePool pool;
+  if (StreamAlreadyFailed(stream, status)) return;
+
+  uint64_t target = 0;
+  {
+    absl::MutexLock lock(&event->mu);
+    target = event->target;
+  }
+  if (target == 0) {
+    Ok(status);
+    return;
+  }
+
+  OrderedCommandBuffer buffer(stream);
+  if (!buffer.ok()) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create a command buffer to wait on the event.");
+    return;
+  }
+  [buffer.get() encodeWaitForEvent:event->event value:target];
+  buffer.Commit();
+  Ok(status);
+}
+
+void BlockHostForEvent(const SP_Device* device, SP_Event event,
+                       TF_Status* status) {
+  uint64_t target = 0;
+  {
+    absl::MutexLock lock(&event->mu);
+    target = event->target;
+  }
+  if (target == 0) {
+    Ok(status);
+    return;
+  }
+  if (![event->event waitUntilSignaledValue:target timeoutMS:UINT64_MAX]) {
+    Fail(status, TF_INTERNAL, "Metal: timed out waiting for an event.");
+    return;
+  }
+  Ok(status);
+}
+
+/*** TIMERS ***/
+
+void CreateTimer(const SP_Device* device, SP_Timer* timer, TF_Status* status) {
+  *timer = new SP_Timer_st();
+  Ok(status);
+}
+
+void DestroyTimer(const SP_Device* device, SP_Timer timer) { delete timer; }
+
+void StartTimer(const SP_Device* device, SP_Stream stream, SP_Timer timer,
+                TF_Status* status) {
+  ScopedAutoreleasePool pool;
+  OrderedCommandBuffer buffer(stream);
+  if (!buffer.ok()) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create a command buffer to start the timer.");
+    return;
+  }
+  // Metal reports timings on the command buffer, so an otherwise empty buffer
+  // is what marks the point in the stream. GPUEndTime of this empty buffer is
+  // the moment the GPU reached this point.
+  [buffer.get() addCompletedHandler:^(id<MTLCommandBuffer> completed) {
+    absl::MutexLock lock(&timer->mu);
+    timer->start_seconds = completed.GPUEndTime;
+    timer->started = true;
+  }];
+  buffer.Commit();
+  Ok(status);
+}
+
+void StopTimer(const SP_Device* device, SP_Stream stream, SP_Timer timer,
+               TF_Status* status) {
+  ScopedAutoreleasePool pool;
+  OrderedCommandBuffer buffer(stream);
+  if (!buffer.ok()) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create a command buffer to stop the timer.");
+    return;
+  }
+  [buffer.get() addCompletedHandler:^(id<MTLCommandBuffer> completed) {
+    absl::MutexLock lock(&timer->mu);
+    timer->end_seconds = completed.GPUEndTime;
+    timer->stopped = true;
+  }];
+  // Waited on, so that `nanoseconds` has both timestamps by the time core
+  // reads them. The start handler is ordered before this one and has therefore
+  // also run.
+  buffer.CommitAndWait();
+  Ok(status);
+}
+
+uint64_t TimerNanoseconds(SP_Timer timer) {
+  absl::MutexLock lock(&timer->mu);
+  if (!timer->started || !timer->stopped) return 0;
+  const double elapsed = timer->end_seconds - timer->start_seconds;
+  if (elapsed <= 0.0) return 0;
+  return static_cast<uint64_t>(elapsed * 1e9);
+}
+
+/*** TRANSFERS ***/
+
+// Every device address is host-addressable (see MetalBufferRegistry), so a
+// transfer is a memcpy. What it still needs is stream ordering: the copy must
+// not overtake GPU work already enqueued, and later work must not overtake the
+// copy. CommitWithHostCompletion provides exactly that, without the staging
+// buffer and second copy a blit-based implementation would require.
+void EnqueueHostCopy(SP_Stream stream, void* dst, const void* src,
+                     uint64_t size, const char* what, TF_Status* status) {
+  ScopedAutoreleasePool pool;
+  if (size == 0) {
+    Ok(status);
+    return;
+  }
+  if (dst == nullptr || src == nullptr) {
+    Fail(status, TF_INVALID_ARGUMENT,
+         std::string("Metal: null address passed to ") + what + ".");
+    return;
+  }
+  if (StreamAlreadyFailed(stream, status)) return;
+
+  OrderedCommandBuffer buffer(stream);
+  if (!buffer.ok()) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         std::string("Metal: could not create a command buffer for ") + what +
+             ".");
+    return;
+  }
+  buffer.CommitWithHostCompletion(^{
+    std::memcpy(dst, src, size);
+  });
+  Ok(status);
+}
+
+void MemcpyDToH(const SP_Device* device, SP_Stream stream, void* host_dst,
+                const SP_DeviceMemoryBase* device_src, uint64_t size,
+                TF_Status* status) {
+  EnqueueHostCopy(stream, host_dst, device_src->opaque, size,
+                  "a device-to-host copy", status);
+}
+
+void MemcpyHToD(const SP_Device* device, SP_Stream stream,
+                SP_DeviceMemoryBase* device_dst, const void* host_src,
+                uint64_t size, TF_Status* status) {
+  EnqueueHostCopy(stream, device_dst->opaque, host_src, size,
+                  "a host-to-device copy", status);
+}
+
+void MemcpyDToD(const SP_Device* device, SP_Stream stream,
+                SP_DeviceMemoryBase* device_dst,
+                const SP_DeviceMemoryBase* device_src, uint64_t size,
+                TF_Status* status) {
+  EnqueueHostCopy(stream, device_dst->opaque, device_src->opaque, size,
+                  "a device-to-device copy", status);
+}
+
+// The synchronous variants take no stream, so they drain the whole device
+// before copying. Draining first is what makes the plain memcpy safe.
+void SyncCopy(const SP_Device* device, void* dst, const void* src,
+              uint64_t size, TF_Status* status) {
+  if (size == 0) {
+    Ok(status);
+    return;
+  }
+  if (dst == nullptr || src == nullptr) {
+    Fail(status, TF_INVALID_ARGUMENT,
+         "Metal: null address passed to a synchronous copy.");
+    return;
+  }
+  StateOf(device)->BlockUntilIdle();
+  std::memcpy(dst, src, size);
+  Ok(status);
+}
+
+void SyncMemcpyDToH(const SP_Device* device, void* host_dst,
+                    const SP_DeviceMemoryBase* device_src, uint64_t size,
+                    TF_Status* status) {
+  SyncCopy(device, host_dst, device_src->opaque, size, status);
+}
+
+void SyncMemcpyHToD(const SP_Device* device, SP_DeviceMemoryBase* device_dst,
+                    const void* host_src, uint64_t size, TF_Status* status) {
+  SyncCopy(device, device_dst->opaque, host_src, size, status);
+}
+
+void SyncMemcpyDToD(const SP_Device* device, SP_DeviceMemoryBase* device_dst,
+                    const SP_DeviceMemoryBase* device_src, uint64_t size,
+                    TF_Status* status) {
+  SyncCopy(device, device_dst->opaque, device_src->opaque, size, status);
+}
+
+/*** SYNCHRONISATION ***/
+
+void BlockHostUntilDone(const SP_Device* device, SP_Stream stream,
+                        TF_Status* status) {
+  uint64_t target = 0;
+  {
+    absl::MutexLock lock(&stream->mu);
+    target = stream->last_enqueued;
+  }
+  if (target > 0 && ![stream->order_event waitUntilSignaledValue:target
+                                                       timeoutMS:UINT64_MAX]) {
+    Fail(status, TF_INTERNAL, "Metal: timed out draining a stream.");
+    return;
+  }
+  if (StreamAlreadyFailed(stream, status)) return;
+  Ok(status);
+}
+
+void SynchronizeAllActivity(const SP_Device* device, TF_Status* status) {
+  StateOf(device)->BlockUntilIdle();
+  Ok(status);
+}
+
+/*** FILLS ***/
+
+// Byte fills go through the blit encoder: it is the one operation Metal does
+// natively over a whole buffer range, and it keeps large fills off the CPU.
+void EncodeFill(SP_Stream stream, SP_DeviceMemoryBase* location, uint8_t value,
+                uint64_t size, const char* what, TF_Status* status) {
+  ScopedAutoreleasePool pool;
+  if (size == 0) {
+    Ok(status);
+    return;
+  }
+  if (StreamAlreadyFailed(stream, status)) return;
+
+  id<MTLBuffer> buffer = nil;
+  size_t offset = 0;
+  if (!ResolveOrFail(location->opaque, what, &buffer, &offset, status)) return;
+
+  // Metal traps on a range that runs past the end of the buffer, so reject it
+  // here with a message that names the sizes involved.
+  if (offset + size > [buffer length]) {
+    Fail(status, TF_INVALID_ARGUMENT,
+         std::string("Metal: ") + what + " of " + std::to_string(size) +
+             " bytes at offset " + std::to_string(offset) +
+             " runs past the end of a " + std::to_string([buffer length]) +
+             " byte allocation.");
+    return;
+  }
+
+  OrderedCommandBuffer command_buffer(stream);
+  if (!command_buffer.ok()) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         std::string("Metal: could not create a command buffer for ") + what +
+             ".");
+    return;
+  }
+  id<MTLBlitCommandEncoder> encoder = [command_buffer.get() blitCommandEncoder];
+  [encoder fillBuffer:buffer range:NSMakeRange(offset, size) value:value];
+  [encoder endEncoding];
+  command_buffer.Commit();
+  Ok(status);
+}
+
+void MemZero(const SP_Device* device, SP_Stream stream,
+             SP_DeviceMemoryBase* location, uint64_t size, TF_Status* status) {
+  EncodeFill(stream, location, 0, size, "a device memory zero fill", status);
+}
+
+void Memset(const SP_Device* device, SP_Stream stream,
+            SP_DeviceMemoryBase* location, uint8_t pattern, uint64_t size,
+            TF_Status* status) {
+  EncodeFill(stream, location, pattern, size, "a device memory fill", status);
+}
+
+void Memset32(const SP_Device* device, SP_Stream stream,
+              SP_DeviceMemoryBase* location, uint32_t pattern, uint64_t size,
+              TF_Status* status) {
+  ScopedAutoreleasePool pool;
+  if (size == 0) {
+    Ok(status);
+    return;
+  }
+  if (size % sizeof(uint32_t) != 0) {
+    Fail(status, TF_INVALID_ARGUMENT,
+         "Metal: memset32 size must be a multiple of 4 bytes.");
+    return;
+  }
+  // A blit fill writes one byte value, so a repeating 32-bit pattern that is
+  // not four equal bytes has to be written word by word. Doing it on the host
+  // is correct on a unified memory system; a compute shader would be faster
+  // for large buffers and is left for the kernel work.
+  const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&pattern);
+  if (bytes[0] == bytes[1] && bytes[1] == bytes[2] && bytes[2] == bytes[3]) {
+    EncodeFill(stream, location, bytes[0], size, "a device memory 32-bit fill",
+               status);
+    return;
+  }
+
+  if (StreamAlreadyFailed(stream, status)) return;
+  OrderedCommandBuffer buffer(stream);
+  if (!buffer.ok()) {
+    Fail(status, TF_RESOURCE_EXHAUSTED,
+         "Metal: could not create a command buffer for a 32-bit fill.");
+    return;
+  }
+  void* destination = location->opaque;
+  const uint64_t words = size / sizeof(uint32_t);
+  buffer.CommitWithHostCompletion(^{
+    uint32_t* out = static_cast<uint32_t*>(destination);
+    for (uint64_t i = 0; i < words; ++i) out[i] = pattern;
+  });
+  Ok(status);
+}
+
+/*** HOST CALLBACKS ***/
+
+TF_Bool HostCallback(const SP_Device* device, SP_Stream stream,
+                     SE_StatusCallbackFn callback_fn, void* callback_arg) {
+  ScopedAutoreleasePool pool;
+  OrderedCommandBuffer buffer(stream);
+  if (!buffer.ok()) return false;
+  buffer.CommitWithHostCompletion(^{
+    TF_Status* status = TF_NewStatus();
+    callback_fn(callback_arg, status);
+    TF_DeleteStatus(status);
+  });
+  return true;
+}
+
+}  // namespace
+
+void PopulateStreamExecutor(SP_StreamExecutor* se) {
+  se->struct_size = SP_STREAMEXECUTOR_STRUCT_SIZE;
+  se->ext = nullptr;
+
+  se->allocate = Allocate;
+  se->deallocate = Deallocate;
+  se->host_memory_allocate = HostMemoryAllocate;
+  se->host_memory_deallocate = HostMemoryDeallocate;
+  se->unified_memory_allocate = UnifiedMemoryAllocate;
+  se->unified_memory_deallocate = UnifiedMemoryDeallocate;
+  se->get_allocator_stats = GetAllocatorStats;
+  se->device_memory_usage = DeviceMemoryUsage;
+
+  se->create_stream = CreateStream;
+  se->destroy_stream = DestroyStream;
+  se->create_stream_dependency = CreateStreamDependency;
+  se->get_stream_status = GetStreamStatus;
+#if !defined(TF_METAL_NO_STREAM_OPTIONS)
+  se->create_stream_with_options = CreateStreamWithOptions;
+#endif  // TF_METAL_NO_STREAM_OPTIONS
+
+  se->create_event = CreateEvent;
+  se->destroy_event = DestroyEvent;
+  se->get_event_status = GetEventStatus;
+  se->record_event = RecordEvent;
+  se->wait_for_event = WaitForEvent;
+
+  se->create_timer = CreateTimer;
+  se->destroy_timer = DestroyTimer;
+  se->start_timer = StartTimer;
+  se->stop_timer = StopTimer;
+
+  se->memcpy_dtoh = MemcpyDToH;
+  se->memcpy_htod = MemcpyHToD;
+  se->memcpy_dtod = MemcpyDToD;
+  se->sync_memcpy_dtoh = SyncMemcpyDToH;
+  se->sync_memcpy_htod = SyncMemcpyHToD;
+  se->sync_memcpy_dtod = SyncMemcpyDToD;
+
+  se->block_host_for_event = BlockHostForEvent;
+  se->block_host_until_done = BlockHostUntilDone;
+  se->synchronize_all_activity = SynchronizeAllActivity;
+
+  se->mem_zero = MemZero;
+  se->memset = Memset;
+  se->memset32 = Memset32;
+
+  se->host_callback = HostCallback;
+}
+
+void PopulateTimerFns(SP_TimerFns* timer_fns) {
+  timer_fns->struct_size = SP_TIMER_FNS_STRUCT_SIZE;
+  timer_fns->ext = nullptr;
+  timer_fns->nanoseconds = TimerNanoseconds;
+}
+
+}  // namespace metal
+}  // namespace tensorflow

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -73,6 +73,33 @@ tf_cc_shared_object(
 )
 
 tf_py_strict_test(
+    name = "metal_device_test",
+    size = "small",
+    srcs = ["metal_device_test.py"],
+    main = "metal_device_test.py",
+    tags = [
+        # Skips itself unless a Metal device is present, so it is safe to run
+        # anywhere, but it only means anything on an Apple silicon machine
+        # with a --config=metal build.
+        "no_oss",
+        "notap",
+    ],
+    deps = [
+        ":config",
+        ":constant_op",
+        ":dtypes",
+        ":for_generated_wrappers",
+        ":test_lib",
+        "//tensorflow/python/eager:context",
+        "//tensorflow/python/ops:array_ops",
+        "//tensorflow/python/ops:math_ops",
+        "//tensorflow/python/ops:nn_ops",
+        "//tensorflow/python/ops:random_ops",
+        "//third_party/py/numpy",
+    ],
+)
+
+tf_py_strict_test(
     name = "file_system_test",
     size = "small",
     srcs = ["file_system_test.py"],

--- a/tensorflow/python/framework/metal_device_test.py
+++ b/tensorflow/python/framework/metal_device_test.py
@@ -1,0 +1,153 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""End-to-end tests for the Metal PluggableDevice backend.
+
+These only run on an Apple silicon machine with a TensorFlow built using
+--config=metal. Everywhere else they skip, so the file is harmless in the
+normal CI matrix.
+"""
+
+import platform
+
+import numpy as np
+
+from tensorflow.python.framework import config
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test
+
+
+def _metal_is_available():
+  """True when a Metal device from this backend is present."""
+  if platform.system() != "Darwin" or platform.machine() != "arm64":
+    return False
+  # The backend registers under the GPU device type, and on macOS no other
+  # backend does, so any GPU device here is a Metal one.
+  return bool(config.list_physical_devices("GPU"))
+
+
+class MetalDeviceTest(test.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    if not _metal_is_available():
+      self.skipTest("No Metal device; TensorFlow was probably not built with "
+                    "--config=metal.")
+
+  def testDeviceIsListed(self):
+    devices = config.list_physical_devices("GPU")
+    self.assertNotEmpty(devices)
+    self.assertEqual(devices[0].device_type, "GPU")
+
+  def testDeviceDetailsNameTheMetalPlatform(self):
+    device = config.list_physical_devices("GPU")[0]
+    details = config.get_device_details(device)
+    # hardware_name comes from MTLDevice.name, so it should say something
+    # about an Apple GPU rather than being blank.
+    self.assertIn("device_name", details)
+    self.assertNotEmpty(details["device_name"])
+
+  def testTensorPlacement(self):
+    with ops.device("/GPU:0"):
+      value = constant_op.constant([1.0, 2.0, 3.0], dtype=dtypes.float32)
+    self.assertIn("GPU:0", value.device)
+
+  def testRoundTripPreservesValues(self):
+    """Exercises the host-to-device and device-to-host copy paths."""
+    expected = np.arange(1024, dtype=np.float32).reshape(32, 32)
+    with ops.device("/GPU:0"):
+      on_device = constant_op.constant(expected)
+    self.assertAllEqual(expected, on_device.numpy())
+
+  def testAdd(self):
+    lhs = np.random.rand(64, 64).astype(np.float32)
+    rhs = np.random.rand(64, 64).astype(np.float32)
+    with ops.device("/GPU:0"):
+      result = math_ops.add(constant_op.constant(lhs),
+                            constant_op.constant(rhs))
+    self.assertIn("GPU:0", result.device)
+    self.assertAllClose(lhs + rhs, result.numpy())
+
+  def testAddScalarBroadcast(self):
+    values = np.random.rand(16, 16).astype(np.float32)
+    with ops.device("/GPU:0"):
+      result = math_ops.add(constant_op.constant(values),
+                            constant_op.constant(2.0, dtype=dtypes.float32))
+    self.assertAllClose(values + 2.0, result.numpy())
+
+  def testMul(self):
+    lhs = np.random.rand(8, 8).astype(np.float32)
+    rhs = np.random.rand(8, 8).astype(np.float32)
+    with ops.device("/GPU:0"):
+      result = math_ops.multiply(constant_op.constant(lhs),
+                                 constant_op.constant(rhs))
+    self.assertAllClose(lhs * rhs, result.numpy())
+
+  def testMatMul(self):
+    lhs = np.random.rand(64, 96).astype(np.float32)
+    rhs = np.random.rand(96, 32).astype(np.float32)
+    with ops.device("/GPU:0"):
+      result = math_ops.matmul(constant_op.constant(lhs),
+                               constant_op.constant(rhs))
+    self.assertIn("GPU:0", result.device)
+    self.assertAllClose(np.matmul(lhs, rhs), result.numpy(), rtol=1e-5,
+                        atol=1e-5)
+
+  def testMatMulTransposed(self):
+    lhs = np.random.rand(96, 64).astype(np.float32)
+    rhs = np.random.rand(32, 96).astype(np.float32)
+    with ops.device("/GPU:0"):
+      result = math_ops.matmul(constant_op.constant(lhs),
+                               constant_op.constant(rhs),
+                               transpose_a=True, transpose_b=True)
+    self.assertAllClose(np.matmul(lhs.T, rhs.T), result.numpy(), rtol=1e-5,
+                        atol=1e-5)
+
+  def testMatMulFloat16(self):
+    lhs = np.random.rand(32, 32).astype(np.float16)
+    rhs = np.random.rand(32, 32).astype(np.float16)
+    with ops.device("/GPU:0"):
+      result = math_ops.matmul(constant_op.constant(lhs),
+                               constant_op.constant(rhs))
+    self.assertAllClose(np.matmul(lhs.astype(np.float32),
+                                  rhs.astype(np.float32)),
+                        result.numpy().astype(np.float32),
+                        rtol=1e-2, atol=1e-2)
+
+  def testIdentity(self):
+    values = np.random.rand(16, 16).astype(np.float32)
+    with ops.device("/GPU:0"):
+      result = array_ops.identity(constant_op.constant(values))
+    self.assertIn("GPU:0", result.device)
+    self.assertAllEqual(values, result.numpy())
+
+  def testChainedOpsStayOnDevice(self):
+    """A short chain, to check that stream ordering holds across kernels."""
+    lhs = np.random.rand(48, 48).astype(np.float32)
+    rhs = np.random.rand(48, 48).astype(np.float32)
+    with ops.device("/GPU:0"):
+      product = math_ops.matmul(constant_op.constant(lhs),
+                                constant_op.constant(rhs))
+      shifted = math_ops.add(product, constant_op.constant(1.0))
+      doubled = math_ops.multiply(shifted, constant_op.constant(2.0))
+    self.assertAllClose((np.matmul(lhs, rhs) + 1.0) * 2.0, doubled.numpy(),
+                        rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -272,6 +272,18 @@ def if_macos(a, otherwise = []):
         "//conditions:default": otherwise,
     })
 
+def if_metal(a, otherwise = []):
+    """Selects `a` when the Metal PluggableDevice backend is enabled.
+
+    Gated on --define=with_metal_support=true (set by --config=metal), so that
+    no Objective-C++ source is compiled and no dependency is added on any
+    platform unless the backend is explicitly requested.
+    """
+    return select({
+        clean_dep("//tensorflow:with_metal_support"): a,
+        "//conditions:default": otherwise,
+    })
+
 def if_ios(a, otherwise = []):
     return select({
         clean_dep("//tensorflow:ios"): a,


### PR DESCRIPTION
## What

A Metal GPU backend for Apple silicon, built into TensorFlow and gated behind `--config=metal`. This change is the device and memory foundation plus a small set of kernels: 29 files, about 4,500 lines.

It builds a `/device:GPU:0` that allocates, copies, synchronises, and runs the arithmetic, `MatMul` and `Identity`. That is deliberately not a useful op set. It is enough to show the compute path end to end, and the foundation is what has to be right first, because everything else is built on its memory model.

## Why

`tensorflow-metal`, the out-of-tree plugin the README points macOS users to, last shipped 1.2.0 on 2025-01-31, publishes no wheel past cp312, has no sdist, and its repository was archived in 2021.

It also no longer works. Installed alongside a stock `tensorflow==2.20.0` in a clean virtual environment, on a Python it supports, `import tensorflow` raises:

```
NotFoundError: dlopen(.../tensorflow-plugins/libmetal_plugin.dylib):
  Library not loaded: @rpath/_pywrap_tensorflow_internal.so
```

Forcing the library path past that gets to the real cause:

```
Symbol not found: __ZN10tensorflow28_AttrValue_default_instance_E
```

That is a protobuf C++ symbol: the plugin is linked against TensorFlow's internal C++ ABI, not only the stable C API. The same plugin works on 2.18.1 and 2.19.1 and fails on 2.20.0, so this is a version ceiling, not a misinstallation. There is currently no working GPU path for TensorFlow on a Mac.

## Design

**A PluggableDevice, not a device factory.** The backend implements the StreamExecutor C API, the same interface an out-of-tree plugin implements, and registers it in-process rather than through `dlopen`. `RegisterPluggableDevicePlugin` already has an overload taking a `PluggableDeviceInit_Api` by pointer; until now only tests used it. That reuses the whole of `tensorflow/core/common_runtime/pluggable_device` unchanged, and keeps the backend extractable to a separate repository if that is the right home.

**Unified memory is the load-bearing decision.** On Apple silicon there is one physical memory, so host and device copies are a `memcpy` rather than a staged blit. That removes the transfer cost that dominates small-model performance on a Mac, and it is the reason a Metal backend is worth having at all. Only devices reporting `hasUnifiedMemory` are accepted, and that is a correctness gate rather than a preference: on a discrete GPU, shared-storage buffers are host-side staging needing explicit `didModifyRange:` and `synchronizeResource:`, so the zero-copy transfers would silently read stale data.

**The buffer registry, because a device address is not opaque to core.** The BFC allocator carves sub-allocations out of a region by pointer arithmetic, and kernels receive interior pointers. A plugin returning an `id<MTLBuffer>` in that field breaks the first time core adds an offset to it. `MetalBufferRegistry` recovers the `(buffer, offset)` pair a Metal encoder needs from an arbitrary interior pointer, and `metal_buffer_registry_test.mm` covers an interior pointer, the boundary between two allocations, and a pointer belonging to no allocation.

**Stream ordering.** A `SP_Stream` is an `MTLCommandQueue` plus an `MTLSharedEvent` and a counter. Every command buffer waits for the previous value and signals the next, so work executes in the order TensorFlow enqueued it even though Metal command buffers may otherwise complete out of order.

## Build isolation

Without `--config=metal` the `if_metal()` select collapses to its default branch on every platform: no Objective-C++ is compiled, no dependency is added, and the Linux and Windows build graphs are unchanged. Every target in the new packages is `target_compatible_with = ["@platforms//os:macos"]`, so wildcard builds elsewhere skip them rather than failing.

The registrar is linked into `libtensorflow_framework` only. `TF_DISABLE_METAL=1` keeps the backend out of the process without a rebuild.

## Objective-C++ in the tree

Not a new thing: sixty `.mm` files already ship under `tensorflow/lite/delegates/gpu/metal`, built with `objc_library(..., sdk_frameworks = ["Metal"])` from `@rules_cc//cc:objc_library.bzl`. This follows the same pattern, isolated in its own directory and behind its own config.

## Verification

Measured on an Apple M4 Max. Every source type-checks against the macOS SDK. The kernels here were run on the GPU through TensorFlow's own dispatch with soft placement disabled, so an op with no GPU kernel raises rather than quietly answering from the host, and their results match the CPU kernels for the same ops.

Not measured: no `bazel build` of the full framework, because `apple_support` cannot resolve an SDK without a full Xcode install on this machine, so undefined symbols and BUILD dependency gaps remain possible.

Tests included:
- `//tensorflow/core/common_runtime/metal:metal_buffer_registry_test`
- `tensorflow/python/framework/metal_device_test.py`, which skips off Apple silicon

## Relationship to #126254

[#126254](https://github.com/tensorflow/tensorflow/pull/126254) is the same backend with the op coverage filled in, and at 38,000 lines it is not a reviewable change. This is its first eighth, self-contained and useful on its own. If the foundation is acceptable the coverage can follow in themed changes; if the in-tree question is settled the other way, this is the change to say so on, and the answer costs a reviewer far less time here.

I would rather have that discussion than pre-empt it. The argument for in-tree is the situation above: the out-of-tree mechanism has been available for Metal since TF 2.5, and what it produced is a plugin that stopped shipping and now breaks `import tensorflow` on a current release. An out-of-tree replacement inherits the same failure mode.

---

CLA: signed.

---

Drafted with assistance from Claude Opus 5.
