### PR TITLE
[XLA:tf2xla] Support half, bfloat16, and integer dtypes in RangeOp

### DIFF
--- a/tensorflow/compiler/tests/ternary_ops_test.py
+++ b/tensorflow/compiler/tests/ternary_ops_test.py
@@ -60,7 +60,7 @@ class TernaryOpsTest(xla_test.XLATestCase, parameterized.TestCase):
     self.assertEqual(result[0], expected[0])
 
   def testRange(self):
-    for dtype in self.int_types | self.float_types:
+    for dtype in (self.int_types | self.float_types) - {np.uint8}:
       self._testTernary(
           math_ops.range,
           dtype(1),

--- a/tensorflow/compiler/tests/ternary_ops_test.py
+++ b/tensorflow/compiler/tests/ternary_ops_test.py
@@ -60,18 +60,19 @@ class TernaryOpsTest(xla_test.XLATestCase, parameterized.TestCase):
     self.assertEqual(result[0], expected[0])
 
   def testRange(self):
-    self._testTernary(
-        math_ops.range,
-        np.int32(1),
-        np.int32(2),
-        np.int32(1),
-        expected=np.array([1], dtype=np.int32))
-    self._testTernary(
-        math_ops.range,
-        np.int32(1),
-        np.int32(7),
-        np.int32(2),
-        expected=np.array([1, 3, 5], dtype=np.int32))
+    for dtype in self.int_types | self.float_types:
+      self._testTernary(
+          math_ops.range,
+          dtype(1),
+          dtype(2),
+          dtype(1),
+          expected=np.array([1], dtype=dtype))
+      self._testTernary(
+          math_ops.range,
+          dtype(1),
+          dtype(7),
+          dtype(2),
+          expected=np.array([1, 3, 5], dtype=dtype))
 
   def testSelect(self):
     for dtype in self.numeric_types:

--- a/tensorflow/compiler/tf2xla/kernels/sequence_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/sequence_ops.cc
@@ -48,10 +48,10 @@ absl::StatusOr<xla::XlaOp> CreateRangeTensor(
   T limit = limit_literal.Get<T>({});
   T delta = delta_literal.Get<T>({});
 
-  if (delta == 0) {
+  if (delta == static_cast<T>(0)) {
     return errors::InvalidArgument("Requires delta != 0: ", delta);
   }
-  if (delta > 0) {
+  if (delta > static_cast<T>(0)) {
     if (start > limit) {
       return errors::InvalidArgument(
           "Requires start <= limit when delta > 0: ", start, "/", limit);
@@ -62,13 +62,21 @@ absl::StatusOr<xla::XlaOp> CreateRangeTensor(
           "Requires start >= limit when delta < 0: ", start, "/", limit);
     }
   }
-  int64_t size =
-      (std::is_integral<T>::value
-           ? static_cast<T>(
-                 limit == start
-                     ? 0
-                     : (std::abs(limit - start) - 1) / std::abs(delta) + 1)
-           : std::ceil(std::abs((limit - start) / delta)));
+  int64_t size;
+  if constexpr (std::is_integral<T>::value) {
+    int64_t start_i = static_cast<int64_t>(start);
+    int64_t limit_i = static_cast<int64_t>(limit);
+    int64_t delta_i = static_cast<int64_t>(delta);
+    size = (limit_i == start_i
+                ? 0
+                : (std::abs(limit_i - start_i) - 1) / std::abs(delta_i) + 1);
+  } else {
+    double start_f = static_cast<double>(start);
+    double limit_f = static_cast<double>(limit);
+    double delta_f = static_cast<double>(delta);
+    size = static_cast<int64_t>(
+        std::ceil(std::abs((limit_f - start_f) / delta_f)));
+  }
 
   return xla::ConstantR0(builder, start) +
          xla::ConstantR0(builder, delta) *
@@ -86,13 +94,13 @@ class RangeOp : public XlaOpKernel {
     const TensorShape delta_in_shape = ctx->InputShape(2);
     OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(start_in_shape),
                 errors::InvalidArgument("start must be a scalar, not shape ",
-                                        start_in_shape.DebugString()));
+                                         start_in_shape.DebugString()));
     OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(limit_in_shape),
                 errors::InvalidArgument("limit must be a scalar, not shape ",
-                                        limit_in_shape.DebugString()));
+                                         limit_in_shape.DebugString()));
     OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(delta_in_shape),
                 errors::InvalidArgument("delta must be a scalar, not shape ",
-                                        delta_in_shape.DebugString()));
+                                         delta_in_shape.DebugString()));
     xla::Literal start, limit, delta;
     OP_REQUIRES_OK(ctx, ctx->ConstantInput(
                             0, &start, xla::ValueInferenceMode::kLowerBound));
@@ -103,6 +111,13 @@ class RangeOp : public XlaOpKernel {
     DataType type = input_type(0);
     absl::StatusOr<xla::XlaOp> output;
     switch (type) {
+      case DT_INT8:
+        output = CreateRangeTensor<int8_t>(start, limit, delta, ctx->builder());
+        break;
+      case DT_INT16:
+        output =
+            CreateRangeTensor<int16_t>(start, limit, delta, ctx->builder());
+        break;
       case DT_INT32:
         output =
             CreateRangeTensor<int32_t>(start, limit, delta, ctx->builder());
@@ -110,6 +125,26 @@ class RangeOp : public XlaOpKernel {
       case DT_INT64:
         output =
             CreateRangeTensor<int64_t>(start, limit, delta, ctx->builder());
+        break;
+      case DT_UINT16:
+        output =
+            CreateRangeTensor<uint16_t>(start, limit, delta, ctx->builder());
+        break;
+      case DT_UINT32:
+        output =
+            CreateRangeTensor<uint32_t>(start, limit, delta, ctx->builder());
+        break;
+      case DT_UINT64:
+        output =
+            CreateRangeTensor<uint64_t>(start, limit, delta, ctx->builder());
+        break;
+      case DT_HALF:
+        output =
+            CreateRangeTensor<Eigen::half>(start, limit, delta, ctx->builder());
+        break;
+      case DT_BFLOAT16:
+        output =
+            CreateRangeTensor<bfloat16>(start, limit, delta, ctx->builder());
         break;
       case DT_FLOAT:
         output = CreateRangeTensor<float>(start, limit, delta, ctx->builder());
@@ -133,7 +168,7 @@ class RangeOp : public XlaOpKernel {
       xla::XlaOp delta = ctx->Input(2);
       xla::XlaOp limit = ctx->Input(1);
       xla::XlaOp start = ctx->Input(0);
-      if (type == DT_INT32 || type == DT_INT64) {
+      if (DataTypeIsInteger(type)) {
         auto dynamic_size = (xla::Abs(limit - start) + xla::Abs(delta) -
                              xla::One(ctx->builder(), ctx->input_xla_type(0))) /
                             xla::Abs(delta);

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2097,8 +2097,13 @@ def range(start, limit=None, delta=1, dtype=None, name="range"):  # pylint: disa
     # infer dtype if not explicitly provided
     if dtype is None:
       dtype_hierarchy = [
+          dtypes.int8,
+          dtypes.int16,
           dtypes.int32,
           dtypes.int64,
+          dtypes.uint16,
+          dtypes.uint32,
+          dtypes.uint64,
           dtypes.float16,
           dtypes.bfloat16,
           dtypes.float32,


### PR DESCRIPTION
The TensorFlow `Range` op accepts `bfloat16`, `half`, `float`, `double`, `int8`, `int16`, `int32`, `int64`, `uint16`, `uint32`, and `uint64`.

In `tensorflow/compiler/tf2xla/kernels/sequence_ops.cc`, `RangeOp::Compile` only handled `DT_INT32`, `DT_INT64`, `DT_FLOAT`, and `DT_DOUBLE`. Compiling `tf.range` with `jit_compile=True` on `float16`, `bfloat16`, or other integer dtypes failed with an `InvalidArgumentError`.

This adds `DT_HALF`, `DT_BFLOAT16`, `DT_INT8`, `DT_INT16`, `DT_UINT16`, `DT_UINT32`, and `DT_UINT64` to `RangeOp::Compile`, updates dynamic dimension calculation to check `DataTypeIsInteger`, and adds test coverage in `ternary_ops_test.py`.

Fixes #113143.