### PR TITLE
Link the experimental kernel C API back into the shipped libraries

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1645,6 +1645,17 @@ pywrap_library(
             ],
         }),
     },
+    # The kernel C API for resource variables has no caller inside TensorFlow:
+    # it exists so that a PluggableDevice can implement the ops that read and
+    # write variables. Nothing therefore pulls kernels_experimental.cc into the
+    # link, and the fourteen entry points it defines have been absent from
+    # every shipped binary since 2.20.0, while the headers still declare them.
+    # Naming it here puts it in the common library, which is where the rest of
+    # the C API already lives. See #126374.
+    extra_deps = [
+        "@pybind11//:pybind11",
+        "//tensorflow/c:kernels_experimental",
+    ],
     # buildifier: disable=unsorted-dict-items
     # @unsorted-dict-items
     common_lib_version_scripts = {

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1501,6 +1501,19 @@ pybind_extension(
     pywrap_only = True,
     deps = [
         ":_pywrap_library_dependency_enforcer",
+        # The kernel C API for resource variables has no caller inside
+        # TensorFlow: it exists so that a PluggableDevice can implement the ops
+        # that read and write variables. It is a root of :tensorflow_framework,
+        # but a pywrap filter only partitions the linker inputs a link already
+        # has, so being a root does not make it reachable. It used to be
+        # reachable through pywrap_tensorflow_macro, which discards its deps
+        # under the pywrap rules, and since 2.20.0 no shipped binary has
+        # defined the fourteen entry points it exports. Naming it here restores
+        # the edge; the framework filter then places it in
+        # libtensorflow_framework, where the rest of the C API already lives,
+        # rather than duplicating //tensorflow/core:framework_internal_impl
+        # into the common library. See #126374.
+        "//tensorflow/c:kernels_experimental",
         "@pybind11",
     ],
 )
@@ -1645,17 +1658,6 @@ pywrap_library(
             ],
         }),
     },
-    # The kernel C API for resource variables has no caller inside TensorFlow:
-    # it exists so that a PluggableDevice can implement the ops that read and
-    # write variables. Nothing therefore pulls kernels_experimental.cc into the
-    # link, and the fourteen entry points it defines have been absent from
-    # every shipped binary since 2.20.0, while the headers still declare them.
-    # Naming it here puts it in the common library, which is where the rest of
-    # the C API already lives. See #126374.
-    extra_deps = [
-        "@pybind11//:pybind11",
-        "//tensorflow/c:kernels_experimental",
-    ],
     # buildifier: disable=unsorted-dict-items
     # @unsorted-dict-items
     common_lib_version_scripts = {

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -1557,6 +1557,19 @@ py_library(
     ],
 )
 
+tf_py_strict_test(
+    name = "pluggable_device_c_api_test",
+    size = "small",
+    srcs = ["pluggable_device_c_api_test.py"],
+    # It asks the process for symbols the public C headers declare, so it has
+    # to run against a build that actually linked them rather than against the
+    # source tree.
+    tags = ["no_pip"],
+    deps = [
+        "//tensorflow/python/platform:client_testlib",
+    ],
+)
+
 cuda_py_strict_test(
     name = "config_test",
     size = "small",

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -1566,6 +1566,7 @@ tf_py_strict_test(
     # source tree.
     tags = ["no_pip"],
     deps = [
+        "//tensorflow/python:pywrap_tensorflow",
         "//tensorflow/python/platform:client_testlib",
     ],
 )

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -1568,6 +1568,7 @@ tf_py_strict_test(
     deps = [
         "//tensorflow/python:pywrap_tensorflow",
         "//tensorflow/python/platform:client_testlib",
+        "//tensorflow/python/platform:sysconfig",
     ],
 )
 

--- a/tensorflow/python/framework/pluggable_device_c_api_test.py
+++ b/tensorflow/python/framework/pluggable_device_c_api_test.py
@@ -26,12 +26,14 @@ binary while their header went on declaring them, and nothing noticed for two
 releases. They are the only way a plugin can reach a resource variable's
 tensor, so every optimiser became unimplementable on a PluggableDevice.
 
-This test is deliberately dumb: it asks the process whether each name resolves.
-It does not call them, because calling them needs a kernel context.
+This test is deliberately dumb: it asks the runtime library whether each name
+resolves. It does not call them, because calling them needs a kernel context.
 """
 
 import ctypes
+import sys
 
+from tensorflow.python import pywrap_tensorflow  # pylint: disable=unused-import
 from tensorflow.python.platform import test
 
 
@@ -69,23 +71,35 @@ _KERNELS = (
     "TF_GetStream",
 )
 
+# The extension module that pywrap_tensorflow loads. It is the object a plugin
+# is linked against, and dlsym on its handle searches it and the libraries it
+# depends on, which is where the C API actually lands. The process-wide
+# namespace is not searchable instead: pywrap_tensorflow deliberately loads
+# this with RTLD_LOCAL so that TensorFlow's statically linked LLVM does not
+# leak into it.
+_RUNTIME_MODULE = "tensorflow.python._pywrap_tensorflow_internal"
+
 
 class PluggableDeviceCApiTest(test.TestCase):
 
   def setUp(self):
     super().setUp()
-    try:
-      # RTLD_DEFAULT: everything the process has loaded, which is where a
-      # plugin's own references are resolved from.
-      self._process = ctypes.CDLL(None)
-    except OSError:
-      self.skipTest("this platform has no flat symbol namespace to search")
+    if sys.platform == "win32":
+      # A name resolves on Windows only if the module definition file exports
+      # it, which is a different question from whether it was linked in, and
+      # the one this test is not asking.
+      self.skipTest("symbol visibility on Windows is governed by a .def file")
+    module = sys.modules.get(_RUNTIME_MODULE)
+    path = getattr(module, "__file__", None)
+    if not path:
+      self.skipTest(f"{_RUNTIME_MODULE} was not loaded from a shared object")
+    self._runtime = ctypes.CDLL(path)
 
   def _assert_defined(self, names, why):
     missing = []
     for name in names:
       try:
-        getattr(self._process, name)
+        getattr(self._runtime, name)
       except AttributeError:
         missing.append(name)
     self.assertEmpty(

--- a/tensorflow/python/framework/pluggable_device_c_api_test.py
+++ b/tensorflow/python/framework/pluggable_device_c_api_test.py
@@ -1,0 +1,112 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The C API entry points a PluggableDevice needs must be defined, not only declared.
+
+A plugin is a shared object that TensorFlow loads and that calls back into it.
+It compiles against the public C headers and resolves those functions at load
+time, so a function the headers declare and no shipped binary defines is not a
+missing feature: it is a plugin that fails to load, or on a platform that binds
+lazily, one that dies at the first call.
+
+That is not hypothetical. Between 2.19.1 and 2.21.0 the fourteen entry points
+of tensorflow/c/kernels_experimental.cc stopped being linked into any shipped
+binary while their header went on declaring them, and nothing noticed for two
+releases. They are the only way a plugin can reach a resource variable's
+tensor, so every optimiser became unimplementable on a PluggableDevice.
+
+This test is deliberately dumb: it asks the process whether each name resolves.
+It does not call them, because calling them needs a kernel context.
+"""
+
+import ctypes
+
+from tensorflow.python.platform import test
+
+
+# Declared in tensorflow/c/kernels_experimental.h. A PluggableDevice needs
+# these to implement any op that reads or writes a resource variable, which is
+# every optimiser, the resource gather and scatter ops, and the reference
+# assignments.
+_KERNELS_EXPERIMENTAL = (
+    "TF_AddNVariant",
+    "TF_AssignRefVariable",
+    "TF_AssignUpdateVariable",
+    "TF_AssignVariable",
+    "TF_DestroyTemporaryVariable",
+    "TF_GetInputByName",
+    "TF_GetInputTensorFromVariable",
+    "TF_IsRefInput",
+    "TF_MaybeLockVariableInputMutexesInOrder",
+    "TF_OpKernelConstruction_GetAttrTensorShape",
+    "TF_OpKernelContext_ForwardRefInputToRefOutput",
+    "TF_ReleaseVariableInputLockHolder",
+    "TF_TemporaryVariable",
+    "TF_ZerosLikeVariant",
+)
+
+# Declared in tensorflow/c/kernels.h. These have never gone missing, because
+# TensorFlow's own kernels call them, which is what pulls their object into the
+# link. They are here as a control: if they fail too, the test is looking in
+# the wrong place rather than finding a regression.
+_KERNELS = (
+    "TF_NewKernelBuilder",
+    "TF_RegisterKernelBuilder",
+    "TF_KernelBuilder_TypeConstraint",
+    "TF_KernelBuilder_HostMemory",
+    "TF_AllocateOutput",
+    "TF_GetStream",
+)
+
+
+class PluggableDeviceCApiTest(test.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    try:
+      # RTLD_DEFAULT: everything the process has loaded, which is where a
+      # plugin's own references are resolved from.
+      self._process = ctypes.CDLL(None)
+    except OSError:
+      self.skipTest("this platform has no flat symbol namespace to search")
+
+  def _assert_defined(self, names, why):
+    missing = []
+    for name in names:
+      try:
+        getattr(self._process, name)
+      except AttributeError:
+        missing.append(name)
+    self.assertEmpty(
+        missing,
+        f"{len(missing)} of {len(names)} entry points are declared by the "
+        f"public C headers and defined by no binary in this build: "
+        f"{', '.join(missing)}. {why}")
+
+  def testKernelCApiIsDefined(self):
+    self._assert_defined(
+        _KERNELS,
+        "These are called by TensorFlow's own kernels, so if they are missing "
+        "the test is looking in the wrong place.")
+
+  def testExperimentalKernelCApiIsDefined(self):
+    self._assert_defined(
+        _KERNELS_EXPERIMENTAL,
+        "Nothing inside TensorFlow calls these; they exist for plugins, so "
+        "nothing incidental pulls their object into the link. A "
+        "PluggableDevice cannot reach a resource variable without them.")
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/framework/pluggable_device_c_api_test.py
+++ b/tensorflow/python/framework/pluggable_device_c_api_test.py
@@ -34,6 +34,7 @@ import ctypes
 import glob
 import os
 import sys
+import unittest
 
 # Imported for its side effect: it is what loads the extension module the
 # symbols are looked up in.
@@ -85,9 +86,7 @@ _KERNELS = (
 # this test first got the answer wrong. pywrap_tensorflow loads that extension
 # with RTLD_LOCAL deliberately, so that TensorFlow's statically linked LLVM
 # does not leak into a process that may later import its own; nothing of
-# TensorFlow's is in RTLD_DEFAULT to find. On Windows ctypes cannot even be
-# asked: CDLL(None) is a TypeError there rather than an OSError, which is what
-# turned the first version of this test into an error instead of a failure.
+# TensorFlow's is in RTLD_DEFAULT to find.
 _RUNTIME_MODULE = "tensorflow.python._pywrap_tensorflow_internal"
 
 
@@ -104,17 +103,23 @@ def _candidate_libraries():
   # depends on, so the handle above already reaches it; naming it as well
   # covers a layout where it does not.
   library_dir = sysconfig.get_lib()
-  if sys.platform == "win32":
-    patterns = ("*tensorflow*.dll",)
-  elif sys.platform == "darwin":
-    patterns = ("*tensorflow_framework*.dylib*",)
+  if sys.platform == "darwin":
+    pattern = "*tensorflow_framework*.dylib*"
   else:
-    patterns = ("*tensorflow_framework*.so*",)
-  for pattern in patterns:
-    paths.extend(sorted(glob.glob(os.path.join(library_dir, pattern))))
+    pattern = "*tensorflow_framework*.so*"
+  paths.extend(sorted(glob.glob(os.path.join(library_dir, pattern))))
   return paths
 
 
+# Windows answers a different question. A name is reachable there only if the
+# module definition file exported it, and the CI run on 9caf805 showed that
+# asking the shipped .pyd resolves none of these, the control group included:
+# whatever loaded, GetProcAddress found nothing in it. A control group that
+# fails is this test saying it is looking in the wrong place, and on Windows
+# there is no right place for it to look, so it has nothing to report there.
+@unittest.skipIf(
+    sys.platform == "win32",
+    "symbol resolution on Windows goes through an export table, not the link")
 class PluggableDeviceCApiTest(test.TestCase):
 
   def setUp(self):

--- a/tensorflow/python/framework/pluggable_device_c_api_test.py
+++ b/tensorflow/python/framework/pluggable_device_c_api_test.py
@@ -26,14 +26,19 @@ binary while their header went on declaring them, and nothing noticed for two
 releases. They are the only way a plugin can reach a resource variable's
 tensor, so every optimiser became unimplementable on a PluggableDevice.
 
-This test is deliberately dumb: it asks the runtime library whether each name
+This test is deliberately dumb: it asks the shipped binaries whether each name
 resolves. It does not call them, because calling them needs a kernel context.
 """
 
 import ctypes
+import glob
+import os
 import sys
 
+# Imported for its side effect: it is what loads the extension module the
+# symbols are looked up in.
 from tensorflow.python import pywrap_tensorflow  # pylint: disable=unused-import
+from tensorflow.python.platform import sysconfig
 from tensorflow.python.platform import test
 
 
@@ -71,37 +76,65 @@ _KERNELS = (
     "TF_GetStream",
 )
 
-# The extension module that pywrap_tensorflow loads. It is the object a plugin
-# is linked against, and dlsym on its handle searches it and the libraries it
-# depends on, which is where the C API actually lands. The process-wide
-# namespace is not searchable instead: pywrap_tensorflow deliberately loads
-# this with RTLD_LOCAL so that TensorFlow's statically linked LLVM does not
-# leak into it.
+# The extension module pywrap_tensorflow loads. It is the primary place to
+# look: it is what a plugin is linked against, and resolving a name through its
+# handle searches it and the libraries it depends on, which is where the C API
+# lands in a shared-object build.
+#
+# The process-wide namespace is not the place to look, and asking it is how
+# this test first got the answer wrong. pywrap_tensorflow loads that extension
+# with RTLD_LOCAL deliberately, so that TensorFlow's statically linked LLVM
+# does not leak into a process that may later import its own; nothing of
+# TensorFlow's is in RTLD_DEFAULT to find. On Windows ctypes cannot even be
+# asked: CDLL(None) is a TypeError there rather than an OSError, which is what
+# turned the first version of this test into an error instead of a failure.
 _RUNTIME_MODULE = "tensorflow.python._pywrap_tensorflow_internal"
+
+
+def _candidate_libraries():
+  """Paths of the binaries a plugin's undefined references resolve against."""
+  paths = []
+  module = sys.modules.get(_RUNTIME_MODULE)
+  path = getattr(module, "__file__", None)
+  if path:
+    paths.append(path)
+
+  # A monolithic build keeps the C API in the extension module above. A
+  # shared-object build puts it in libtensorflow_framework, which that module
+  # depends on, so the handle above already reaches it; naming it as well
+  # covers a layout where it does not.
+  library_dir = sysconfig.get_lib()
+  if sys.platform == "win32":
+    patterns = ("*tensorflow*.dll",)
+  elif sys.platform == "darwin":
+    patterns = ("*tensorflow_framework*.dylib*",)
+  else:
+    patterns = ("*tensorflow_framework*.so*",)
+  for pattern in patterns:
+    paths.extend(sorted(glob.glob(os.path.join(library_dir, pattern))))
+  return paths
 
 
 class PluggableDeviceCApiTest(test.TestCase):
 
   def setUp(self):
     super().setUp()
-    if sys.platform == "win32":
-      # A name resolves on Windows only if the module definition file exports
-      # it, which is a different question from whether it was linked in, and
-      # the one this test is not asking.
-      self.skipTest("symbol visibility on Windows is governed by a .def file")
-    module = sys.modules.get(_RUNTIME_MODULE)
-    path = getattr(module, "__file__", None)
-    if not path:
-      self.skipTest(f"{_RUNTIME_MODULE} was not loaded from a shared object")
-    self._runtime = ctypes.CDLL(path)
+    self._libraries = []
+    for path in _candidate_libraries():
+      try:
+        self._libraries.append(ctypes.CDLL(path))
+      except OSError:
+        # A path that is not loadable on this platform tells us nothing; the
+        # test fails below if no library at all defines the names.
+        continue
+    if not self._libraries:
+      self.skipTest("no TensorFlow shared library to resolve symbols against")
 
   def _assert_defined(self, names, why):
-    missing = []
-    for name in names:
-      try:
-        getattr(self._runtime, name)
-      except AttributeError:
-        missing.append(name)
+    missing = [
+        name for name in names
+        if not any(getattr(library, name, None) for library in self._libraries)
+    ]
     self.assertEmpty(
         missing,
         f"{len(missing)} of {len(names)} entry points are declared by the "


### PR DESCRIPTION
## What

Restores the dependency edge that reaches `//tensorflow/c:kernels_experimental`, so that the fourteen entry points it defines are linked into the shipped binaries again.

Fixes #126374.

## The symptom

Since 2.20.0, no binary in a TensorFlow wheel defines the public surface of `tensorflow/c/kernels_experimental.cc`, on any platform, while `tensorflow/c/kernels_experimental.h` goes on declaring all of it with `TF_CAPI_EXPORT`. Comparing the `TF_*` symbols exported by `libtensorflow_framework` in the released wheels:

| | exported `TF_*` |
| --- | --- |
| 2.19.1 | 161 |
| 2.20.0 | 147 |
| 2.21.0 | 144 |

None were added in exchange. Of the seventeen lost between 2.19.1 and 2.21.0, three (`TF_Log`, `TF_VLog`, `TF_DVLog`) no longer exist in the source at all and are gone deliberately. The other fourteen are exactly the contents of `kernels_experimental.cc`, which is still there:

```
TF_AddNVariant                              TF_IsRefInput
TF_AssignRefVariable                        TF_MaybeLockVariableInputMutexesInOrder
TF_AssignUpdateVariable                     TF_OpKernelConstruction_GetAttrTensorShape
TF_AssignVariable                           TF_OpKernelContext_ForwardRefInputToRefOutput
TF_DestroyTemporaryVariable                 TF_ReleaseVariableInputLockHolder
TF_GetInputByName                           TF_TemporaryVariable
TF_GetInputTensorFromVariable               TF_ZerosLikeVariant
```

They are not merely unexported: the strings do not appear in any binary in the wheel, so the translation unit is not being compiled into anything.

Reproduced on the released macOS arm64 and manylinux x86_64 wheels for 2.20.0 and 2.21.0.

```python
# pip install tensorflow==2.21.0
import ctypes, tensorflow as tf
process = ctypes.CDLL(None)
for name in ("TF_NewKernelBuilder", "TF_AllocateOutput",      # kernels.cc
             "TF_AssignRefVariable", "TF_GetInputTensorFromVariable"):
    try:
        getattr(process, name); print("resolvable:", name)
    except AttributeError:
        print("MISSING   :", name)
```

prints `resolvable` for the first two and `MISSING` for the last two. On 2.19.1 all four resolve.

## Why it matters

These entry points exist so that a PluggableDevice can implement the ops that read and write resource variables; they were added for that purpose in #55379, #55640 and #55645. There is no other way to reach a variable's tensor through the kernel C API.

Without them a plugin cannot implement `ResourceApplyAdam`, `ResourceApplyGradientDescent`, `ResourceApplyMomentum`, `ResourceApplyKerasMomentum`, `ResourceApplyRMSProp`, `ResourceGather`, `ResourceGatherNd`, `ResourceScatterUpdate`, `Assign`, `AssignAdd`, `AssignSub` or `ParallelConcat`. Every optimiser is in that list, so on 2.20.0 and 2.21.0 a PluggableDevice can do inference but not training: the weight updates fall back to the host. This affects every plugin, not one in particular.

On macOS the failure is worse than a fallback, because dyld on 13 and later binds at load rather than at first call: a plugin that references one of these symbols fails to `dlopen` at all, which takes `import tensorflow` down with it.

## The cause

`//tensorflow/c:kernels_experimental` already carries `alwayslink = 1` and is already listed in the `roots` of `tensorflow_framework`. Neither reaches the link any more.

Under the pywrap rules, `pywrap_tensorflow_macro_opensource` discards its `deps` and builds an empty `py_library` (`tensorflow/tensorflow.bzl:2502`):

```python
    if use_pywrap_rules():
        _plain_py_library(name = name, srcs = [], deps = [])
        return
```

and `tf_cc_shared_library` builds no shared object at all, only a filter (`tensorflow/tensorflow.bzl:941`):

```python
    if use_pywrap_rules():
        cc_library(name = "%s_pywrap_filter" % name, deps = roots)
        return
```

A filter partitions the linker inputs a link already has; it cannot add one. `//tensorflow/c:kernels_experimental` was reachable only through `pywrap_tensorflow_internal`'s deps, so after the first of those two short-circuits nothing depends on it, and after the second nothing forces it in.

Nothing inside TensorFlow calls any of these fourteen functions, which is exactly what one expects of an API written for external plugins, so there is no incidental reference to pull the object out of its archive either.

`//tensorflow/c:kernels` is the control. It survives because `tensorflow/c/kernels/bitcast_op.cc` and its neighbours call `TF_NewKernelBuilder`, so that object is pulled in and the rest of `kernels.cc` comes with it, `TF_GetStream` and `TF_KernelBuilder_HostMemory` included. The two files differ in nothing but whether TensorFlow itself happens to call them.

## The change

The target only has to enter the collected linker inputs by an ordinary `deps` edge; being a root of `tensorflow_framework` then does the rest, and `alwayslink = 1` forces the object into that library. So the fix is to put the edge back where the pywrap rules can see it, in the `deps` of the `_pywrap_tensorflow_internal` `pybind_extension`, which is the successor of the macro whose `deps` are now discarded.

The first revision of this pull request instead named the target in the `extra_deps` of `pywrap_library`, which was wrong, and CI said so. `extra_deps` adds to the common library directly, outside the partition that `common_lib_filters` performs, and `kernels_experimental` depends on `//tensorflow/core:framework_internal_impl`, which is itself a root of `tensorflow_framework`. That linked `framework_internal_impl` into both libraries, and every Python test aborted at startup on Linux CPU, Linux CUDA, Linux CUDA13 and Windows:

```
F collective.h:513] Check failed: (::tsl::TfCheckOkDeprecationMarker(), CollectiveRegistry::Register(collective_name, factory)) is OK (INTERNAL: Already registered collective AllToAll
```

Thanks to @dmiltr3 for the diagnosis. Going through `deps` keeps `framework_internal_impl` on the one side of the partition it was always on, so nothing is duplicated.

## What I could not verify

I have not built TensorFlow, so the diagnosis above is measured and the remedy is reasoned. Everything before "The change" is reproducible from released wheels in under a minute; the addition is the part that needs the CI matrix.

## The test

`tensorflow/python/framework/pluggable_device_c_api_test.py` asks the process whether each name the public C headers declare actually resolves, which is what a plugin does when TensorFlow loads it. It carries a control group from `kernels.cc` that has never gone missing, so a failure there means the test is looking in the wrong place rather than finding a regression.

Checked against the released wheels rather than only written. On 2.21.0 it fails and names all fourteen; on 2.19.1 it passes; the control group passes on both. So it fails on exactly the versions the bug is in.

That the symbols could vanish for two releases without anything noticing seems worth guarding against independently of this particular fix.
