### PR TITLE
[FusedOps] Support broadcast-shaped bias with leading 1s in fused MatMul and Conv2D

### DIFF
--- a/tensorflow/core/kernels/conv_ops_fused_impl.h
+++ b/tensorflow/core/kernels/conv_ops_fused_impl.h
@@ -375,12 +375,20 @@ struct LaunchFusedConv2DOp<GPUDevice, T> {
     const int64_t out_cols = GetTensorDim(*output, params.data_format, 'W');
     const int64_t out_depths = GetTensorDim(*output, params.data_format, 'C');
 
-    // Bias of the following dimensions: [ output_depth ]
+    // Bias of the following dimensions: [ output_depth ] or [1, ..., 1, output_depth]
     const Tensor& bias = context->input(2);
-    OP_REQUIRES(context, bias.dims() == 1,
+    OP_REQUIRES(context, bias.dims() >= 1,
                 absl::InvalidArgumentError(absl::StrCat(
-                    "bias must be 1-dimensional", bias.shape().DebugString())));
-    OP_REQUIRES(context, bias.dim_size(0) == out_depths,
+                    "bias must be at least 1-dimensional, got: ",
+                    bias.shape().DebugString())));
+    for (int i = 0; i < bias.dims() - 1; ++i) {
+      OP_REQUIRES(context, bias.dim_size(i) == 1,
+                  absl::InvalidArgumentError(absl::StrCat(
+                      "For bias_dims > 1, all except the last dimension "
+                      "must be 1, got: ",
+                      bias.shape().DebugString())));
+    }
+    OP_REQUIRES(context, bias.dim_size(bias.dims() - 1) == out_depths,
                 absl::InvalidArgumentError(
                     absl::StrCat("bias depth must be equal to out depth",
                                  bias.shape().DebugString())));

--- a/tensorflow/core/kernels/fused_eigen_output_kernels.h
+++ b/tensorflow/core/kernels/fused_eigen_output_kernels.h
@@ -411,12 +411,22 @@ using WithFusedBatchNormAndLeakyRelu = FusedBatchNormOutputKernel<T, LeakyRelu>;
 template <typename T>
 absl::Status InitBiasAddArgs(OpKernelContext* context, BiasAddArgs<T>* args,
                              const float* leakyrelu_alpha = nullptr) {
-  // Bias of the following dimensions: [ output_depth ]
+  // Bias of the following dimensions: [ output_depth ] or [1, ..., 1, output_depth]
   const Tensor& bias = context->input(2);
 
-  if (bias.dims() != 1)
+  if (bias.dims() < 1) {
     return absl::InvalidArgumentError(
-        absl::StrCat("bias must be 1-dimensional", bias.shape().DebugString()));
+        absl::StrCat("bias must be at least 1-dimensional, got: ",
+                     bias.shape().DebugString()));
+  }
+  for (int i = 0; i < bias.dims() - 1; ++i) {
+    if (bias.dim_size(i) != 1) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("For bias_dims > 1, all except the last dimension "
+                       "must be 1, got: ",
+                       bias.shape().DebugString()));
+    }
+  }
 
   const auto data_ptr = [](const Tensor& tensor) -> const T* {
     return reinterpret_cast<const T*>(tensor.tensor_data().data());

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -453,10 +453,20 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     // + <other pointwise operations>. Therefore, the bias tensor is required.
     const Tensor& bias = context->input(2);
 
-    if (bias.dims() != 1) {
-      OP_REQUIRES_OK(context, absl::InvalidArgumentError(
-                                  absl::StrCat("bias must be 1-dimensional",
-                                               bias.shape().DebugString())));
+    if (bias.dims() < 1) {
+      OP_REQUIRES_OK(context,
+                     absl::InvalidArgumentError(absl::StrCat(
+                         "bias must be at least 1-dimensional, got: ",
+                         bias.shape().DebugString())));
+    }
+    for (int i = 0; i < bias.dims() - 1; ++i) {
+      if (bias.dim_size(i) != 1) {
+        OP_REQUIRES_OK(context,
+                       absl::InvalidArgumentError(absl::StrCat(
+                           "For bias_dims > 1, all except the last dimension "
+                           "must be 1, got: ",
+                           bias.shape().DebugString())));
+      }
     }
 
     auto a_ptr = AsDeviceMemory(a.template flat<T>().data(),

--- a/tensorflow/core/kernels/matmul_op_test.cc
+++ b/tensorflow/core/kernels/matmul_op_test.cc
@@ -288,6 +288,25 @@ class FusedMatMulOpTest : public OpsTestBase {
                              run_fused);
   }
 
+  void VerifyMatMulWithBroadcastBias(int m, int k, int n, bool transpose_a,
+                                     bool transpose_b) {
+    DataType dtype = DataTypeToEnum<T>::v();
+    Tensor lhs(dtype, {transpose_a ? k : m, transpose_a ? m : k});
+    lhs.flat<T>() = lhs.flat<T>().setRandom();
+    Tensor rhs(dtype, {transpose_b ? n : k, transpose_b ? k : n});
+    rhs.flat<T>() = rhs.flat<T>().setRandom();
+    Tensor bias(dtype, {1, n});
+    bias.flat<T>() = bias.flat<T>().setRandom();
+
+    Tensor fused_matmul;
+    bool skipped = false;
+    RunFusedMatMulOp(lhs, rhs, {bias}, {"BiasAdd"}, transpose_a, transpose_b,
+                     &fused_matmul, /*allow_gpu_device=*/true, &skipped);
+    if (!skipped) {
+      ASSERT_EQ(fused_matmul.shape(), TensorShape({m, n}));
+    }
+  }
+
   // Verifies that computing MatMul+BiasAdd+{Activation} in a graph is identical
   // to FusedMatMul.
   void VerifyConv2DWithBiasAndActivation(int m, int k, int n, bool transpose_a,
@@ -356,6 +375,10 @@ TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul1x256x1) {
   this->VerifyMatMulWithBias(1, 256, 1, false, false);
 }
 
+TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMulWithBroadcastBias) {
+  this->VerifyMatMulWithBroadcastBias(8, 16, 32, false, false);
+}
+
 static auto GetActivations(DataType dtype) {
   // "GeluExact", "Tanh", "Sigmoid" fusions are only supported for half-float
   // datatype
@@ -407,6 +430,7 @@ REGISTER_TYPED_TEST_SUITE_P(FusedMatMulWithBiasOpTest,       //
                             MatMul1x256x256,                 //
                             MatMul256x256x1,                 //
                             MatMul1x256x1,                   //
+                            MatMulWithBroadcastBias,         //
                             MatMul256x128x64WithActivation,  //
                             MatMul1x256x256WithActivation,   //
                             MatMul256x256x1WithActivation,   //

--- a/tensorflow/python/kernel_tests/math_ops/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/matmul_op_test.py
@@ -19,6 +19,7 @@ import operator
 import numpy as np
 
 from tensorflow.python import tf2
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -53,6 +54,23 @@ class MatMulMixedType(test_lib.TestCase):
     c = math_ops.batch_mat_mul_v3(a, b, adj_y=True, Tout=np_bf16)
     self.assertAllEqual((2, 2), c.shape)
     self.assertAllEqual([[5, 11], [11, 25]], c)
+
+
+@test_util.with_eager_op_as_function
+class MatMulAddFusionTest(test_lib.TestCase):
+  """Test broadcasting behavior when MatMul and Add are fused in graph execution."""
+
+  def testMatMulAddBroadcastInTfFunction(self):
+    @def_function.function
+    def f(x):
+      return math_ops.add(
+          math_ops.matmul(x, x, transpose_a=True),
+          math_ops.matmul(array_ops.ones([1, 1], dtype=x.dtype), x),
+      )
+
+    x = constant_op.constant(np.ones([1, 7], dtype=np.float32))
+    res = f(x)
+    self.assertEqual(tuple(res.shape), (7, 7))
 
 
 @test_util.with_eager_op_as_function


### PR DESCRIPTION
Fixes #126661

### Description
When Grappler remapper fuses MatMul or Conv2D with an Add whose broadcasted bias tensor has leading 1s (such as `[1, N]` or `[1, 1, N]`), the fused node wires the multi-dimensional bias tensor directly into the fused op.

While `MklFusedMatMulOp` in `mkl_matmul_op_fused.cc` already supports `bias_dims > 1` when all leading dimensions are 1, `InitBiasAddArgs` in `fused_eigen_output_kernels.h`, `LaunchFusedMatMulOp` in `matmul_op_fused.cc` (GPU), and `LaunchFusedConv2DOp` in `conv_ops_fused_impl.h` strictly enforced `bias.dims() == 1`. When `_FusedMatMul` executed on the Eigen CPU path (such as inside a `tf.function`), it failed with `InvalidArgumentError: bias must be 1-dimensional`.

This patch updates `InitBiasAddArgs`, `LaunchFusedMatMulOp` (GPU), and `LaunchFusedConv2DOp` to validate that for bias tensors with rank >= 1, all dimensions except the last are 1. This aligns the Eigen and GPU kernels with the remapper and MKL implementations.

### Verification
- Tested with the reproduction script from #126661 under `tf.function` and confirmed the shape and numerical output match eager execution.
- Added C++ unit test `FusedMatMulWithBiasOpTest.MatMulWithBroadcastBias` in `matmul_op_test.cc`.
- Added Python regression test `MatMulAddFusionTest.testMatMulAddBroadcastInTfFunction` in `matmul_op_test.py`.