### PR TITLE
Validate PACK axis fits int8 before narrowing store in pack.cc

### DIFF
--- a/tensorflow/lite/kernels/pack.cc
+++ b/tensorflow/lite/kernels/pack.cc
@@ -46,6 +46,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   }
   TF_LITE_ENSURE(context, NumDimensions(input0) >= data->axis);
   TF_LITE_ENSURE(context, data->axis >= 0);
+  TF_LITE_ENSURE(context, data->axis <= INT8_MAX);
 
   if (input0->type != kTfLiteInt32 && input0->type != kTfLiteFloat32 &&
 #if defined(TFLITE_ENABLE_EXTRA_REFERENCE_KERNELS)
@@ -101,10 +102,11 @@ template <typename T>
 TfLiteStatus PackImpl(TfLiteContext* context, TfLiteNode* node,
                       TfLiteTensor* output, int values_count, int axis) {
   TF_LITE_ENSURE(context, axis >= 0);
+  TF_LITE_ENSURE(context, axis <= INT8_MAX);
 
   VectorOfTensors<T> all_inputs(*context, *node->inputs);
   tflite::PackParams op_params;
-  op_params.axis = axis;
+  op_params.axis = static_cast<int8_t>(axis);
   op_params.inputs_count = values_count;
 
   reference_ops::Pack<T>(op_params, all_inputs.shapes(), all_inputs.data(),

--- a/tensorflow/lite/kernels/pack_test.cc
+++ b/tensorflow/lite/kernels/pack_test.cc
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <cstring>
 #include <initializer_list>
+#include <limits>
 #include <type_traits>
 #include <vector>
 
@@ -83,6 +84,50 @@ class PackOpModel : public SingleOpModel {
  private:
   int output_;
 };
+
+class PrepareOnlyPackOpModel : public SingleOpModel {
+ public:
+  PrepareOnlyPackOpModel(const std::vector<int>& input_shape, int axis,
+                         int values_count) {
+    std::vector<std::vector<int>> all_input_shapes;
+    for (int i = 0; i < values_count; ++i) {
+      all_input_shapes.push_back(input_shape);
+      AddInput({TensorType_FLOAT32, input_shape});
+    }
+    AddOutput(TensorType_FLOAT32);
+    SetBuiltinOp(BuiltinOperator_PACK, BuiltinOptions_PackOptions,
+                 CreatePackOptions(builder_, values_count, axis).Union());
+    BuildInterpreter(all_input_shapes,
+                     /*num_threads=*/1,
+                     /*allow_fp32_relax_to_fp16=*/false,
+                     /*apply_delegate=*/false,
+                     /*allocate_and_delegate=*/false);
+  }
+};
+
+TEST(PackPrepareTest, RejectsAxisOutsideInt8Range) {
+  constexpr int kAxis = std::numeric_limits<int8_t>::max() + 1;
+  const std::vector<int> input_shape(kAxis, 1);
+  PrepareOnlyPackOpModel too_large(input_shape, kAxis, /*values_count=*/2);
+  EXPECT_EQ(too_large.AllocateTensors(), kTfLiteError);
+
+  PrepareOnlyPackOpModel normalized_too_large(input_shape, /*axis=*/-1,
+                                              /*values_count=*/2);
+  EXPECT_EQ(normalized_too_large.AllocateTensors(), kTfLiteError);
+}
+
+TEST(PackOpTest, PacksAtInt8MaxAxis) {
+  constexpr int kAxis = std::numeric_limits<int8_t>::max();
+  const std::vector<int> input_shape(kAxis, 1);
+  PackOpModel<float> model({TensorType_FLOAT32, input_shape}, kAxis,
+                           /*values_count=*/2);
+  model.SetInput(0, {1});
+  model.SetInput(1, {2});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  std::vector<int> expected_shape = input_shape;
+  expected_shape.push_back(/*values_count=*/2);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray(expected_shape));
+}
 
 // float32 tests.
 TEST(PackOpTest, FloatThreeInputs) {


### PR DESCRIPTION
`TfLitePackParams::axis` is a 32-bit schema field, but `tflite::PackParams::axis` (`tensorflow/lite/kernels/internal/types.h`) is an `int8_t`. `pack.cc` copies the validated 32-bit axis into that field with no range check (`op_params.axis = axis;` in `PackImpl`). For input ranks above 127, a model-supplied axis >= 128 passes every check in `Prepare` (the comparisons run on the un-truncated int) and then wraps negative at the narrowing store. The reference `Pack` kernel then starts its copy-size loop at `params.axis + 1` and calls `RuntimeShape::Dims` at a negative index (DCHECK-only protection in release builds), multiplying the out-of-bounds value it reads there into the `memcpy` element count executed against the output tensor. Reproduced on the 2.21.0 pip wheel: `AllocateTensors` accepts a rank-201 input pair with `axis: 200`, and `Invoke` dies with an access violation inside the kernel (axis 200 becomes -56 after the store, first read at `Dims(-55)`).

This is the same parameter-type-mismatch class fixed for the int16 kernels in 8c345955 ("Validate int16 kernel parameters during prepare"), which added range checks to the gather/split/split_v/unpack axes and the conv/pooling stride and dilation fields. `pack.cc` carries an equivalent narrowing store into an `int8_t` field and is the remaining member of that family with no guard.

Fix: reject the axis in `Prepare` once the normalized value exceeds `INT8_MAX` (the existing checks already bound it below by 0), re-check in `PackImpl` before the store, and make the narrowing explicit with `static_cast<int8_t>`, mirroring how 8c345955 hardened the int16 sites.

Tests:

- `PackPrepareTest.RejectsAxisOutsideInt8Range`: Prepare-only models with `axis = 128` over rank-128 inputs (direct), and `axis = -1` over the same rank (normalizes to 128 in `Prepare`). Both must fail `AllocateTensors` with `kTfLiteError`. Before this change both are accepted, and invoking the direct case crashes the interpreter.
- `PackOpTest.PacksAtInt8MaxAxis`: boundary pin — `axis = 127` over rank-127 inputs still packs successfully with the expected `[1 x ... x 1 x 2]` output shape.

Verified against a Linux build of this tree: on the base commit the new reject test fails its assertions (`AllocateTensors` returns `kTfLiteOk` where `kTfLiteError` is expected) and the boundary test passes; with this change the full `pack_test` suite passes.
