### PR TITLE
Add TridiagonalSolve GPU validation tests and empty-batch check

### DIFF
--- a/tensorflow/core/kernels/linalg/tridiagonal_solve_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/tridiagonal_solve_op_gpu.cu.cc
@@ -293,6 +293,12 @@ class TridiagonalSolveOpGpu : public OpKernel {
       batch_size *= lhs.dim_size(i);
     }
 
+    if (batch_size == 0) {
+      Tensor* output;
+      OP_REQUIRES_OK(context, context->allocate_output(0, rhs.shape(), &output));
+      return;
+    }
+
     // The batching mechanism of LinearAlgebraOp is used when it's not
     // possible or desirable to use GtsvBatched.
     const bool use_linalg_op =

--- a/tensorflow/python/kernel_tests/linalg/tridiagonal_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/tridiagonal_solve_op_test.py
@@ -23,6 +23,7 @@ from tensorflow.python.eager import backprop
 from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -501,6 +502,12 @@ class TridiagonalSolveOpTest(test.TestCase):
             y_placeholder: y
         })
 
+  def testEmptyBatch(self):
+    self._test(
+        diags=constant_op.constant(0, shape=(0, 3, 4), dtype=dtypes.float32),
+        rhs=constant_op.constant(0, shape=(0, 4, 1), dtype=dtypes.float32),
+        expected=constant_op.constant(0, shape=(0, 4, 1), dtype=dtypes.float32))
+
   # Invalid input shapes
 
   @flags(FLAG_NO_PARAMETERIZATION)
@@ -513,6 +520,8 @@ class TridiagonalSolveOpTest(test.TestCase):
     test_raises((5, 3, 4), (4, 5))
     test_raises((5, 3, 4), (5))
     test_raises((5), (5, 4))
+    test_raises((5, 3, 4), (4, 4, 1))
+    test_raises((5, 3, 4), (5, 3, 1))
 
   @flags(FLAG_NO_PARAMETERIZATION)
   def testInvalidShapesSequenceFormat(self):
@@ -537,6 +546,55 @@ class TridiagonalSolveOpTest(test.TestCase):
     test_raises((5, 4, 7), (5, 4))
     test_raises((5, 4, 4), (3, 4))
     test_raises((5, 4, 4), (5, 3))
+
+  @test_util.run_deprecated_v1
+  def testInvalidShapesWithPlaceholders(self):
+    if context.executing_eagerly():
+      return
+    # Use placeholders to bypass Python static shape checks and trigger C++
+    # validation in TridiagonalSolveOpGpu.
+    diags = array_ops.placeholder(dtypes.float64, shape=None)
+    rhs = array_ops.placeholder(dtypes.float64, shape=None)
+    x = linalg_impl.tridiagonal_solve(
+        diags, rhs, "compact", partial_pivoting=self.pivoting)
+
+    with self.cached_session() as sess:
+      # 1. LHS rank < 2
+      with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                  "LHS tensor must have rank >= 2"):
+        sess.run(x, feed_dict={diags: np.ones((5,)), rhs: np.ones((5, 4))})
+
+      # 2. LHS rank != RHS rank
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError,
+          "LHS and RHS tensors must have the same rank"):
+        sess.run(x, feed_dict={
+            diags: np.ones((5, 3, 4)), rhs: np.ones((5, 4))
+        })
+
+      # 3. LHS and RHS batch dimensions mismatch
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError,
+          "LHS and RHS tensors must have the same batch dimensions"):
+        sess.run(x, feed_dict={
+            diags: np.ones((5, 3, 4)), rhs: np.ones((4, 4, 1))
+        })
+
+      # 4. Expected 3 diagonals
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError,
+          "Expected diagonals to be provided as a matrix with 3 rows"):
+        sess.run(x, feed_dict={
+            diags: np.ones((5, 4, 4)), rhs: np.ones((5, 4, 1))
+        })
+
+      # 5. Expected same matrix size
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError,
+          "Expected same matrix size in both arguments"):
+        sess.run(x, feed_dict={
+            diags: np.ones((5, 3, 4)), rhs: np.ones((5, 3, 1))
+        })
 
   # Tests with placeholders
 

--- a/tensorflow/python/kernel_tests/linalg/tridiagonal_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/tridiagonal_solve_op_test.py
@@ -552,22 +552,23 @@ class TridiagonalSolveOpTest(test.TestCase):
     if context.executing_eagerly():
       return
     # Use placeholders to bypass Python static shape checks and trigger C++
-    # validation in TridiagonalSolveOpGpu.
+    # validation in TridiagonalSolveOpGpu and CPU LinearAlgebraOp.
     diags = array_ops.placeholder(dtypes.float64, shape=None)
     rhs = array_ops.placeholder(dtypes.float64, shape=None)
     x = linalg_impl.tridiagonal_solve(
         diags, rhs, "compact", partial_pivoting=self.pivoting)
 
-    with self.cached_session() as sess:
+    with self.cached_session(use_gpu=True) as sess:
       # 1. LHS rank < 2
-      with self.assertRaisesRegex(errors.InvalidArgumentError,
-                                  "LHS tensor must have rank >= 2"):
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError,
+          r"(LHS tensor|Input tensor 0) must have rank >= 2"):
         sess.run(x, feed_dict={diags: np.ones((5,)), rhs: np.ones((5, 4))})
 
       # 2. LHS rank != RHS rank
       with self.assertRaisesRegex(
           errors.InvalidArgumentError,
-          "LHS and RHS tensors must have the same rank"):
+          r"(LHS and RHS|All input) tensors must have the same rank"):
         sess.run(x, feed_dict={
             diags: np.ones((5, 3, 4)), rhs: np.ones((5, 4))
         })
@@ -575,7 +576,8 @@ class TridiagonalSolveOpTest(test.TestCase):
       # 3. LHS and RHS batch dimensions mismatch
       with self.assertRaisesRegex(
           errors.InvalidArgumentError,
-          "LHS and RHS tensors must have the same batch dimensions"):
+          r"(LHS and RHS tensors must have the same batch dimensions|"
+          r"All input tensors must have the same outer dimensions)"):
         sess.run(x, feed_dict={
             diags: np.ones((5, 3, 4)), rhs: np.ones((4, 4, 1))
         })
@@ -591,7 +593,8 @@ class TridiagonalSolveOpTest(test.TestCase):
       # 5. Expected same matrix size
       with self.assertRaisesRegex(
           errors.InvalidArgumentError,
-          "Expected same matrix size in both arguments"):
+          r"(Expected same matrix size in both arguments|"
+          r"Expected the same number of left-hand sides and right-hand sides)"):
         sess.run(x, feed_dict={
             diags: np.ones((5, 3, 4)), rhs: np.ones((5, 3, 1))
         })


### PR DESCRIPTION
Supersedes #111072.

Adds the regression tests requested in review on #111072, plus an
empty-batch early return in TridiagonalSolveOpGpu when batch_size is 0.

Fixes #111069