### PR TITLE
Fix type promotion and input handling in tnp.logaddexp and tnp.logaddexp2

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -558,7 +558,7 @@ def logaddexp2(x1, x2):
     return np_array_ops.where(
         isnan(delta),
         x1 + x2,  # NaNs or infinities of the same sign.
-        amax + log1p(exp2(-abs(delta))) / np.log(2),
+        amax + log1p(exp2(-abs(delta))) / math_ops.cast(np.log(2), x1.dtype),
     )
 
   return _bin_op(f, x1, x2)

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -529,25 +529,39 @@ def outer(a, b):
 @tf_export.tf_export('experimental.numpy.logaddexp', v1=[])
 @np_utils.np_doc('logaddexp')
 def logaddexp(x1, x2):
-  amax = maximum(x1, x2)
-  delta = x1 - x2
-  return np_array_ops.where(
-      isnan(delta),
-      x1 + x2,  # NaNs or infinities of the same sign.
-      amax + log1p(exp(-abs(delta))),
-  )
+  def f(x1, x2):
+    if not np.issubdtype(x1.dtype.as_numpy_dtype, np.inexact):
+      float_dtype = np_utils.result_type(float)
+      x1 = math_ops.cast(x1, float_dtype)
+      x2 = math_ops.cast(x2, float_dtype)
+    amax = maximum(x1, x2)
+    delta = x1 - x2
+    return np_array_ops.where(
+        isnan(delta),
+        x1 + x2,  # NaNs or infinities of the same sign.
+        amax + log1p(exp(-abs(delta))),
+    )
+
+  return _bin_op(f, x1, x2)
 
 
 @tf_export.tf_export('experimental.numpy.logaddexp2', v1=[])
 @np_utils.np_doc('logaddexp2')
 def logaddexp2(x1, x2):
-  amax = maximum(x1, x2)
-  delta = x1 - x2
-  return np_array_ops.where(
-      isnan(delta),
-      x1 + x2,  # NaNs or infinities of the same sign.
-      amax + log1p(exp2(-abs(delta))) / np.log(2),
-  )
+  def f(x1, x2):
+    if not np.issubdtype(x1.dtype.as_numpy_dtype, np.inexact):
+      float_dtype = np_utils.result_type(float)
+      x1 = math_ops.cast(x1, float_dtype)
+      x2 = math_ops.cast(x2, float_dtype)
+    amax = maximum(x1, x2)
+    delta = x1 - x2
+    return np_array_ops.where(
+        isnan(delta),
+        x1 + x2,  # NaNs or infinities of the same sign.
+        amax + log1p(exp2(-abs(delta))) / np.log(2),
+    )
+
+  return _bin_op(f, x1, x2)
 
 
 @tf_export.tf_export('experimental.numpy.polyval', v1=[])

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_no_numpy_methods_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_no_numpy_methods_test.py
@@ -126,6 +126,28 @@ class MathWithoutNumpyMethodsOnTensorTest(test.TestCase):
           err_msg='average({})'.format(arg),
       )
 
+  def testLogaddexpAcceptsIntegerInputs(self):
+    # `logaddexp` and `logaddexp2` promote integer arguments to a float dtype,
+    # which must not depend on `enable_numpy_methods_on_tensor()`.
+    x1 = np.array([1, 2, 3], dtype=np.int32)
+    for x2 in (np.int32(1), np.array([4, 5, 6], dtype=np.int32)):
+      actual = np_math_ops.logaddexp(x1, x2)
+      np.testing.assert_allclose(
+          np.asarray(actual),
+          np.logaddexp(x1, x2),
+          rtol=1e-6,
+          atol=1e-6,
+          err_msg='logaddexp({}, {})'.format(x1, x2),
+      )
+      actual2 = np_math_ops.logaddexp2(x1, x2)
+      np.testing.assert_allclose(
+          np.asarray(actual2),
+          np.logaddexp2(x1, x2),
+          rtol=1e-6,
+          atol=1e-6,
+          err_msg='logaddexp2({}, {})'.format(x1, x2),
+      )
+
   def testFloatInputsAreUnchanged(self):
     arg = np.array([1.5, 2.5, 3.5], dtype=np.float32)
     for name, tf_fun, np_fun in _PROMOTING_UNARY_OPS:

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -207,6 +207,30 @@ class MathTest(test.TestCase, parameterized.TestCase):
     expected = np.hypot(x, y)
     np.testing.assert_equal(actual.tolist(), expected.tolist())
 
+  def testLogaddexp(self):
+    self._testBinaryOp(np_math_ops.logaddexp, np.logaddexp, 'logaddexp')
+    self._testBinaryOp(np_math_ops.logaddexp2, np.logaddexp2, 'logaddexp2')
+
+  def testLogaddexpNonFloatInputs(self):
+    int_args = [
+        ([1, 2, 3], [4, 5, 6]),
+        (np.array([1, 2], dtype=np.int32), np.array([3, 4], dtype=np.int32)),
+        (np.array([1, 2], dtype=np.int64), np.array([3, 4], dtype=np.int64)),
+        (1, 2),
+        ([1.0, 2.0], [3.0, 4.0]),
+    ]
+    for x1, x2 in int_args:
+      self.match(
+          np_math_ops.logaddexp(x1, x2),
+          np.logaddexp(np.asarray(x1), np.asarray(x2)),
+          msg='logaddexp({}, {})'.format(x1, x2),
+      )
+      self.match(
+          np_math_ops.logaddexp2(x1, x2),
+          np.logaddexp2(np.asarray(x1), np.asarray(x2)),
+          msg='logaddexp2({}, {})'.format(x1, x2),
+      )
+
   def match(self, actual, expected, msg='', check_dtype=True):
     self.assertIsInstance(actual, np_arrays.ndarray)
     if check_dtype:


### PR DESCRIPTION
### Problem
`tf.experimental.numpy.logaddexp` and `tf.experimental.numpy.logaddexp2` previously did not use `_bin_op` and performed raw Python arithmetic on their input arguments. This caused:
1. Python sequences / lists (e.g., `tnp.logaddexp([1.0, 2.0], [3.0, 4.0])`) to fail with `TypeError: unsupported operand type(s) for -: 'list' and 'list'`.
2. Integer tensors / scalars (e.g., `tnp.logaddexp(1, 2)` or `tnp.logaddexp(tnp.array([1, 2]), tnp.array([3, 4]))`) to fail with `InvalidArgumentError: cannot compute AddV2 as input #1(zero-based) was expected to be a int32 tensor but is a double tensor [Op:AddV2]` because `amax` was not promoted to floating-point while `log1p(exp(-abs(delta)))` was.
3. Mixed-precision inputs (e.g., `float32` and `float64`) to fail without binary type promotion.

### Solution
- Wrap `logaddexp` and `logaddexp2` in `_bin_op` to handle array conversion and binary type promotion consistently with other binary ops in `np_math_ops.py`.
- In the op body, if the promoted operand dtype is not inexact (floating-point or complex), cast operands to `np_utils.result_type(float)` via `math_ops.cast`.
- Ensure `np.log(2)` in `logaddexp2` is cast to the operand dtype to preserve input floating-point precision (`float32`, `float64`, etc.).
- Add unit test coverage in `np_math_ops_test.py` and `np_math_ops_no_numpy_methods_test.py`.
