### PR TITLE
Fix tnp.eye column count when M=0

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -100,7 +100,7 @@ def ones_like(a, dtype=None):
 def eye(N, M=None, k=0, dtype=float):  # pylint: disable=invalid-name,missing-docstring
   if dtype:
     dtype = np_utils.result_type(dtype)
-  if not M:
+  if M is None:
     M = N
   # Making sure N, M and k are `int`
   N = int(N)

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -230,6 +230,13 @@ class ArrayCreationTest(test.TestCase):
                 np_array_ops.eye(n, m, k, dtype=dtype),
                 np.eye(n, m, k, dtype=dtype))
 
+    # Test M=0 and N=0 zero-dimension edge cases
+    for n in (0, 1, 3):
+      for m in (0, 1, 3):
+        self.match(np_array_ops.eye(n, m), np.eye(n, m))
+        for k in range(-n - 1, m + 2):
+          self.match(np_array_ops.eye(n, m, k), np.eye(n, m, k))
+
   def testIdentity(self):
     n_max = 3
 


### PR DESCRIPTION
### Problem
In `tf.experimental.numpy.eye`, passing `M=0` (e.g. `tnp.eye(3, 0)`) resulted in an `(N, N)` identity matrix rather than an `(N, 0)` matrix with 0 columns.

This occurred because `eye` checked `if not M: M = N`, evaluating `not 0` as `True` and overwriting `M = 0` with `M = N`.

### Solution
- Change the default parameter check in `np_array_ops.eye` from `if not M:` to `if M is None:`, matching the behavior of `np_array_ops.tri` and standard NumPy semantics where `M` defaults to `N` only when omitted (`None`).
- Add test coverage for `M=0` and `N=0` across multiple diagonals `k` in `np_array_ops_test.py`.
