### PR TITLE
fix(gpu): prevent integer overflow in RollKernel on large tensors

### DIFF
--- a/tensorflow/core/kernels/roll_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/roll_op_gpu.cu.cc
@@ -30,12 +30,12 @@ typedef Eigen::GpuDevice GPUDevice;
 namespace {
 
 template <typename T>
-__global__ void RollKernel(const int32_t nthreads, const int32_t num_dims,
+__global__ void RollKernel(const int64_t nthreads, const int32_t num_dims,
                            const T* __restrict__ input, T* __restrict__ output,
                            const int32_t* __restrict__ dim_size,
                            const int32_t* __restrict__ threshold,
                            const int64_t* __restrict__ dim_range) {
-  CUDA_1D_KERNEL_LOOP(out_idx, nthreads) {
+  for (int64_t out_idx : GpuGridRangeX(nthreads)) {
     int64_t offset = 0;
     for (int i = 0; i < num_dims; i++) {
       const int64_t stride = dim_range[i] / dim_size[i];
@@ -75,12 +75,15 @@ struct Roll<GPUDevice, T> {
     d.memcpyHostToDevice(thres_buf, threshold.data(), thres_bytes);
     d.memcpyHostToDevice(range_buf, dim_range.data(), range_bytes);
 
-    GpuLaunchConfig cfg = GetGpuLaunchConfig(num_elements, d);
+    absl::StatusOr<GpuLaunchConfig64> config =
+        GetGpuLaunchConfig64(num_elements, d);
+    OP_REQUIRES_OK(const_cast<OpKernelContext*>(context), config.status());
 
     TF_CHECK_OK(
-        GpuLaunchKernel(RollKernel<T>, cfg.block_count, cfg.thread_per_block, 0,
-                        d.stream(), cfg.virtual_thread_count, num_dims, input,
-                        output, reinterpret_cast<const int32_t*>(dim_buf),
+        GpuLaunchKernel(RollKernel<T>, config->block_count,
+                        config->thread_per_block, 0, d.stream(),
+                        config->virtual_thread_count, num_dims, input, output,
+                        reinterpret_cast<const int32_t*>(dim_buf),
                         reinterpret_cast<const int32_t*>(thres_buf),
                         reinterpret_cast<const int64_t*>(range_buf)));
 


### PR DESCRIPTION
Fixes #109520

### Summary of Changes

In `tensorflow/core/kernels/roll_op_gpu.cu.cc`, `RollKernel` took `const int32_t nthreads` and used `CUDA_1D_KERNEL_LOOP(out_idx, nthreads)`, which expanded to `GpuGridRangeX<int>`.

When a tensor has more than `INT32_MAX` elements (such as shape `[46341, 46340]`), `cfg.virtual_thread_count` overflows 32-bit signed integer limits. This causes `out_idx` to wrap around, leading to negative index computation and out-of-bounds GPU memory access (`cudaErrorIllegalAddress`).

This patch:
- Changes the `nthreads` parameter in `RollKernel` from `int32_t` to `int64_t`.
- Replaces `CUDA_1D_KERNEL_LOOP` with `for (int64_t out_idx : GpuGridRangeX(nthreads))`, enabling 64-bit indexing without integer overflow.

### Validation

- Checked `GpuGridRangeX` loop iteration with `int64_t` indices on `GPUDevice`.
- Verified type compatibility with `GpuLaunchKernel` and `GetGpuLaunchConfig`.