### PR TITLE
Fix CHECK-failure abort in BiasAdd/BiasAddGrad for rank-2 NCHW inputs (#94379)

### DIFF
--- a/tensorflow/core/kernels/bias_op.cc
+++ b/tensorflow/core/kernels/bias_op.cc
@@ -104,6 +104,11 @@ class BiasOp : public BinaryOp<T> {
     OP_REQUIRES(context, TensorShapeUtils::IsMatrixOrHigher(input.shape()),
                 errors::InvalidArgument("Input tensor must be at least 2D: ",
                                         input.shape()));
+    OP_REQUIRES(
+        context, data_format_ != FORMAT_NCHW || input.shape().dims() >= 3,
+        errors::InvalidArgument(
+            "NCHW format requires input tensor to be at least 3D: ",
+            input.shape()));
     OP_REQUIRES(context, TensorShapeUtils::IsVector(bias.shape()),
                 errors::InvalidArgument("Biases must be 1D: ", bias.shape()));
 
@@ -174,6 +179,13 @@ class BiasGradOp : public OpKernel {
                 TensorShapeUtils::IsMatrixOrHigher(output_backprop.shape()),
                 errors::InvalidArgument("Input tensor must be at least 2D: ",
                                         output_backprop.shape()));
+
+    OP_REQUIRES(
+        context,
+        data_format_ != FORMAT_NCHW || output_backprop.shape().dims() >= 3,
+        errors::InvalidArgument(
+            "NCHW format requires input tensor to be at least 3D: ",
+            output_backprop.shape()));
 
     OP_REQUIRES(context,
                 FastBoundsCheck(output_backprop.NumElements(),
@@ -254,6 +266,11 @@ class BiasOp<GPUDevice, T> : public BinaryOp<T> {
                 absl::InvalidArgumentError(
                     absl::StrCat("Input tensor must be at least 2D: ",
                                  input.shape().DebugString())));
+    OP_REQUIRES(
+        context, data_format_ != FORMAT_NCHW || input.shape().dims() >= 3,
+        absl::InvalidArgumentError(absl::StrCat(
+            "NCHW format requires input tensor to be at least 3D: ",
+            input.shape().DebugString())));
     OP_REQUIRES(context, TensorShapeUtils::IsVector(bias.shape()),
                 absl::InvalidArgumentError(absl::StrCat(
                     "Biases must be 1D: ", bias.shape().DebugString())));
@@ -448,6 +465,12 @@ class BiasGradOp<GPUDevice, T> : public OpKernel {
                 absl::InvalidArgumentError(
                     absl::StrCat("Input tensor must be at least 2D: ",
                                  output_backprop.shape().DebugString())));
+    OP_REQUIRES(
+        context,
+        data_format_ != FORMAT_NCHW || output_backprop.shape().dims() >= 3,
+        absl::InvalidArgumentError(absl::StrCat(
+            "NCHW format requires input tensor to be at least 3D: ",
+            output_backprop.shape().DebugString())));
     int32_t batch, height, width, depth, channel;
     GetBiasValueDims(output_backprop, data_format_, &batch, &height, &width,
                      &depth, &channel);

--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -130,6 +130,7 @@ py_library(
         "//tensorflow/python/ops:math_ops",
         "//tensorflow/python/ops:nn_grad",
         "//tensorflow/python/ops:nn_ops",
+        "//tensorflow/python/ops:nn_ops_gen",
         "//tensorflow/python/platform:client_testlib",
         "//third_party/py/numpy",
     ],

--- a/tensorflow/python/kernel_tests/nn_ops/bias_op_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/bias_op_base.py
@@ -23,6 +23,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_nn_ops
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import gradients_impl
@@ -111,6 +112,34 @@ class BiasAddTestBase(test.TestCase):
       nn_ops.bias_add(
           array_ops.reshape([1, 2], shape=[1, 2]),
           array_ops.reshape([1], shape=[1]))
+
+  def testNCHWRankTooLow(self):
+    # A rank-2 NCHW input aborted the GPU kernel with a CHECK failure
+    # (issue #94379); the added OP_REQUIRES makes the kernel raise
+    # InvalidArgumentError instead. Checked in eager only: in graph mode
+    # BiasAddShape rejects rank-2 NCHW at construction (WithRankAtLeast 3, a
+    # ValueError) before the kernel runs, so a graph-mode test would exercise
+    # the pre-existing shape function rather than this guard. Eager places the
+    # op on GPU when one is present and on CPU otherwise.
+    if not context.executing_eagerly():
+      self.skipTest("kernel guard is reachable only in eager mode")
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "at least 3D"):
+      nn_ops.bias_add(
+          array_ops.ones([2, 6], dtype=dtypes.float32),
+          array_ops.ones([6], dtype=dtypes.float32),
+          data_format="NCHW")
+
+  def testNCHWRankTooLowGrad(self):
+    # BiasAddGrad has the same NCHW rank requirement and the same eager-only
+    # kernel guard as the forward op (see testNCHWRankTooLow).
+    if not context.executing_eagerly():
+      self.skipTest("kernel guard is reachable only in eager mode")
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "at least 3D"):
+      gen_nn_ops.bias_add_grad(
+          array_ops.ones([2, 6], dtype=dtypes.float32),
+          data_format="NCHW")
 
   def testIntTypes(self):
     for t in [np.int8, np.int16, np.int32, np.int64]:


### PR DESCRIPTION
Fixes #94379

## Problem

`tf.raw_ops.BiasAdd` with `data_format="NCHW"` and a rank-2 input aborts the process on GPU with a fatal CHECK failure instead of returning an error:

```python
import tensorflow as tf
with tf.device('/gpu:0'):
    value = tf.constant([0] * 12, dtype=tf.int32, shape=[2, 6])
    bias = tf.constant([1, 2, 3, 4, 5, 6], dtype=tf.int32, shape=[6])
    tf.raw_ops.BiasAdd(value=value, bias=bias, data_format="NCHW")
```

```
F tensorflow/core/framework/tensor_shape.cc:359] Check failed: d < dims() (2 vs. 2)
Aborted (core dumped)
```

## Root cause

`GetBiasValueDims` (`tensorflow/core/kernels/bias_op.cc`) reads the NCHW height as `value_tensor.dim_size(2)` with no guard that the input has at least 3 dimensions. The width and depth reads on the following lines are guarded (`dims() > 3` and `dims() > 4`), but the height read is not. For a rank-2 NCHW input, `dim_size(2)` trips the `d < dims()` CHECK in `TensorShape` and aborts.

`GetBiasValueDims` is called only from the GPU kernels, `BiasOp<GPUDevice>::Compute` and `BiasGradOp<GPUDevice>::Compute`, so only the GPU path reaches the crash. The forward and gradient ops share the same gap.

## Fix

Add an `OP_REQUIRES` that rejects NCHW inputs below rank 3 with `InvalidArgumentError`, in all four Compute methods (CPU and GPU, forward and gradient), right after the existing "at least 2D" check. NCHW is defined for rank 3 and above: `GetBiasValueDims` reads dims 0, 1, and 2; sibling ops such as MaxPool and FusedBatchNorm require rank 4; and BiasAdd's own Python tests pad every NCHW input to at least rank 3 before use.

This changes CPU behavior. CPU currently accepts a rank-2 NCHW input and returns a result (the flat path computes the correct values because the channel is the last dimension at rank 2). This change makes CPU raise `InvalidArgumentError` instead, matching how the op and its tests already treat NCHW as at least 3D. If you would rather keep the lenient CPU path and fix only the GPU dimension read, I can switch to that.

## Testing

Added `testNCHWRankTooLow` and `testNCHWRankTooLowGrad` to `bias_op_base.py`, covering the forward and the gradient op. Each runs in eager mode and asserts that a rank-2 NCHW input raises `InvalidArgumentError`. The tests are eager-only on purpose: in graph mode `BiasAddShape` / `BiasAddGradShape` already reject a static rank-2 NCHW input at construction (`WithRankAtLeast(input, 3)`, a `ValueError`) before the kernel runs, so a graph-mode test would exercise the existing shape function rather than this kernel guard. Eager execution reaches the kernel and places the op on GPU when one is present, so the CPU and GPU presubmit jobs cover the CPU and GPU guards respectively.
