### PR TITLE
Allow reads from a statically empty TensorList under XLA

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -1814,6 +1814,7 @@ tf_xla_py_strict_test(
         "//tensorflow/python/framework:errors",
         "//tensorflow/python/ops:array_ops",
         "//tensorflow/python/ops:list_ops",
+        "//tensorflow/python/ops:map_fn",
         "//tensorflow/python/platform:client_testlib",
         "//third_party/py/numpy",
         "@absl_py//absl/testing:parameterized",

--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -1809,6 +1809,7 @@ tf_xla_py_strict_test(
     ],
     deps = [
         ":xla_test",
+        "//tensorflow/python/eager:def_function",
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:errors",

--- a/tensorflow/compiler/tests/tensor_list_ops_test.py
+++ b/tensorflow/compiler/tests/tensor_list_ops_test.py
@@ -25,10 +25,32 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import list_ops
+from tensorflow.python.ops import map_fn
 from tensorflow.python.platform import test
 
 
 class ListOpsTest(parameterized.TestCase, xla_test.XLATestCase):
+
+  def testGetItemFromEmptyList(self):
+    # Regression test for GitHub issue 109648. Reading from a statically
+    # empty list appears in code that never runs, such as the body of a
+    # while loop with a zero trip count, but XLA compiles that code anyway
+    # and used to reject the read at compile time. It now yields zeros of
+    # the element shape.
+    with self.session() as sess, self.test_scope():
+      l = list_ops.tensor_list_reserve(
+          element_shape=[2], element_dtype=dtypes.float32, num_elements=0)
+      e = list_ops.tensor_list_get_item(l, 0, element_dtype=dtypes.float32)
+      self.assertAllEqual(sess.run(e), [0.0, 0.0])
+
+  def testMapFnOverEmptyTensor(self):
+    # End to end case for GitHub issue 109648: map_fn over a zero length
+    # tensor compiles its loop body even though it never runs, and the
+    # TensorListGetItem in that body used to fail compilation.
+    with self.session() as sess, self.test_scope():
+      x = array_ops.zeros([0], dtype=dtypes.float32)
+      y = map_fn.map_fn(lambda t: t + 1.0, x)
+      self.assertAllEqual(sess.run(y).shape, (0,))
 
   def testElementShape(self):
     with self.session() as sess, self.test_scope():

--- a/tensorflow/compiler/tests/tensor_list_ops_test.py
+++ b/tensorflow/compiler/tests/tensor_list_ops_test.py
@@ -20,6 +20,7 @@ import os
 from absl.testing import parameterized
 import numpy as np
 from tensorflow.compiler.tests import xla_test
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
@@ -46,11 +47,16 @@ class ListOpsTest(parameterized.TestCase, xla_test.XLATestCase):
   def testMapFnOverEmptyTensor(self):
     # End to end case for GitHub issue 109648: map_fn over a zero length
     # tensor compiles its loop body even though it never runs, and the
-    # TensorListGetItem in that body used to fail compilation.
-    with self.session() as sess, self.test_scope():
+    # TensorListGetItem in that body used to fail compilation. The whole
+    # function is jit-compiled so the list stays inside XLA rather than
+    # crossing the XLA/TF boundary at the unstack and stack ops.
+    @def_function.function(jit_compile=True)
+    def f(x):
+      return map_fn.map_fn(lambda t: t + 1.0, x)
+
+    with self.session() as sess:
       x = array_ops.zeros([0], dtype=dtypes.float32)
-      y = map_fn.map_fn(lambda t: t + 1.0, x)
-      self.assertAllEqual(sess.run(y).shape, (0,))
+      self.assertAllEqual(sess.run(f(x)).shape, (0,))
 
   def testElementShape(self):
     with self.session() as sess, self.test_scope():

--- a/tensorflow/compiler/tf2xla/kernels/tensor_list_utils.cc
+++ b/tensorflow/compiler/tf2xla/kernels/tensor_list_utils.cc
@@ -549,6 +549,21 @@ absl::Status ExecuteTensorListGetItem(xla::XlaOp list, xla::XlaOp index,
   TF_ASSIGN_OR_RETURN(xla::Shape list_shape, b->GetShape(list));
   const xla::Shape& buffer_shape =
       xla::ShapeUtil::GetTupleElementShape(list_shape, 0);
+
+  if (buffer_shape.dimensions(0) == 0) {
+    // The list is statically empty, so this read can only appear in code
+    // that never executes at runtime, such as the body of a while loop
+    // with a zero trip count, which XLA still compiles. The slice below
+    // would fail compile-time shape inference, so return zeros of the
+    // element shape instead, mirroring how ExecuteTensorListSetItem
+    // ignores writes that cannot fit the list.
+    *result = xla::Broadcast(
+        xla::ConstantLiteral(
+            b, xla::LiteralUtil::Zero(buffer_shape.element_type())),
+        buffer_shape.dimensions().subspan(1));
+    return absl::OkStatus();
+  }
+
   std::vector<xla::XlaOp> start_indices(buffer_shape.dimensions().size(),
                                         xla::ConstantR0<int32_t>(b, 0));
   start_indices[0] = index;


### PR DESCRIPTION
Fixes #109648.

## Problem

`tf.map_fn` over a zero-length tensor fails to compile under `jit_compile=True`:

```
INVALID_ARGUMENT: Slice dim size 1 greater than dynamic slice dimension: 0.
  [[{{node map/while/TensorArrayV2Read/TensorListGetItem}}]]
tf2xla conversion failed while converting map_while_body...
```

Reproduced on TF 2.21.0 XLA:CPU with both the map_fn reproducer and a direct minimal trigger (`TensorListReserve(num_elements=0)` followed by `TensorListGetItem`). Non-XLA execution handles the same program fine, returning an empty result.

The cause is in `ExecuteTensorListGetItem` (`tensor_list_utils.cc`): it unconditionally emits a `DynamicSlice` of one element out of the list buffer, and when the buffer's leading dimension is statically zero, XLA's compile-time shape inference rejects the slice. Such a read only appears in code that never executes at runtime, most commonly the body of a while loop with a zero trip count, but XLA compiles loop bodies unconditionally, so the whole function fails to compile even though the loop is dead.

## Fix

For a read from a statically empty list, return zeros of the element shape instead of emitting the slice. This mirrors the established pattern in `ExecuteTensorListSetItem` in the same file, which already ignores writes whose update cannot fit the list ("If the update is larger than the list part, the DynamicUpdateSlice will fail so just ignore this operation and return list as is"); with that existing behavior on the write side, the read-side guard is the only missing piece for the zero-length `map_fn` case.

## Tests

In `compiler/tests/tensor_list_ops_test.py`:
- `testGetItemFromEmptyList` covers the direct minimal trigger and checks the zeros result.
- `testMapFnOverEmptyTensor` covers the end-to-end reported case and checks the empty output.

Both fail against the current wheels with the reported compile error (verified locally on XLA:CPU). BUILD gains the `map_fn` dep for the strict-deps test target.
