### PR TITLE
Reject RaggedGather value-count overflow instead of a heap-buffer-overflow write

### DIFF
--- a/tensorflow/core/kernels/ragged_gather_op.cc
+++ b/tensorflow/core/kernels/ragged_gather_op.cc
@@ -128,6 +128,7 @@ class RaggedGatherOpBase : public OpKernel {
       std::vector<std::pair<SPLITS_TYPE, SPLITS_TYPE>>* value_slices,
       SPLITS_TYPE* num_values) {
     *num_values = 0;
+    int64_t total_values = 0;
     value_slices->clear();
 
     int num_splits = indices_in.dims() - 1 + params_nested_splits_in.size();
@@ -188,9 +189,17 @@ class RaggedGatherOpBase : public OpKernel {
       }
       if (limit != start) {
         value_slices->emplace_back(start, limit);
-        *num_values += limit - start;
+        total_values += limit - start;
       }
     }
+    // The value count is accumulated in a wide type and validated before it is
+    // narrowed to SPLITS_TYPE, so an int32 Tsplits cannot silently wrap and
+    // drive an undersized output allocation in WriteValues.
+    if (total_values > std::numeric_limits<SPLITS_TYPE>::max()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Number of values ", total_values, " exceeds limits of Tsplits"));
+    }
+    *num_values = static_cast<SPLITS_TYPE>(total_values);
     return absl::OkStatus();
   }
 

--- a/tensorflow/python/ops/ragged/BUILD
+++ b/tensorflow/python/ops/ragged/BUILD
@@ -965,6 +965,7 @@ py_test(
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:array_ops",
         "//tensorflow/python/ops:gradients_impl",
+        "//tensorflow/python/ops:ragged_array_ops_gen",
         "//tensorflow/python/platform:test",
         "//third_party/py/numpy",
         "@absl_py//absl/testing:parameterized",

--- a/tensorflow/python/ops/ragged/ragged_gather_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_gather_op_test.py
@@ -26,6 +26,7 @@ from tensorflow.python.framework import indexed_slices
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_ragged_array_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops.ragged import ragged_factory_ops
 from tensorflow.python.ops.ragged import ragged_gather_ops
@@ -221,6 +222,23 @@ class RaggedGatherOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     with self.assertRaisesRegex(errors.InvalidArgumentError,
                                 r'indices\[1\] = 3 is not in \[0, 2\)'):
       self.evaluate(ragged_gather_ops.gather(ragged_params, ragged_indices))
+
+  def testValueCountOverflowError(self):
+    # The gathered value count (num_indices * gathered_row_length) overflows an
+    # int32 Tsplits: 65537 * 65536 = 2**32 + 65536. Before the fix this wrapped
+    # to 65536, drove an undersized output allocation, and the copy loop then
+    # wrote past it (heap-buffer-overflow). The raw op pins Tsplits=int32; the
+    # high-level gather defaults to int64 splits and cannot reproduce.
+    with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                'exceeds limits of Tsplits'):
+      self.evaluate(
+          gen_ragged_array_ops.ragged_gather(
+              params_nested_splits=[
+                  constant_op.constant([0, 65536], dtype=dtypes.int32)
+              ],
+              params_dense_values=array_ops.zeros([65536], dtype=dtypes.uint8),
+              indices=array_ops.zeros([65537], dtype=dtypes.int32),
+              OUTPUT_RAGGED_RANK=1))
 
   def testUnknownIndicesRankError(self):
     if context.executing_eagerly():


### PR DESCRIPTION
Fixes #126135.

## Problem

`RaggedGather` with int32 `Tsplits` can compute a total output value count that exceeds int32. The count is accumulated in the splits type (`ragged_gather_op.cc`), so it wraps. The wrapped, smaller count is used to allocate the output values tensor, but the copy loop still walks the full un-wrapped set of slices, so it writes past the allocation. AddressSanitizer reports a heap-buffer-overflow write at `ragged_gather_op.cc:47`.

Repro from the issue:

```python
tf.raw_ops.RaggedGather(
    params_nested_splits=[tf.constant([0, 65536], tf.int32)],
    params_dense_values=tf.zeros([65536], tf.uint8),
    indices=tf.zeros([65537], tf.int32),
    OUTPUT_RAGGED_RANK=1,
)
```

The true count is `65537 * 65536 = 2**32 + 65536`, which wraps to `65536` in int32.

## Fix

Accumulate the value count in `int64_t`, then validate it against `std::numeric_limits<SPLITS_TYPE>::max()` before the output is allocated, returning `InvalidArgumentError` on overflow. This follows the existing guard in `ragged_range_op.cc` ("Number of rows exceeds limits of Tsplits"). Valid inputs are unaffected: the narrowed count equals the previous value.

## Test

Adds `testValueCountOverflowError` to `ragged_gather_op_test.py`. It drives the raw `RaggedGather` op to pin `Tsplits=int32`, because the high-level `ragged_gather_ops.gather` defaults to int64 splits and cannot reproduce the wrap. The test inputs are small: the guard returns the error before the oversized output is allocated, so the test does not need gigabytes of memory.

## Out of scope

The kernel keeps several `int`-typed index locals (`out_pos` in `WriteValueSlices`, and `start`, `limit`, and the loop counters in `MakeSplits`). This guard caps the value count at the `Tsplits` maximum, so for int32 `Tsplits` those locals cannot overflow. They stay a pre-existing truncation only for int64 `Tsplits` gathering more than `INT_MAX` values, which needs a multi-gigabyte output. That is a separate issue and is not changed here.

## Verification

I did not build locally. Runtime verification is left to the TensorFlow presubmit CI, which builds and runs `ragged_gather_op_test`.
