### PR TITLE
TFLite SLICE: validate static-output slice bounds without changing allocation type

### DIFF
--- a/tensorflow/lite/kernels/slice.cc
+++ b/tensorflow/lite/kernels/slice.cc
@@ -58,20 +58,33 @@ TfLiteStatus CalculateOutputShapeVector(TfLiteContext* context,
                                         const TfLiteTensor* begin,
                                         const TfLiteTensor* size,
                                         std::vector<int>* output_shape_vector) {
-  for (int idx = 0; idx < NumDimensions(input); ++idx) {
+  const int input_dims = NumDimensions(input);
+  // `begin` and `size` are indexed by input dimension below. Prepare() only
+  // checks that they agree with each other, which does not bound them against
+  // the input rank, so establish that here before either is dereferenced.
+  TF_LITE_ENSURE_EQ(context, NumElements(begin), input_dims);
+  TF_LITE_ENSURE_EQ(context, NumElements(size), input_dims);
+  for (int idx = 0; idx < input_dims; ++idx) {
+    const T dim_value = static_cast<T>(SizeOfDimension(input, idx));
+    const T begin_value = GetTensorData<T>(begin)[idx];
     T size_value = GetTensorData<T>(size)[idx];
+    // Reject an out-of-range `begin` before it is used in any arithmetic, so
+    // the bounds comparison below cannot be reached with a wrapped value.
+    if (begin_value < 0 || begin_value > dim_value) {
+      TF_LITE_KERNEL_LOG(context, "Invalid begin.");
+      return kTfLiteError;
+    }
     if (size_value < 0) {
       if (size_value != -1) {
         TF_LITE_KERNEL_LOG(context, "Invalid size.");
         return kTfLiteError;
       }
-      size_value = SizeOfDimension(input, idx) - GetTensorData<T>(begin)[idx];
-    } else {
-      if (SizeOfDimension(input, idx) <
-          GetTensorData<T>(begin)[idx] + size_value) {
-        TF_LITE_KERNEL_LOG(context, "Invalid begin and size.");
-        return kTfLiteError;
-      }
+      size_value = dim_value - begin_value;
+    } else if (size_value > dim_value - begin_value) {
+      // Written as a subtraction rather than `begin_value + size_value >
+      // dim_value` so that the comparison cannot overflow.
+      TF_LITE_KERNEL_LOG(context, "Invalid begin and size.");
+      return kTfLiteError;
     }
     output_shape_vector->push_back(static_cast<int>(size_value));
   }
@@ -113,6 +126,39 @@ TfLiteStatus ResizeOutputShape(TfLiteContext* context,
   return context->ResizeTensor(context, output, output_shape);
 }
 
+// Validates the slice window against the input's current extent and confirms
+// that the resulting shape matches an output that was already allocated in
+// Prepare(). It deliberately does not resize the output or change its
+// allocation type, so a statically allocated output stays statically
+// allocated and arena planning is unaffected.
+TfLiteStatus ValidateSliceAgainstOutput(TfLiteContext* context,
+                                        const TfLiteTensor* input,
+                                        const TfLiteTensor* begin,
+                                        const TfLiteTensor* size,
+                                        const TfLiteTensor* output) {
+  std::vector<int> output_shape_vector;
+
+  if (begin->type == kTfLiteInt32) {
+    TF_LITE_ENSURE_STATUS(CalculateOutputShapeVector<int32_t>(
+        context, input, begin, size, &output_shape_vector));
+  } else if (begin->type == kTfLiteInt64) {
+    TF_LITE_ENSURE_STATUS(CalculateOutputShapeVector<int64_t>(
+        context, input, begin, size, &output_shape_vector));
+  } else {
+    TF_LITE_KERNEL_LOG(context, "Type %d is currently not supported by Slice.",
+                       begin->type);
+    return kTfLiteError;
+  }
+
+  TF_LITE_ENSURE_EQ(context, static_cast<int>(output_shape_vector.size()),
+                    NumDimensions(output));
+  for (int idx = 0; idx < NumDimensions(output); ++idx) {
+    TF_LITE_ENSURE_EQ(context, output_shape_vector[idx],
+                      SizeOfDimension(output, idx));
+  }
+  return kTfLiteOk;
+}
+
 bool ShapeHasRank(const TfLiteIntArray* shape) {
   // Note that we consider scalar as false here because there is
   // no differentiation between scalar and dynamic properly supported.
@@ -146,6 +192,16 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // If the shape of output is fully specified then resize even if
   // the input shape is not staticly defined.
   if (!HasUnspecifiedDimension(output) && ShapeHasRank(output->dims)) {
+    // The output keeps its static allocation. When the input extent and both
+    // index tensors are already known, validate the window now; otherwise the
+    // check is deferred to Eval(), which validates without resizing.
+    if (ShapeHasRank(input->dims) && !HasUnspecifiedDimension(input) &&
+        IsConstantOrPersistentTensor(begin) &&
+        IsConstantOrPersistentTensor(size)) {
+      TF_LITE_ENSURE_OK(context, ValidateSliceAgainstOutput(context, input,
+                                                            begin, size,
+                                                            output));
+    }
     return kTfLiteOk;
   }
   // Postpone allocation of output if any of the indexing tensors is not
@@ -175,6 +231,13 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   if (IsDynamicTensor(output)) {
     TF_LITE_ENSURE_OK(context,
                       ResizeOutputShape(context, input, begin, size, output));
+  } else {
+    // The output was allocated statically in Prepare(). Validate the window
+    // against the input's actual extent without resizing it or changing its
+    // allocation type.
+    TF_LITE_ENSURE_OK(
+        context, ValidateSliceAgainstOutput(context, input, begin, size,
+                                            output));
   }
 
   const int input_dims = NumDimensions(input);

--- a/tensorflow/lite/kernels/slice_test.cc
+++ b/tensorflow/lite/kernels/slice_test.cc
@@ -408,6 +408,64 @@ TEST_P(SliceOpTest, BeginNonZeroSizeMinus1Axis1BFloat16) {
                                 Eigen::bfloat16(8), Eigen::bfloat16(9)}));
 }
 
+// A statically shaped output must keep its static allocation. Prepare() returns
+// early for such an output; this asserts that validating it does not convert it
+// to a dynamic tensor, which would change arena planning for valid models.
+TEST(SliceOpTest, StaticOutputKeepsStaticAllocation) {
+  SliceOpModel<float, int32_t> m({4}, {1}, {1}, {1}, {2}, TensorType_INT32,
+                                 TensorType_FLOAT32, TestType::kConst, {2});
+  m.SetInput({1, 2, 3, 4});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2}));
+  EXPECT_NE(m.GetOutputTensor()->allocation_type, kTfLiteDynamic);
+}
+
+// `begin` and `size` supplied at run time are not visible to Prepare(), which
+// returns early because the output shape is fully specified. Without validation
+// in Eval() the kernel reads past the end of the input: begin 3 + size 2 exceeds
+// the input extent of 4.
+TEST(SliceOpTest, RuntimeIndicesOutOfBoundsWithStaticOutput) {
+  SliceOpModel<float, int32_t> m({4}, {1}, {3}, {1}, {2}, TensorType_INT32,
+                                 TensorType_FLOAT32, TestType::kDynamic, {2});
+  m.SetInput({1, 2, 3, 4});
+  EXPECT_NE(m.Invoke(), kTfLiteOk);
+}
+
+// The same case with int64 indices, so both supported index widths are covered.
+TEST(SliceOpTest, RuntimeIndicesOutOfBoundsWithStaticOutputInt64) {
+  SliceOpModel<float, int64_t> m({4}, {1}, {3}, {1}, {2}, TensorType_INT64,
+                                 TensorType_FLOAT32, TestType::kDynamic, {2});
+  m.SetInput({1, 2, 3, 4});
+  EXPECT_NE(m.Invoke(), kTfLiteOk);
+}
+
+// A negative `begin` is rejected before it is used in the bounds arithmetic.
+TEST(SliceOpTest, NegativeBeginWithStaticOutput) {
+  SliceOpModel<float, int32_t> m({4}, {1}, {-1}, {1}, {2}, TensorType_INT32,
+                                 TensorType_FLOAT32, TestType::kDynamic, {2});
+  m.SetInput({1, 2, 3, 4});
+  EXPECT_NE(m.Invoke(), kTfLiteOk);
+}
+
+// CalculateOutputShapeVector() indexes `begin` and `size` by input dimension.
+// Prepare() only checks the two against each other, so an index vector shorter
+// than the input rank is rejected here rather than read out of bounds.
+TEST(SliceOpTest, IndexVectorShorterThanInputRank) {
+  SliceOpModel<float, int32_t> m({2, 3}, {1}, {0}, {1}, {1}, TensorType_INT32,
+                                 TensorType_FLOAT32, TestType::kDynamic, {1, 1});
+  m.SetInput({1, 2, 3, 4, 5, 6});
+  EXPECT_NE(m.Invoke(), kTfLiteOk);
+}
+
+// A valid window whose computed shape disagrees with the declared static output
+// must fail cleanly rather than write into a mismatched buffer.
+TEST(SliceOpTest, ComputedShapeMustMatchDeclaredStaticOutput) {
+  SliceOpModel<float, int32_t> m({4}, {1}, {0}, {1}, {3}, TensorType_INT32,
+                                 TensorType_FLOAT32, TestType::kDynamic, {2});
+  m.SetInput({1, 2, 3, 4});
+  EXPECT_NE(m.Invoke(), kTfLiteOk);
+}
+
 INSTANTIATE_TEST_SUITE_P(SliceOpTest, SliceOpTest,
                          ::testing::Values(TestType::kConst,
                                            TestType::kDynamic));


### PR DESCRIPTION
This supersedes reverted PR #126177.

## The defect (still present on master)

`Prepare()` in `tensorflow/lite/kernels/slice.cc` returns early when the output shape is fully specified:

```c
if (!HasUnspecifiedDimension(output) && ShapeHasRank(output->dims)) {
  return kTfLiteOk;
}
// Postpone allocation of output if any of the indexing tensors is not
// constant, or the input tensor has dynamic dimension.
if (!(IsConstantOrPersistentTensor(begin) && IsConstantOrPersistentTensor(size)) ||
    HasUnspecifiedDimension(input)) {
  SetTensorToDynamic(output);
  return kTfLiteOk;
}
```

That path returns **without** calling `SetTensorToDynamic(output)` and without validating anything. Note that the constancy check for `begin`/`size` sits *below* the return, so it is never reached for a statically shaped output. `Eval()` re-runs `ResizeOutputShape()` only when the output is dynamic, so `CalculateOutputShapeVector()` — the single place `begin` and `size` are checked against the input — never runs.

Two cases reach the kernel unvalidated:

1. the input extent is only known at run time; and
2. `begin`/`size` are runtime tensors, whose values `Prepare()` cannot see at all.

## Why this differs from #126177

The earlier revision widened the early-return condition so that models with a dynamic input dimension fell through and had their output **reclassified as dynamic**. That changed the allocation type of otherwise valid models, which affects arena planning and delegate behaviour. It also only addressed case 1 — case 2 above still took the early return.

This revision separates **validation** from **resizing**:

- **`ValidateSliceAgainstOutput()`** computes the shape implied by the current input and indices and confirms it matches the already allocated output. It never resizes the output or changes its allocation type.
- **`Prepare()`** keeps its early return for a statically shaped output. When the input extent and both index tensors are already known it validates in place; otherwise the check is deferred.
- **`Eval()`** validates the static-output path instead of skipping it, and still resizes only for a genuinely dynamic output.

**The number of `SetTensorToDynamic()` calls is unchanged from master**, so no model changes allocation type as a result of this patch.

## Hardening `CalculateOutputShapeVector()`

It becomes the validation primitive here, so two existing weaknesses are addressed:

- It indexes `begin` and `size` by **input dimension**, but `Prepare()` only checks `NumElements(begin) == NumElements(size)` — never against the input rank. An index vector shorter than the rank is read past its end. A rank check is added before either buffer is dereferenced.
- The bounds test was `SizeOfDimension(input, idx) < begin[idx] + size_value`. `begin` was not range-checked first, and the addition can overflow. `begin` is now validated before use, and the comparison is written as `size_value > dim_value - begin_value`.

## Tests

- a static output keeps its static allocation (guards against the #126177 regression);
- runtime `begin`/`size` out of bounds with a static output — **int32 and int64**;
- negative `begin`;
- index vector shorter than the input rank;
- computed shape disagreeing with the declared static output.

## Notes

I do not know the reason #126177 was rolled back — the rollback commit records none — so I am not asserting one. What I can say is what changed: this revision does not alter any tensor's allocation type, and it closes the runtime-index case the earlier patch left open.

Not compile-tested (no Bazel environment) — please run CI.
