### PR TITLE
Fix grouped Conv2D eager validation for invalid output depth

### DIFF
--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -138,14 +138,16 @@ absl::Status ComputeConv2DDimension(const Conv2DParameters& params,
                   in_depth, " vs ", patch_depth)));
 
   // The last dimension for filter is out_depth.
-  const int out_depth =
-      static_cast<int>(GetFilterDim(filter, filter_format, 'O'));
+  const int64_t out_depth_raw = GetFilterDim(filter, filter_format, 'O');
+  TF_REQUIRES(FastBoundsCheck(out_depth_raw, std::numeric_limits<int>::max()),
+              absl::InvalidArgumentError("Output depth too large"));
+  const int out_depth = static_cast<int>(out_depth_raw);
 
   const int num_groups = in_depth / patch_depth;
   if (in_depth != patch_depth) {
     TF_REQUIRES(num_groups != 0,
                 absl::InvalidArgumentError("Number of groups must not be 0"));
-    TF_REQUIRES(out_depth % num_groups == 0,
+    TF_REQUIRES(out_depth >= num_groups && out_depth % num_groups == 0,
                 absl::InvalidArgumentError(absl::StrCat(
                     "Depth of output (", out_depth,
                     ") is not a multiple of the number of groups (", num_groups,

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -141,6 +141,17 @@ absl::Status ComputeConv2DDimension(const Conv2DParameters& params,
   const int out_depth =
       static_cast<int>(GetFilterDim(filter, filter_format, 'O'));
 
+  const int num_groups = in_depth / patch_depth;
+  if (in_depth != patch_depth) {
+    TF_REQUIRES(num_groups != 0,
+                absl::InvalidArgumentError("Number of groups must not be 0"));
+    TF_REQUIRES(out_depth % num_groups == 0,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Depth of output (", out_depth,
+                    ") is not a multiple of the number of groups (", num_groups,
+                    ")")));
+  }
+
   // The second dimension for input is rows/height.
   // The first dimension for filter is rows/height.
   const int64_t input_rows_raw = GetTensorDim(input, params.data_format, 'H');

--- a/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
@@ -1349,6 +1349,18 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
                                      data_format=data_format,
                                      dtype=dtypes.float32)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testConv2DGroupConvRejectsInvalidOutputDepth(self):
+    x = constant_op.constant(
+        [[[[1.0, 2.0], [3.0, 4.0]]]], dtype=dtypes.float32)
+    filt = constant_op.constant([[[[1.0]]], [[[2.0]]]], dtype=dtypes.float32)
+
+    with self.assertRaisesRegex(
+        (ValueError, errors_impl.InvalidArgumentError),
+        r"Depth of output \(1\) is not a multiple of the number of groups "
+        r"\(2\)"):
+      self.evaluate(nn_ops.conv2d(x, filt, [1, 1, 1, 1], padding="VALID"))
+
   @test_util.deprecated_graph_mode_only
   @test_util.run_gpu_only
   @test.disable_with_predicate(


### PR DESCRIPTION
Fixes #126413 
### Summary
This fixes grouped Conv2D validation in eager mode.

The eager path was missing the check that enforces the output depth to be a multiple of the number of groups when the input depth and filter depth differ. As a result, invalid grouped-convolution configurations could silently pass instead of raising the expected error.

### Changes
- Added the missing grouped-convolution validation in tensorflow/core/kernels/conv_ops.cc
- Added a regression test in tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py

### Why
This keeps eager execution aligned with the existing TensorFlow shape-inference and XLA contract for grouped convolutions.