### PR TITLE
Fix integer overflow in GPU kernel loops for large tensors

### DIFF
--- a/tensorflow/core/kernels/population_count_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/population_count_op_gpu.cu.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/population_count_op.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
+#include "tensorflow/core/util/gpu_launch_config.h"
 
 namespace tensorflow {
 
@@ -33,37 +34,37 @@ typedef Eigen::GpuDevice GPUDevice;
 namespace functor {
 
 template <typename T>
-__global__ void PopulationCountKernel(const int size,
+__global__ void PopulationCountKernel(const int64_t size,
                                       const T* __restrict__ input,
                                       uint8_t* __restrict__ output) {
-  GPU_1D_KERNEL_LOOP(i, size) { output[i] = __popc(ldg(input + i)); }
+  GPU_1D_KERNEL_LOOP(i, size, int64_t) { output[i] = __popc(ldg(input + i)); }
 }
 
 template <>
-__global__ void PopulationCountKernel(const int size,
+__global__ void PopulationCountKernel(const int64_t size,
                                       const int8_t* __restrict__ input,
                                       uint8_t* __restrict__ output) {
   // For some reason, __popc on a negative int8 gets confused.
-  GPU_1D_KERNEL_LOOP(i, size) {
+  GPU_1D_KERNEL_LOOP(i, size, int64_t) {
     output[i] = __popc(ldg(reinterpret_cast<const uint8_t*>(input + i)));
   }
 }
 
 template <>
-__global__ void PopulationCountKernel(const int size,
+__global__ void PopulationCountKernel(const int64_t size,
                                       const int16_t* __restrict__ input,
                                       uint8_t* __restrict__ output) {
   // For some reason, __popc on a negative int16 gets confused.
-  GPU_1D_KERNEL_LOOP(i, size) {
+  GPU_1D_KERNEL_LOOP(i, size, int64_t) {
     output[i] = __popc(ldg(reinterpret_cast<const uint16_t*>(input + i)));
   }
 }
 
 template <>
 __global__ void PopulationCountKernel<int64_t>(
-    const int size, const int64_t* __restrict__ input,
+    const int64_t size, const int64_t* __restrict__ input,
     uint8_t* __restrict__ output) {
-  GPU_1D_KERNEL_LOOP(i, size) { output[i] = __popcll(ldg(input + i)); }
+  GPU_1D_KERNEL_LOOP(i, size, int64_t) { output[i] = __popcll(ldg(input + i)); }
 }
 
 #define DEFINE_GPU_SPECS(T)                                                   \
@@ -72,13 +73,18 @@ __global__ void PopulationCountKernel<int64_t>(
       OpKernelContext* c, typename TTypes<T>::ConstFlat input,                \
       TTypes<uint8>::Flat output) {                                           \
     const GPUDevice& d = c->eigen_device<GPUDevice>();                        \
-    int64 total_count = input.size();                                         \
+    const int64_t total_count = input.size();                                 \
     if (total_count == 0) {                                                   \
       /* Return on empty input. Output is empty for empty inputs,             \
        similar to CPU kernel.   */                                            \
       return;                                                                 \
     }                                                                         \
-    GpuLaunchConfig config = GetGpuLaunchConfig(total_count, d);              \
+    auto config_or = GetGpuLaunchConfig64(total_count, d);                    \
+    if (!config_or.ok()) {                                                    \
+      c->SetStatus(config_or.status());                                       \
+      return;                                                                 \
+    }                                                                         \
+    const GpuLaunchConfig64& config = *config_or;                             \
     TF_CHECK_OK(GpuLaunchKernel(PopulationCountKernel<T>, config.block_count, \
                                 config.thread_per_block, 0, d.stream(),       \
                                 total_count, input.data(), output.data()));   \

--- a/tensorflow/core/kernels/population_count_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/population_count_op_gpu.cu.cc
@@ -25,7 +25,6 @@ limitations under the License.
 #include "tensorflow/core/kernels/population_count_op.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
-#include "tensorflow/core/util/gpu_launch_config.h"
 
 namespace tensorflow {
 

--- a/tensorflow/core/kernels/roll_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/roll_op_gpu.cu.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/roll_op.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
+#include "tensorflow/core/util/gpu_launch_config.h"
 
 namespace tensorflow {
 
@@ -30,12 +31,12 @@ typedef Eigen::GpuDevice GPUDevice;
 namespace {
 
 template <typename T>
-__global__ void RollKernel(const int32_t nthreads, const int32_t num_dims,
+__global__ void RollKernel(const int64_t nthreads, const int32_t num_dims,
                            const T* __restrict__ input, T* __restrict__ output,
                            const int32_t* __restrict__ dim_size,
                            const int32_t* __restrict__ threshold,
                            const int64_t* __restrict__ dim_range) {
-  CUDA_1D_KERNEL_LOOP(out_idx, nthreads) {
+  CUDA_1D_KERNEL_LOOP(out_idx, nthreads, int64_t) {
     int64_t offset = 0;
     for (int i = 0; i < num_dims; i++) {
       const int64_t stride = dim_range[i] / dim_size[i];
@@ -75,7 +76,12 @@ struct Roll<GPUDevice, T> {
     d.memcpyHostToDevice(thres_buf, threshold.data(), thres_bytes);
     d.memcpyHostToDevice(range_buf, dim_range.data(), range_bytes);
 
-    GpuLaunchConfig cfg = GetGpuLaunchConfig(num_elements, d);
+    auto config_or = GetGpuLaunchConfig64(num_elements, d);
+    if (!config_or.ok()) {
+      context->SetStatus(config_or.status());
+      return;
+    }
+    const GpuLaunchConfig64& cfg = *config_or;
 
     TF_CHECK_OK(
         GpuLaunchKernel(RollKernel<T>, cfg.block_count, cfg.thread_per_block, 0,

--- a/tensorflow/core/kernels/roll_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/roll_op_gpu.cu.cc
@@ -77,10 +77,7 @@ struct Roll<GPUDevice, T> {
     d.memcpyHostToDevice(range_buf, dim_range.data(), range_bytes);
 
     auto config_or = GetGpuLaunchConfig64(num_elements, d);
-    if (!config_or.ok()) {
-      context->SetStatus(config_or.status());
-      return;
-    }
+    CHECK_OK(config_or.status());  // Crash OK
     const GpuLaunchConfig64& cfg = *config_or;
 
     TF_CHECK_OK(

--- a/tensorflow/core/kernels/roll_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/roll_op_gpu.cu.cc
@@ -22,7 +22,6 @@ limitations under the License.
 #include "tensorflow/core/kernels/roll_op.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
-#include "tensorflow/core/util/gpu_launch_config.h"
 
 namespace tensorflow {
 

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -34,18 +34,25 @@ limitations under the License.
 #endif
 
 // Deprecated, use 'for(int i : GpuGridRangeX(n))' instead.
-#define GPU_1D_KERNEL_LOOP(i, n, ...) \
-  GPU_1D_KERNEL_LOOP_SELECT(i, n, ##__VA_ARGS__)
-#define GPU_1D_KERNEL_LOOP_SELECT(i, n, T, ...) \
-  for (T i : ::tensorflow::GpuGridRangeX<T>(n))
-#define GPU_1D_KERNEL_LOOP_SELECT(i, n, ...) \
+#define TF_GPU_1D_KERNEL_LOOP_2(i, n) \
   for (int i : ::tensorflow::GpuGridRangeX<int>(n))
-#define CUDA_1D_KERNEL_LOOP(i, n, ...) \
-  CUDA_1D_KERNEL_LOOP_SELECT(i, n, ##__VA_ARGS__)
-#define CUDA_1D_KERNEL_LOOP_SELECT(i, n, T, ...) \
+#define TF_GPU_1D_KERNEL_LOOP_3(i, n, T) \
   for (T i : ::tensorflow::GpuGridRangeX<T>(n))
-#define CUDA_1D_KERNEL_LOOP_SELECT(i, n, ...) \
+#define TF_GPU_1D_KERNEL_LOOP_GET_MACRO(_1, _2, _3, NAME, ...) NAME
+#define GPU_1D_KERNEL_LOOP(...)                                         \
+  TF_GPU_1D_KERNEL_LOOP_GET_MACRO(__VA_ARGS__, TF_GPU_1D_KERNEL_LOOP_3, \
+                                  TF_GPU_1D_KERNEL_LOOP_2)              \
+  (__VA_ARGS__)
+
+#define TF_CUDA_1D_KERNEL_LOOP_2(i, n) \
   for (int i : ::tensorflow::GpuGridRangeX<int>(n))
+#define TF_CUDA_1D_KERNEL_LOOP_3(i, n, T) \
+  for (T i : ::tensorflow::GpuGridRangeX<T>(n))
+#define TF_CUDA_1D_KERNEL_LOOP_GET_MACRO(_1, _2, _3, NAME, ...) NAME
+#define CUDA_1D_KERNEL_LOOP(...)                                          \
+  TF_CUDA_1D_KERNEL_LOOP_GET_MACRO(__VA_ARGS__, TF_CUDA_1D_KERNEL_LOOP_3, \
+                                   TF_CUDA_1D_KERNEL_LOOP_2)              \
+  (__VA_ARGS__)
 
 // Deprecated, use 'for(int i : GpuGridRange?(n))' instead.
 #define GPU_AXIS_KERNEL_LOOP(i, n, axis) \

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -34,9 +34,17 @@ limitations under the License.
 #endif
 
 // Deprecated, use 'for(int i : GpuGridRangeX(n))' instead.
-#define GPU_1D_KERNEL_LOOP(i, n) \
+#define GPU_1D_KERNEL_LOOP(i, n, ...) \
+  GPU_1D_KERNEL_LOOP_SELECT(i, n, ##__VA_ARGS__)
+#define GPU_1D_KERNEL_LOOP_SELECT(i, n, T, ...) \
+  for (T i : ::tensorflow::GpuGridRangeX<T>(n))
+#define GPU_1D_KERNEL_LOOP_SELECT(i, n, ...) \
   for (int i : ::tensorflow::GpuGridRangeX<int>(n))
-#define CUDA_1D_KERNEL_LOOP(i, n) \
+#define CUDA_1D_KERNEL_LOOP(i, n, ...) \
+  CUDA_1D_KERNEL_LOOP_SELECT(i, n, ##__VA_ARGS__)
+#define CUDA_1D_KERNEL_LOOP_SELECT(i, n, T, ...) \
+  for (T i : ::tensorflow::GpuGridRangeX<T>(n))
+#define CUDA_1D_KERNEL_LOOP_SELECT(i, n, ...) \
   for (int i : ::tensorflow::GpuGridRangeX<int>(n))
 
 // Deprecated, use 'for(int i : GpuGridRange?(n))' instead.

--- a/tensorflow/core/util/gpu_kernel_helper_test.cu.cc
+++ b/tensorflow/core/util/gpu_kernel_helper_test.cu.cc
@@ -61,6 +61,8 @@ __global__ void Count1D(GpuLaunchConfig config, int bufsize,
 __global__ void Count1DInt64(GpuLaunchConfig64 config, int bufsize,
                              int* __restrict__ outbuf) {
   GPU_1D_KERNEL_LOOP(x, config.virtual_thread_count, int64_t) {
+    static_assert(std::is_same<decltype(x), int64_t>::value,
+                  "Expected int64_t index");
     if (x < 0) {  // x might overflow when testing extreme case
       break;
     }

--- a/tensorflow/core/util/gpu_kernel_helper_test.cu.cc
+++ b/tensorflow/core/util/gpu_kernel_helper_test.cu.cc
@@ -58,6 +58,15 @@ __global__ void Count1D(GpuLaunchConfig config, int bufsize,
     atomicAdd(&outbuf[x % bufsize], 1);
   }
 }
+__global__ void Count1DInt64(GpuLaunchConfig64 config, int bufsize,
+                             int* __restrict__ outbuf) {
+  GPU_1D_KERNEL_LOOP(x, config.virtual_thread_count, int64_t) {
+    if (x < 0) {  // x might overflow when testing extreme case
+      break;
+    }
+    atomicAdd(&outbuf[x % bufsize], 1);
+  }
+}
 __global__ void Count2D(Gpu2DLaunchConfig config, int bufsize,
                         int* __restrict__ outbuf) {
   GPU_AXIS_KERNEL_LOOP(x, config.virtual_thread_count.x, X) {
@@ -219,6 +228,38 @@ TEST_F(GpuLaunchConfigTest, GetGpuLaunchConfig) {
   TEST_LAUNCH_PARAMETER(123456);
   TEST_LAUNCH_PARAMETER(1 << 30);
 #undef TEST_LAUNCH_PARAMETER
+}
+
+TEST_F(GpuLaunchConfigTest, GetGpuLaunchConfig64WithTyped1DKernelLoop) {
+  GpuLaunchConfig64 cfg;
+  GpuLaunchConfig cfg1d;
+  const int64_t work_element_count = 123456;
+
+  cfg1d = GetGpuLaunchConfig(bufsize, d);
+  TF_CHECK_OK(GpuLaunchKernel(SetOutbufZero, cfg1d.block_count, cfg1d.thread_per_block,
+                              0, d.stream(), cfg1d, outbuf));
+  CUDA_ASSERT_SUCCESS
+
+  cfg = GetGpuLaunchConfig64(work_element_count, d).value();
+  TF_CHECK_OK(GpuLaunchKernel(Count1DInt64, cfg.block_count, cfg.thread_per_block,
+                              0, d.stream(), cfg, bufsize, outbuf));
+  CUDA_EXPECT_SUCCESS
+  copyToHost();
+  EXPECT_EQ(work_element_count,
+            std::accumulate(outbuf_host, outbuf_host + bufsize, 0));
+
+  cfg1d = GetGpuLaunchConfig(bufsize, d, SetOutbufZero, 0, 0);
+  TF_CHECK_OK(GpuLaunchKernel(SetOutbufZero, cfg1d.block_count, cfg1d.thread_per_block,
+                              0, d.stream(), cfg1d, outbuf));
+  CUDA_ASSERT_SUCCESS
+
+  cfg = GetGpuLaunchConfig64(work_element_count, d, Count1DInt64, 0, 0).value();
+  TF_CHECK_OK(GpuLaunchKernel(Count1DInt64, cfg.block_count, cfg.thread_per_block,
+                              0, d.stream(), cfg, bufsize, outbuf));
+  CUDA_EXPECT_SUCCESS
+  copyToHost();
+  EXPECT_EQ(work_element_count,
+            std::accumulate(outbuf_host, outbuf_host + bufsize, 0));
 }
 
 bool operator==(const Gpu2DLaunchConfig& a, const Gpu2DLaunchConfig& b) {


### PR DESCRIPTION
Extended `GPU_1D_KERNEL_LOOP` / `CUDA_1D_KERNEL_LOOP` with an optional index type,
updated `population_count` and `roll` GPU kernels to use `int64_t` sizes and
`GetGpuLaunchConfig64`, and adds `gpu_kernel_helper_test` coverage.

Addressed review feedback on #112249:
- kernel size parameters use `int64_t`
- host launch uses `GetGpuLaunchConfig64` / `GpuLaunchConfig64`
- unit test for the 3-argument `int64_t` macro variant in `gpu_kernel_helper_test.cu.cc`

Fixes #109520
Fixes #104077
Supersedes #112249
