### PR TITLE
fix: Fix XLA JIT dtype constraints for Reciprocal and Inv

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,14 @@ In `tensorflow/c/experimental/filesystem/filesystem_interface.h`, removed `TF_Tr
         previously failed with a lookup error because the `SoftsignGrad`
         backward op had no registered Python gradient.
 
+*   `tf.math.reciprocal`
+
+    *   Constrains the XLA registration of `Reciprocal` and `Inv` to the types
+        that have a device kernel, so `jit_compile=True` no longer silently
+        accepts the integer inputs that eager execution and autoclustering
+        reject. Fixes
+        [#126414](https://github.com/tensorflow/tensorflow/issues/126414).
+
 
 *   `tf.experimental.numpy`
 

--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -1643,11 +1643,13 @@ tf_cc_test(
     srcs = ["xla_op_registry_test.cc"],
     deps = [
         ":xla_compiler",
+        "//tensorflow/compiler/tf2xla/kernels:xla_ops",
         "//tensorflow/core:framework",
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
         "@com_google_absl//absl/log",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/tensorflow/compiler/tf2xla/kernels/BUILD
+++ b/tensorflow/compiler/tf2xla/kernels/BUILD
@@ -1869,6 +1869,7 @@ tf_kernel_library(
         "//tensorflow/compiler/tf2xla:xla_resource",
         "//tensorflow/compiler/tf2xla/ops:xla_ops",
         "//tensorflow/core:framework",
+        "//tensorflow/core:protos_all_cc",
         "@com_google_absl//absl/status:statusor",
         "@xla//xla:xla_data_proto_cc",
         "@xla//xla/hlo/builder:xla_builder",

--- a/tensorflow/compiler/tf2xla/kernels/unary_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/unary_ops.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 // Native XLA implementations of simple unary Ops
 
+#include <array>
 #include <cmath>
 
 #include "absl/status/statusor.h"
@@ -27,9 +28,14 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/xla_data.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/types.pb.h"
 
 namespace tensorflow {
 namespace {
+
+constexpr std::array<DataType, 7> kReciprocalGpuTypes = {
+    {DT_HALF, DT_FLOAT, DT_DOUBLE, DT_BFLOAT16, DT_INT64, DT_COMPLEX64,
+     DT_COMPLEX128}};
 
 #define XLAJIT_MAKE_UNARY(NAME, COMPUTATION)                           \
   class NAME##Op : public XlaOpKernel {                                \
@@ -44,6 +50,15 @@ namespace {
     }                                                                  \
   };                                                                   \
   REGISTER_XLA_OP(Name(#NAME), NAME##Op);
+
+// We don't have kernels for all integer types, so we limit the supported types.
+#define REGISTER_XLA_RECIPROCAL_OP(BUILDER, OP)                        \
+  REGISTER_XLA_OP(BUILDER.TypeConstraint("T", kFloatAndComplexTypes)   \
+                      .Device(DEVICE_CPU_XLA_JIT),                     \
+                  OP);                                                 \
+  REGISTER_XLA_OP(BUILDER.TypeConstraint("T", kReciprocalGpuTypes)     \
+                      .Device(DEVICE_GPU_XLA_JIT),                     \
+                  OP)
 
 XLAJIT_MAKE_UNARY(ComplexAbs, xla::Abs(x));
 
@@ -72,7 +87,9 @@ REGISTER_XLA_OP(Name("IsInf"), MlirXlaOpKernel);
 REGISTER_XLA_OP(Name("IsNan"), MlirXlaOpKernel);
 // Return 1/x
 XLAJIT_MAKE_UNARY(Inv, xla::ScalarLike(x, 1.0) / x);
+REGISTER_XLA_RECIPROCAL_OP(Name("Inv"), InvOp);
 REGISTER_XLA_OP(Name("Reciprocal"), MlirXlaOpKernel);
+REGISTER_XLA_RECIPROCAL_OP(Name("Reciprocal"), MlirXlaOpKernel);
 XLAJIT_MAKE_UNARY(Log, xla::Log(x));
 REGISTER_XLA_OP(Name("Log1p"), MlirXlaOpKernel);
 

--- a/tensorflow/compiler/tf2xla/xla_op_registry_test.cc
+++ b/tensorflow/compiler/tf2xla/xla_op_registry_test.cc
@@ -15,15 +15,23 @@ limitations under the License.
 
 #include "tensorflow/compiler/tf2xla/xla_op_registry.h"
 
+#include <string>
+
+#include <gmock/gmock.h>
 #include "absl/log/log.h"
 #include "tensorflow/compiler/tf2xla/xla_op_kernel.h"
+#include "tensorflow/core/framework/node_def.pb.h"
+#include "tensorflow/core/framework/node_def_util.h"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/platform/test.h"
 
 namespace tensorflow {
 namespace {
+
+using ::testing::UnorderedElementsAre;
 
 // This test is to verify the correctness of XLA op registration with specific
 // backend overrides.
@@ -136,6 +144,42 @@ TEST(XlaOpRegistryTest, OpWithInfeasibleTypeConstraintIsNotRegistered) {
   for (const auto& kernels : registered_kernels) {
     // The operator should not be registered.
     EXPECT_NE(kernels.op(), "DummyInfeasibleTypeConstraintOp");
+  }
+}
+
+// Test that Inv and Reciprocal drop the types that have no CPU device kernel.
+TEST(XlaOpRegistryTest, ReciprocalIsNotRegisteredForUnsupportedTypesOnCpu) {
+  XlaOpRegistry::RegisterCompilationKernels();
+  int found = 0;
+  for (const KernelDef* kernel :
+       XlaOpRegistry::DeviceKernels(DEVICE_CPU_XLA_JIT, true)) {
+    if (kernel->op() != "Inv" && kernel->op() != "Reciprocal") continue;
+    ++found;
+    EXPECT_EQ(kernel->constraint_size(), 1);
+    EXPECT_EQ(kernel->constraint(0).name(), "T");
+    EXPECT_THAT(kernel->constraint(0).allowed_values().list().type(),
+                UnorderedElementsAre(DT_HALF, DT_FLOAT, DT_DOUBLE, DT_BFLOAT16,
+                                     DT_COMPLEX64, DT_COMPLEX128));
+  }
+  EXPECT_EQ(found, 2);
+}
+
+// Test that Inv and Reciprocal have a CPU kernel for DT_FLOAT but not DT_INT32.
+TEST(XlaOpRegistryTest, ReciprocalOnIntegerHasNoCpuCompilationKernel) {
+  XlaOpRegistry::RegisterCompilationKernels();
+  for (const std::string& op : {"Inv", "Reciprocal"}) {
+    NodeDef node_def;
+    node_def.set_name(op);
+    node_def.set_op(op);
+    AddNodeAttr("T", DT_INT32, &node_def);
+    EXPECT_FALSE(FindKernelDef(DeviceType(DEVICE_CPU_XLA_JIT), node_def,
+                               nullptr, nullptr)
+                     .ok());
+    node_def.clear_attr();
+    AddNodeAttr("T", DT_FLOAT, &node_def);
+    EXPECT_TRUE(FindKernelDef(DeviceType(DEVICE_CPU_XLA_JIT), node_def, nullptr,
+                              nullptr)
+                    .ok());
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

→ Fixes [#126414](https://github.com/tensorflow/tensorflow/issues/126414). Kept both generic registrations so `XLA_TPU_JIT` and other backends retain the full `OpDef` set.
→ <ins>NOTE</ins>: I noticed that this 'JIT-wider-than-CPU' shape isn't unique to these two ops. `RealDiv` (all int/uint), `Round` (complex, int8/16), `Rint`, and `Digamma`/`Lgamma` (bfloat16) have it too. This PR is scoped to the two ops in the issue, and I'm happy to help widen this in follow-up PRs.

### How was it verified?

→ Added two tests in `xla_op_registry_test.cc`: one checks the exact CPU dtype set for both ops, and the other verifies that `FindKernelDef` rejects `DT_INT32` while still accepting `DT_FLOAT`, which is the check `jit_compile=True` actually performs. Both fail on `master` and pass with the patch.
→ Existing XLA coverage for these ops (`unary_ops_test.py`, `float_ops_test.py`) only uses float and complex dtypes, so there are no regressions.

cc: @dmiltr3