### PR TITLE
Set the output size when slicing a dynamic dimension in tf2xla Slice

### DIFF
--- a/tensorflow/compiler/tests/slice_ops_test.py
+++ b/tensorflow/compiler/tests/slice_ops_test.py
@@ -50,6 +50,26 @@ class SliceTest(xla_test.XLATestCase):
 
         self.assertAllEqual([], result)
 
+  def testSliceOfDynamicDimension(self):
+    # Regression test for GitHub issue 110789. The input's leading dimension
+    # is dynamic because it comes from where, and a partial slice of such a
+    # dimension returned wrong output sizes, and corrupted the heap on some
+    # platforms, instead of taking the requested slice.
+    with self.session():
+      i = array_ops.placeholder(dtypes.int64, shape=[2, 2, 5])
+      with self.test_scope():
+        indices = array_ops.where(math_ops.not_equal(i, 0))
+        sliced = array_ops.slice(indices, [0, 0], [2, 1])
+        empty = array_ops.slice(indices, [0, 0], [0, 1])
+      params = {
+          i: [[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
+              [[10, 11, 12, 13, 14], [15, 16, 17, 18, 19]]],
+      }
+      # The first two nonzero elements sit at indices (0, 0, 1) and
+      # (0, 0, 2), so the slice holds the first coordinate of each.
+      self.assertAllEqual([[0], [0]], sliced.eval(feed_dict=params))
+      self.assertAllEqual((0, 1), empty.eval(feed_dict=params).shape)
+
   def test3D(self):
     for dtype in self.numeric_types:
       with self.session():

--- a/tensorflow/compiler/tf2xla/kernels/BUILD
+++ b/tensorflow/compiler/tf2xla/kernels/BUILD
@@ -1583,6 +1583,7 @@ tf_kernel_library(
         "//tensorflow/core:lib",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/types:span",
+        "@xla//xla:shape_util",
         "@xla//xla:xla_data_proto_cc",
         "@xla//xla/hlo/builder:value_inference",
         "@xla//xla/hlo/builder:xla_builder",

--- a/tensorflow/compiler/tf2xla/kernels/slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/slice_op.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "xla/hlo/builder/lib/dynamic_shaped_ops.h"
 #include "xla/hlo/builder/value_inference.h"
 #include "xla/hlo/builder/xla_builder.h"
+#include "xla/shape.h"
 #include "xla/xla_data.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/op_requires.h"
@@ -104,6 +105,30 @@ class SliceOp : public XlaOpKernel {
       }
       std::vector<int64_t> strides(begin.size(), 1);
       auto slice = xla::Slice(ctx->Input(0), begin, limits, strides);
+
+      // If the input has dynamic dimensions, the dynamic size that XLA
+      // infers for a partial slice of such a dimension does not implement
+      // the slice semantics, so set the output size explicitly. A dimension
+      // holding `dynamic_size` valid elements contributes
+      // clamp(dynamic_size - begin, 0, size) elements to the slice.
+      auto input_xla_shape = ctx->builder()->GetShape(ctx->Input(0));
+      OP_REQUIRES_OK(ctx, input_xla_shape.status());
+      for (int64_t i = 0; i < input_dims; ++i) {
+        if (input_xla_shape->is_dynamic_dimension(i)) {
+          xla::XlaOp input_dynamic_size =
+              xla::GetDimensionSize(ctx->Input(0), i);
+          xla::XlaOp begin_size = xla::ConstantR0<int32_t>(
+              ctx->builder(), static_cast<int32_t>(begin[i]));
+          xla::XlaOp requested_size = xla::ConstantR0<int32_t>(
+              ctx->builder(), static_cast<int32_t>(wrapped_size[i]));
+          xla::XlaOp output_size =
+              xla::Clamp(xla::ConstantR0<int32_t>(ctx->builder(), 0),
+                         input_dynamic_size - begin_size, requested_size);
+          slice = xla::RemoveDynamicDimension(slice, i);
+          slice = xla::SetDimensionSize(slice, output_size, i);
+        }
+      }
+
       // Check for slice on dynamic dimensions.
       std::vector<bool> size_is_dynamic;
       OP_REQUIRES_OK(


### PR DESCRIPTION
Fixes #110789.

## Problem

Slicing a tensor that carries a dynamic dimension, for example the output of `tf.where`, with constant `begin`/`size` under `jit_compile=True` returns silently wrong results. Verified on TF 2.21.0 and tf-nightly 2.22.0-dev20260823 (XLA:CPU):

| computation | eager | XLA |
|---|---|---|
| `where` then `slice(size=[0, 1])` | (0, 1) | (0, 0) |
| `where` then `slice(size=[2, 1])` | (2, 1) | (0, 1) |
| `where`, `top_k`, `slice(size=[2, 1])` | (2, 1) | (0, 2) |

The nonzero-size case silently drops all the data. On Linux x86 the same defect manifests as heap corruption (`free(): invalid next size`, the crash in the issue), consistent with buffers whose dynamic size metadata disagrees with the requested slice.

The cause is in the constant `begin`/`size` path of the tf2xla `Slice` kernel: it emits a plain `xla::Slice` and leaves the output's dynamism to XLA's dynamic dimension inference. The HLO shows the slice output typed `s64[<=2,1]` from an `s64[<=20,3]` input, and the propagated runtime size for the partially sliced dynamic dimension does not implement the slice semantics. The existing dynamism handling in this path only covers dynamic values of the `size` operand, not dynamic dimensions of the input.

## Fix

After emitting the slice, set the dynamic size of the output explicitly for every dynamic input dimension: a dimension holding `dynamic_size` valid elements contributes `clamp(dynamic_size - begin, 0, size)` elements to the slice. A full slice of a dynamic dimension keeps its current behavior, since the clamp then evaluates to the input's dynamic size. This mirrors how the sibling kernels manage dynamism explicitly with `SetDimensionSize` (the non-constant-size branch of this same file already does), and follows the `GetShape`/`is_dynamic_dimension` pattern used by `split_op.cc`.

When `begin + size` exceeds the runtime dynamic size, the result is clamped rather than raising the error eager mode produces, matching XLA's established policy for runtime bounds under compilation, since compiled programs cannot raise data-dependent errors.

## Test

`testSliceOfDynamicDimension` in `compiler/tests/slice_ops_test.py` slices the output of `where` under the XLA test harness and checks a nonzero and a zero sized slice against the eager values and shapes (expected values verified against eager semantics). Both assertions fail against the current wheels, matching the mismatch table above.
