### PR TITLE
Fix crash during CoreML delegate teardown on iOS 17+

### DIFF
--- a/tensorflow/lite/delegates/coreml/BUILD
+++ b/tensorflow/lite/delegates/coreml/BUILD
@@ -85,6 +85,7 @@ objc_library(
         ":coreml_executor",
         ":mlmodel_proto_cc",
         "//tensorflow/lite:kernel_api",
+        "//tensorflow/lite:minimal_logging",
         "//tensorflow/lite/core/c:common",
         "//tensorflow/lite/delegates/coreml/builders:op_builder",
         "//tensorflow/lite/kernels:kernel_util",

--- a/tensorflow/lite/delegates/coreml/coreml_delegate_kernel.mm
+++ b/tensorflow/lite/delegates/coreml/coreml_delegate_kernel.mm
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/minimal_logging.h"
 
 #import "tensorflow/lite/delegates/coreml/coreml_executor.h"
 
@@ -262,7 +263,15 @@ TfLiteStatus CoreMlDelegateKernel::Invoke(TfLiteContext* context, TfLiteNode* no
   }
 }
 
-CoreMlDelegateKernel::~CoreMlDelegateKernel() { [executor_ cleanup]; }
+CoreMlDelegateKernel::~CoreMlDelegateKernel() {
+  @try {
+    [executor_ cleanup];
+  } @catch (NSException* exception) {
+    TFLITE_LOG_PROD(tflite::TFLITE_LOG_ERROR,
+                    "Exception during CoreML cleanup: %s",
+                    [exception.reason UTF8String]);
+  }
+}
 
 }  // namespace coreml
 }  // namespace delegates

--- a/tensorflow/lite/delegates/coreml/coreml_delegate_kernel.mm
+++ b/tensorflow/lite/delegates/coreml/coreml_delegate_kernel.mm
@@ -267,9 +267,10 @@ CoreMlDelegateKernel::~CoreMlDelegateKernel() {
   @try {
     [executor_ cleanup];
   } @catch (NSException* exception) {
+    const char* reason = [exception.reason UTF8String];
     TFLITE_LOG_PROD(tflite::TFLITE_LOG_ERROR,
                     "Exception during CoreML cleanup: %s",
-                    [exception.reason UTF8String]);
+                    reason ? reason : "Unknown reason");
   }
 }
 

--- a/tensorflow/lite/delegates/coreml/coreml_executor.h
+++ b/tensorflow/lite/delegates/coreml/coreml_executor.h
@@ -42,7 +42,7 @@ struct TensorData {
 - (bool)cleanup;
 
 @property MLModel* model API_AVAILABLE(ios(11));
-@property NSString* mlModelFilePath;
-@property NSString* compiledModelFilePath;
+@property(copy) NSString* mlModelFilePath;
+@property(copy) NSString* compiledModelFilePath;
 @property(nonatomic, readonly) int coreMlVersion;
 @end

--- a/tensorflow/lite/delegates/coreml/coreml_executor.h
+++ b/tensorflow/lite/delegates/coreml/coreml_executor.h
@@ -42,7 +42,7 @@ struct TensorData {
 - (bool)cleanup;
 
 @property MLModel* model API_AVAILABLE(ios(11));
-@property(copy) NSString* mlModelFilePath;
-@property(copy) NSString* compiledModelFilePath;
+@property(nonatomic, copy) NSString* mlModelFilePath;
+@property(nonatomic, copy) NSString* compiledModelFilePath;
 @property(nonatomic, readonly) int coreMlVersion;
 @end

--- a/tensorflow/lite/delegates/coreml/coreml_executor.mm
+++ b/tensorflow/lite/delegates/coreml/coreml_executor.mm
@@ -166,27 +166,27 @@ NSURL* createTemporaryFile() {
 - (bool)cleanup {
   NSError* error = nil;
   NSFileManager* fileManager = [NSFileManager defaultManager];
+  bool success = true;
   if (_mlModelFilePath.length > 0 && [fileManager fileExistsAtPath:_mlModelFilePath]) {
-    [fileManager removeItemAtPath:_mlModelFilePath error:&error];
-    if (error != nil) {
+    if (![fileManager removeItemAtPath:_mlModelFilePath error:&error]) {
       NSLog(@"Failed cleaning up model: %@", [error localizedDescription]);
-      return NO;
+      success = false;
     }
   }
+  error = nil;
   if (_compiledModelFilePath.length > 0 && [fileManager fileExistsAtPath:_compiledModelFilePath]) {
-    [fileManager removeItemAtPath:_compiledModelFilePath error:&error];
-    if (error != nil) {
+    if (![fileManager removeItemAtPath:_compiledModelFilePath error:&error]) {
       NSLog(@"Failed cleaning up compiled model: %@", [error localizedDescription]);
-      return NO;
+      success = false;
     }
   }
-  return YES;
+  return success;
 }
 
 - (NSURL*)saveModel:(CoreML::Specification::Model*)model {
   NSURL* modelUrl = createTemporaryFile();
   NSString* modelPath = [modelUrl path];
-  _mlModelFilePath = modelPath;
+  self.mlModelFilePath = modelPath;
   if (model->specificationversion() == 3) {
     _coreMlVersion = 2;
   } else if (model->specificationversion() == 4) {
@@ -209,8 +209,8 @@ NSURL* createTemporaryFile() {
     NSLog(@"Error compiling model %@", [error localizedDescription]);
     return NO;
   }
-  _mlModelFilePath = [modelUrl path];
-  _compiledModelFilePath = [compileUrl path];
+  self.mlModelFilePath = [modelUrl path];
+  self.compiledModelFilePath = [compileUrl path];
 
   if (@available(iOS 12.0, *)) {
     MLModelConfiguration* config = [[MLModelConfiguration alloc] init];

--- a/tensorflow/lite/delegates/coreml/coreml_executor.mm
+++ b/tensorflow/lite/delegates/coreml/coreml_executor.mm
@@ -165,15 +165,20 @@ NSURL* createTemporaryFile() {
 
 - (bool)cleanup {
   NSError* error = nil;
-  [[NSFileManager defaultManager] removeItemAtPath:_mlModelFilePath error:&error];
-  if (error != nil) {
-    NSLog(@"Failed cleaning up model: %@", [error localizedDescription]);
-    return NO;
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+  if (_mlModelFilePath.length > 0 && [fileManager fileExistsAtPath:_mlModelFilePath]) {
+    [fileManager removeItemAtPath:_mlModelFilePath error:&error];
+    if (error != nil) {
+      NSLog(@"Failed cleaning up model: %@", [error localizedDescription]);
+      return NO;
+    }
   }
-  [[NSFileManager defaultManager] removeItemAtPath:_compiledModelFilePath error:&error];
-  if (error != nil) {
-    NSLog(@"Failed cleaning up compiled model: %@", [error localizedDescription]);
-    return NO;
+  if (_compiledModelFilePath.length > 0 && [fileManager fileExistsAtPath:_compiledModelFilePath]) {
+    [fileManager removeItemAtPath:_compiledModelFilePath error:&error];
+    if (error != nil) {
+      NSLog(@"Failed cleaning up compiled model: %@", [error localizedDescription]);
+      return NO;
+    }
   }
   return YES;
 }
@@ -181,6 +186,7 @@ NSURL* createTemporaryFile() {
 - (NSURL*)saveModel:(CoreML::Specification::Model*)model {
   NSURL* modelUrl = createTemporaryFile();
   NSString* modelPath = [modelUrl path];
+  _mlModelFilePath = modelPath;
   if (model->specificationversion() == 3) {
     _coreMlVersion = 2;
   } else if (model->specificationversion() == 4) {


### PR DESCRIPTION
On iOS 17+, `[NSFileManager removeItemAtPath:]` throws an `NSInvalidArgumentException` if given a nil or dangling path due to Swift Foundation string bridging. In the CoreML delegate, `mlModelFilePath` and `compiledModelFilePath` defaulted to `assign` (resulting in dangling pointers after autorelease pool drains), and any thrown exception inside `~CoreMlDelegateKernel()` caused an immediate `std::terminate()`.

Fixes:
- Use `@property(copy)` for file path properties in `CoreMlExecutor`.
- Guard `cleanup` by checking string length and file existence before removing files.
- Set `_mlModelFilePath` early in `saveModel:` to avoid leaking temp files if compilation fails.
- Wrap `[executor_ cleanup]` in `@try/@catch` inside `~CoreMlDelegateKernel()` and log errors via `TFLITE_LOG_PROD`.