### PR TITLE
Fix heap buffer overflows in TFLite kernels by clamping memcpy lengths

### DIFF
--- a/tensorflow/lite/kernels/bitcast.cc
+++ b/tensorflow/lite/kernels/bitcast.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
 
@@ -90,7 +91,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   // Only copy data if input and output do not share a buffer.
   if (output->data.data != input->data.data) {
-    memcpy(output->data.data, input->data.data, input->bytes);
+    // Clamp the copy length to the destination size. `input->bytes` is
+    // derived from the raw FlatBuffer buffer size for constant tensors
+    // and may be inflated relative to the logical shape, so it must be
+    // bounded by `output->bytes` to avoid an out-of-bounds write.
+    memcpy(output->data.data, input->data.data,
+           std::min(input->bytes, output->bytes));
   }
   return kTfLiteOk;
 }

--- a/tensorflow/lite/kernels/bitcast_test.cc
+++ b/tensorflow/lite/kernels/bitcast_test.cc
@@ -155,5 +155,39 @@ TEST(BitcastOpModel, BitcastInt16ToUint32WrongShape) {
 #endif
 }
 
+class BitcastConstInputOpModel : public SingleOpModel {
+ public:
+  BitcastConstInputOpModel(const TensorData& input, const TensorData& output,
+                           const std::vector<int8_t>& data) {
+    input_ = AddConstInput(input, data);
+    output_ = AddOutput(output);
+    SetBuiltinOp(BuiltinOperator_BITCAST, BuiltinOptions_BitcastOptions,
+                 CreateBitcastOptions(builder_).Union());
+    BuildInterpreter({GetShape(input_)});
+  }
+
+  int output() const { return output_; }
+
+ private:
+  int input_;
+  int output_;
+};
+
+// A constant tensor's raw FlatBuffer buffer may legally be larger than
+// its logical shape requires; the model loader only validates
+// required_bytes <= buffer_size. The copy into the output must be
+// bounded by the output allocation, not by the raw buffer length.
+TEST(BitcastOpModel, ConstantInputWithOversizedBuffer) {
+  std::vector<int8_t> input_data(1 << 12);
+  for (int i = 0; i < 4; ++i) {
+    input_data[i] = i + 1;
+  }
+  BitcastConstInputOpModel m({TensorType_INT8, {4}}, {TensorType_UINT8, {4}},
+                             input_data);
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.ExtractVector<uint8_t>(m.output()),
+              ElementsAreArray({1, 2, 3, 4}));
+}
+
 }  // namespace
 }  // namespace tflite

--- a/tensorflow/lite/kernels/expand_dims.cc
+++ b/tensorflow/lite/kernels/expand_dims.cc
@@ -15,6 +15,7 @@ limitations under the License.
 #include <stdint.h>
 #include <string.h>
 
+#include <algorithm>
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
 #include "tensorflow/lite/kernels/internal/tensor.h"
@@ -120,7 +121,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   }
   // Only copy data if input and output do not share a buffer.
   if (output->data.data != input->data.data) {
-    memcpy(output->data.data, input->data.data, input->bytes);
+    // Clamp the copy length to the destination size. `input->bytes` is
+    // derived from the raw FlatBuffer buffer size for constant tensors
+    // and may be inflated relative to the logical shape, so it must be
+    // bounded by `output->bytes` to avoid an out-of-bounds write.
+    memcpy(output->data.data, input->data.data,
+           std::min(input->bytes, output->bytes));
   }
   return kTfLiteOk;
 }

--- a/tensorflow/lite/kernels/expand_dims_test.cc
+++ b/tensorflow/lite/kernels/expand_dims_test.cc
@@ -141,5 +141,45 @@ TEST(ExpandDimsOpTest, StrTensor) {
   EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 3}));
 }
 
+template <typename InputType>
+class ExpandDimsConstInputOpModel : public SingleOpModel {
+ public:
+  ExpandDimsConstInputOpModel(int axis, std::initializer_list<int> input_shape,
+                              const std::vector<InputType>& input_data) {
+    input_ = AddConstInput(GetTensorType<InputType>(), input_data, input_shape);
+    axis_ = AddConstInput(TensorType_INT32, {axis}, {1});
+    output_ = AddOutput(GetTensorType<InputType>());
+    SetBuiltinOp(BuiltinOperator_EXPAND_DIMS, BuiltinOptions_ExpandDimsOptions,
+                 0);
+    BuildInterpreter({input_shape, {1}});
+  }
+
+  std::vector<InputType> GetValues() {
+    return ExtractVector<InputType>(output_);
+  }
+  std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
+
+ private:
+  int input_;
+  int axis_;
+  int output_;
+};
+
+// A constant tensor's raw FlatBuffer buffer may legally be larger than its
+// logical shape requires; the model loader only validates
+// required_bytes <= buffer_size. The copy into the output must be
+// bounded by the output allocation, not by the raw buffer length.
+TYPED_TEST(ExpandDimsOpTest, ConstantInputWithOversizedBuffer) {
+  const std::vector<TypeParam> logical{-1, 1, -2, 2};
+  std::vector<TypeParam> input_data(1 << 12);
+  for (int i = 0; i < 4; ++i) {
+    input_data[i] = logical[i];
+  }
+  ExpandDimsConstInputOpModel<TypeParam> m(0, {2, 2}, input_data);
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetValues(), ElementsAreArray(logical));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 2, 2}));
+}
+
 }  // namespace
 }  // namespace tflite

--- a/tensorflow/lite/kernels/hadamard_rotation.cc
+++ b/tensorflow/lite/kernels/hadamard_rotation.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -174,7 +175,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     input_feature_size = input_tensor->dims->data[2];
   }
 
-  memcpy(output->data.f, input_tensor->data.f, input_tensor->bytes);
+    // Clamp the copy length to the destination size. `input_tensor->bytes` is
+    // derived from the raw FlatBuffer buffer size for constant tensors
+    // and may be inflated relative to the logical shape, so it must be
+    // bounded by `output->bytes` to avoid an out-of-bounds write.
+  memcpy(output->data.f, input_tensor->data.f,
+         std::min(input_tensor->bytes, output->bytes));
 
   const int num_hadamards_per_feature = input_feature_size / hadamard_size;
   const int total_transforms =

--- a/tensorflow/lite/kernels/hadamard_rotation_test.cc
+++ b/tensorflow/lite/kernels/hadamard_rotation_test.cc
@@ -39,8 +39,13 @@ using ::testing::Values;
 class BaseHadamardRotationOpModel : public SingleOpModel {
  public:
   BaseHadamardRotationOpModel(const int size, const TensorData& input,
-                              const TensorData& output) {
-    input1_ = AddInput(input);
+                              const TensorData& output,
+                              const std::vector<float>* const_input = nullptr) {
+    if (const_input != nullptr) {
+      input1_ = AddConstInput(input, *const_input);
+    } else {
+      input1_ = AddInput(input);
+    }
     output1_ = AddOutput(output);
 
     flexbuffers::Builder fbb;
@@ -166,6 +171,26 @@ TEST_P(HadamardRotationOpTest, RandomInputTest) {
 
 INSTANTIATE_TEST_SUITE_P(HadamardSizes, HadamardRotationOpTest,
                          Values(4, 16, 64));
+
+// A constant tensor's raw FlatBuffer buffer may legally be larger than
+// its logical shape requires; the model loader only validates
+// required_bytes <= buffer_size. The copy into the output must be
+// bounded by the output allocation, not by the raw buffer length.
+TEST(HadamardRotationOpTest, ConstantInputWithOversizedBuffer) {
+  const int size = 2;
+  std::vector<float> input_data(1 << 12, 1.0);
+  BaseHadamardRotationOpModel m(size, {TensorType_FLOAT32, {1, size * 2}},
+                                {TensorType_FLOAT32, {1, size * 2}},
+                                &input_data);
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  std::vector<float> output = m.GetOutput1<float>();
+  EXPECT_FLOAT_EQ(output[0], std::sqrt(size));
+  EXPECT_FLOAT_EQ(output[size], std::sqrt(size));
+  for (int i = 1; i < size; ++i) {
+    EXPECT_FLOAT_EQ(output[i], 0.0);
+    EXPECT_FLOAT_EQ(output[size + i], 0.0);
+  }
+}
 
 }  // namespace
 }  // namespace custom

--- a/tensorflow/lite/kernels/reshape.cc
+++ b/tensorflow/lite/kernels/reshape.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
 
@@ -139,7 +140,12 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
         SetTensorToPersistentRo(output);
         TF_LITE_ENSURE_OK(context, ResizeOutput(context, node));
         op_data->output_ptr = output->data.data;
-        memcpy(output->data.data, input->data.data, input->bytes);
+    // Clamp the copy length to the destination size. `input->bytes` is
+    // derived from the raw FlatBuffer buffer size for constant tensors
+    // and may be inflated relative to the logical shape, so it must be
+    // bounded by `output->bytes` to avoid an out-of-bounds write.
+        memcpy(output->data.data, input->data.data,
+               std::min(input->bytes, output->bytes));
       } else {
         TF_LITE_ENSURE_OK(context, ResizeOutput(context, node));
       }
@@ -208,7 +214,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   }
   // Only copy data if input and output do not share a buffer.
   if (output->data.data != input->data.data) {
-    memcpy(output->data.data, input->data.data, input->bytes);
+    // Clamp the copy length to the destination size. `input->bytes` is
+    // derived from the raw FlatBuffer buffer size for constant tensors
+    // and may be inflated relative to the logical shape, so it must be
+    // bounded by `output->bytes` to avoid an out-of-bounds write.
+    memcpy(output->data.data, input->data.data,
+           std::min(input->bytes, output->bytes));
   }
 
   return kTfLiteOk;

--- a/tensorflow/lite/kernels/reshape_test.cc
+++ b/tensorflow/lite/kernels/reshape_test.cc
@@ -266,6 +266,39 @@ TYPED_TEST(ReshapeOpTest, Strings) {
   }
 }
 
+// A constant tensor's raw FlatBuffer buffer may legally be larger than
+// its logical shape requires; the model loader only validates
+// required_bytes <= buffer_size. The copy into the output must be
+// bounded by the output allocation, not by the raw buffer length.
+TYPED_TEST(ReshapeOpTest, ConstantInputWithOversizedBuffer) {
+  std::vector<TypeParam> logical{1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<TypeParam> input_data(1 << 12);
+  for (int i = 0; i < 8; ++i) {
+    input_data[i] = logical[i];
+  }
+  ReshapeOpModel<TypeParam> m({1, 2, 4, 1}, {3}, {2, 2, 2},
+                              ShapeSpecificationType::kAsReshapeOption,
+                              &input_data);
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(logical));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+// Same oversized constant input, but with the new shape supplied as a
+// non-constant tensor, so the copy happens in Eval() instead of Prepare().
+TYPED_TEST(ReshapeOpTest, ConstantInputWithOversizedBufferDynamicShape) {
+  std::vector<TypeParam> logical{1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<TypeParam> input_data(1 << 12);
+  for (int i = 0; i < 8; ++i) {
+    input_data[i] = logical[i];
+  }
+  ReshapeOpModel<TypeParam> m({1, 2, 4, 1}, {1}, {8},
+                              ShapeSpecificationType::kAsTensor, &input_data);
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(logical));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({8}));
+}
+
 TEST(ReshapeShapeResolverTest, ResolvesInferredDimension) {
   TfLiteContext context = MakeSilentContext();
   RuntimeShape input_shape = MakeRuntimeShape({2, 3, 4});

--- a/tensorflow/lite/kernels/roll.cc
+++ b/tensorflow/lite/kernels/roll.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <algorithm>
 #include <cstring>
 #include <vector>
 
@@ -38,7 +39,13 @@ std::vector<int32_t> ExtractIntegerVector(const TfLiteTensor* t) {
   const RuntimeShape& shape = GetTensorShape(t);
   std::vector<int32_t> result(shape.FlatSize());
   if (t->type == kTfLiteInt32) {
-    memcpy(result.data(), t->data.raw_const, t->bytes);
+    // Clamp the copy length to the destination size. `t->bytes` is
+    // derived from the raw FlatBuffer buffer size for constant tensors
+    // and may be inflated relative to the logical shape, so it must be
+    // bounded by the destination allocation to avoid an out-of-bounds
+    // write.
+    memcpy(result.data(), t->data.raw_const,
+           std::min(t->bytes, result.size() * sizeof(int32_t)));
   } else {
     const int64_t* data = GetTensorData<int64_t>(t);
     for (int i = 0; i < result.size(); ++i) {

--- a/tensorflow/lite/kernels/roll_test.cc
+++ b/tensorflow/lite/kernels/roll_test.cc
@@ -31,15 +31,22 @@ using ::testing::ElementsAreArray;
 class BaseRollOpModel : public SingleOpModel {
  public:
   BaseRollOpModel(TensorData input, const std::vector<int32_t>& shift,
-                  const std::vector<int64_t>& axis, TensorData output) {
+                  const std::vector<int64_t>& axis, TensorData output,
+                  const std::vector<int32_t>* const_shift = nullptr) {
     if (input.type == TensorType_FLOAT32 || input.type == TensorType_INT64) {
       // Clear quantization params.
       input.min = input.max = 0.f;
       output.min = output.max = 0.f;
     }
     input_ = AddInput(input);
-    shift_ = AddInput(
-        TensorData(TensorType_INT32, {static_cast<int>(shift.size())}));
+    if (const_shift != nullptr) {
+      shift_ = AddConstInput(
+          TensorData(TensorType_INT32, {static_cast<int>(shift.size())}),
+          *const_shift);
+    } else {
+      shift_ = AddInput(
+          TensorData(TensorType_INT32, {static_cast<int>(shift.size())}));
+    }
     axis_ =
         AddInput(TensorData(TensorType_INT64, {static_cast<int>(axis.size())}));
     output_ = AddOutput(output);
@@ -47,7 +54,9 @@ class BaseRollOpModel : public SingleOpModel {
     SetCustomOp("Roll", {}, ops::custom::Register_ROLL);
     BuildInterpreter({GetShape(input_), GetShape(shift_), GetShape(axis_)});
 
-    PopulateTensor(shift_, shift);
+    if (const_shift == nullptr) {
+      PopulateTensor(shift_, shift);
+    }
     PopulateTensor(axis_, axis);
   }
 
@@ -192,6 +201,22 @@ TEST(RollOpTest, BoolRoll3D) {
                                 true,  true,  true,  true,  false, false, true,
                                 false, false, false, false, true,  false, false,
                                 false, true,  false, false}));
+}
+
+// A constant tensor's raw FlatBuffer buffer may legally be larger than
+// its logical shape requires; the model loader only validates
+// required_bytes <= buffer_size. The copy into the output must be
+// bounded by the output allocation, not by the raw buffer length.
+TEST(RollOpTest, ConstShiftWithOversizedBuffer) {
+  std::vector<int32_t> shift(1 << 12, 3);
+  BaseRollOpModel m(
+      /*input=*/{TensorType_FLOAT32, {10}, 0, 31.875},
+      /*shift=*/{3}, /*axis=*/{0},
+      /*output=*/{TensorType_FLOAT32, {}, 0, 31.875}, &shift);
+  m.SetInput<float>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput<float>(),
+              ElementsAreArray({7, 8, 9, 0, 1, 2, 3, 4, 5, 6}));
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/kernels/stablehlo_scatter.cc
+++ b/tensorflow/lite/kernels/stablehlo_scatter.cc
@@ -220,7 +220,12 @@ TfLiteStatus EvalWithTypes(TfLiteContext* context, TfLiteNode* node) {
                     GetOutputSafe(context, node, kOutputTensor, &output));
 
   // First copy all of the data to the output before applying the updates.
-  memcpy(output->data.data, input->data.data, input->bytes);
+    // Clamp the copy length to the destination size. `input->bytes` is
+    // derived from the raw FlatBuffer buffer size for constant tensors
+    // and may be inflated relative to the logical shape, so it must be
+    // bounded by `output->bytes` to avoid an out-of-bounds write.
+  memcpy(output->data.data, input->data.data,
+         std::min(input->bytes, output->bytes));
 
   RuntimeShape input_shape = GetTensorShape(input);
   int input_rank = input_shape.DimensionsCount();

--- a/tensorflow/lite/kernels/stablehlo_scatter_test.cc
+++ b/tensorflow/lite/kernels/stablehlo_scatter_test.cc
@@ -39,8 +39,13 @@ class StablehloScatterOpModel : public SingleOpModel {
   StablehloScatterOpModel(const TensorData& input, const TensorData& indices,
                           const TensorData& updates,
                           const TfLiteStablehloScatterParams& params,
-                          StablehloScatterOpType op_type) {
-    input_ = AddInput(input);
+                          StablehloScatterOpType op_type,
+                          const std::vector<float>* const_input = nullptr) {
+    if (const_input != nullptr) {
+      input_ = AddConstInput(input, *const_input);
+    } else {
+      input_ = AddInput(input);
+    }
     indices_ = AddInput(indices);
     updates_ = AddInput(updates);
     output_ = AddOutput(input.type);
@@ -267,6 +272,46 @@ TEST(StablehloScatterOpTest, PerformsUpdate) {
   ASSERT_EQ(model.Invoke(), kTfLiteOk);
   std::vector<float> expected_values = {1, 2, 2, 2, 2, 2, 7, 8, 2,  2,  2,  2,
                                         2, 2, 2, 2, 2, 2, 2, 2, 21, 22, 23, 24};
+  EXPECT_THAT(model.GetOutput<float>(), ElementsAreArray(expected_values));
+}
+
+// A constant tensor's raw FlatBuffer buffer may legally be larger than
+// its logical shape requires; the model loader only validates
+// required_bytes <= buffer_size. The copy into the output must be
+// bounded by the output allocation, not by the raw buffer length.
+TEST(StablehloScatterOpTest, ConstantOperandWithOversizedBuffer) {
+  StablehloScatterOpType op_type = StablehloScatterOpType::kAdd;
+
+  TfLiteStablehloScatterParams params = {
+      false,   // indices_are_sorted
+      {2, 3},  // std::vector<update_window_dims>
+      2,       // num_update_window_dims
+      {0},     // std::vector<inserted_window_dims>
+      1,       // num_inserted_window_dims
+      {1, 0},  // std::vector<scatter_dims_to_operand_dims>
+      2,       // num_scatter_dims_to_operand_dims
+      2,       // index_vector_dim
+      false,   // unique_indices
+      1        // update_computation_subgraph_index
+  };
+  std::vector<float> input_data(1 << 12);
+  const std::vector<float> logical{1,  2,  3,  4,  5,  6,  7,  8,
+                                   9,  10, 11, 12, 13, 14, 15, 16,
+                                   17, 18, 19, 20, 21, 22, 23, 24};
+  for (int i = 0; i < 24; ++i) {
+    input_data[i] = logical[i];
+  }
+  StablehloScatterOpModel model(
+      {TensorType_FLOAT32, {3, 4, 2}}, {TensorType_INT64, {2, 3, 2}},
+      {TensorType_FLOAT32, {2, 3, 2, 2}}, params, op_type, &input_data);
+  model.SetIndices<int64_t>({0, 2, 1, 0, 2, 1, 0, 1, 1, 0, 0, 9});
+  model.SetUpdates<float>(
+      {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2});
+
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  std::vector<float> expected_values = {1,  2,  7,  8,  9,  10, 7,  8,
+                                        11, 12, 13, 14, 15, 16, 17, 18,
+                                        19, 20, 21, 22, 21, 22, 23, 24};
   EXPECT_THAT(model.GetOutput<float>(), ElementsAreArray(expected_values));
 }
 


### PR DESCRIPTION
## Problem

A constant tensor in a `.tflite` model carries `tensor->bytes` equal to the
raw FlatBuffer buffer length. `Subgraph::SetTensorParametersReadOnly` only
validates `required_bytes <= bytes`, so a constant tensor whose raw buffer is
longer than its logical shape requires is a legal model. The kernels listed
below then use `input->bytes` directly as the memcpy length into an output
tensor that the runtime allocates at the logical shape size. An oversized
constant buffer therefore produces a heap out-of-bounds write whose length
and content are chosen by the model author; the write fires during
`AllocateTensors()` (reshape Prepare) or `Invoke()` for the other ops.

This is the same defect fixed for `DynamicUpdateSliceInt4` in dbff6667f3
("Fix heap buffer overflow in DynamicUpdateSliceInt4 by clamping memcpy
length"): `input->bytes` is derived from the raw FlatBuffer buffer size for
constant tensors and may be inflated relative to the logical shape. The same
unclamped pattern remained in six more kernels.

## Fix

Clamp every affected copy to the destination size, exactly like dbff6667f3:

| Kernel | Copy site | Op |
|---|---|---|
| `kernels/reshape.cc` | Prepare (constant-input branch) and Eval | RESHAPE |
| `kernels/bitcast.cc` | Eval | BITCAST |
| `kernels/expand_dims.cc` | Eval | EXPAND_DIMS |
| `kernels/stablehlo_scatter.cc` | Eval | STABLEHLO_SCATTER |
| `kernels/hadamard_rotation.cc` | Eval | `aeq.hadamard_rotation` (registered by `BuiltinOpResolver`) |
| `kernels/roll.cc` | `ExtractIntegerVector` | `Roll` custom op |

For `roll.cc` the destination is a `std::vector<int32_t>` sized by the
logical `FlatSize()`, so the bound there is
`result.size() * sizeof(int32_t)`.

## Tests

Each touched kernel test file gains a regression test that adds the data
input as a constant tensor whose raw buffer exceeds its logical shape
(`SingleOpModel` writes `sizeof(T) * data.size()` buffer bytes independently
of the tensor shape) and asserts the op still returns `kTfLiteOk` with the
correct logical output. The reshape test covers both copy sites: the
Prepare-time copy (shape supplied via `ReshapeOptions`) and the Eval-time
copy (shape supplied as a non-constant tensor). Before this change the new
tests write past the output allocation (they abort or die under
sanitizers); with it they pass.

## Notes

- An alternative root-cause fix is to have `SetTensorParametersReadOnly`
  advertise `BytesRequired(type, dims)` instead of the raw buffer length.
  That changes the meaning of `tensor->bytes` for every consumer, so the
  per-site clamps — the approach already merged for `DynamicUpdateSlice` —
  are the smaller, precedent-following change.
- Distinct from issue #124982 (new-shape rank overflow writing past the
  output dims array in reshape): the overflow here is the constant tensor's
  raw buffer content written past the output data allocation, with
  attacker-chosen length and content, and no error raised on stock builds.