### PR TITLE
[Grappler/Kernels] Support multi-dimensional bias with leading ones in fused MatMul and Conv2D

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -708,8 +708,7 @@ bool IsBiasSemanticAdd(const RemapperContext& ctx,
     int conv_channel_dim;
     conv_channel_dim = shape.dim(shape.dim_size() - 1).size();
 
-    if (shape.dim_size() == 4 && bcast_shape.dim_size() > 4) return false;
-    if (shape.dim_size() == 5 && bcast_shape.dim_size() > 5) return false;
+    if (bcast_shape.dim_size() > shape.dim_size()) return false;
 
     if (shape.dim_size() < 2) return false;
     // Check that the conv node's channel dim is equal to the 1-dim add node's

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -1492,6 +1492,111 @@ TEST_F(RemapperTest, FuseMatmulWithAdd) {
   test::ExpectClose(tensors[0], tensors_expected[0], 1e-6);
 }
 
+// Fuse matmul(transpose_a=true) + add {1,C}
+TEST_F(RemapperTest, FuseMatmulTransposeAWithAdd) {
+  if (!IsMKLEnabled()) GTEST_SKIP() << "Test only applicable to MKL.";
+
+  using ::tensorflow::ops::Placeholder;
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+
+  auto lhs_shape = ops::Placeholder::Shape({32, 8});
+  auto rhs_shape = ops::Placeholder::Shape({32, 64});
+
+  auto lhs = Placeholder(s.WithOpName("lhs"), DT_FLOAT, lhs_shape);
+  auto rhs = Placeholder(s.WithOpName("rhs"), DT_FLOAT, rhs_shape);
+
+  auto matmul = ops::MatMul(s.WithOpName("matmul"), lhs, rhs,
+                            ops::MatMul::Attrs().TransposeA(true));
+  auto add_const = ops::Const(s.WithOpName("add_const"), 1.0f, {1, 64});
+  auto add = ops::Add(s.WithOpName("add"), matmul, add_const);
+  auto fetch = ops::Identity(s.WithOpName("fetch"), add);
+
+  auto lhs_t = GenerateTensorWithSetRandom<DT_FLOAT>({32, 8});
+  auto rhs_t = GenerateTensorWithSetRandom<DT_FLOAT>({32, 64});
+
+  GrapplerItem item;
+  item.fetch = {"fetch"};
+  item.feed = {{"lhs", lhs_t}, {"rhs", rhs_t}};
+  TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+
+  // Place all nodes on CPU.
+  for (int i = 0; i < item.graph.node_size(); ++i) {
+    item.graph.mutable_node(i)->set_device("/device:CPU:0");
+  }
+
+  Remapper optimizer(RewriterConfig::AGGRESSIVE);
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  int found = 0;
+  for (const NodeDef& node : output.node()) {
+    if (node.name() == "add") {
+      EXPECT_EQ(node.op(), "_FusedMatMul");
+      ASSERT_GE(node.input_size(), 3);
+      EXPECT_EQ(node.input(0), "lhs");
+      EXPECT_EQ(node.input(1), "rhs");
+
+      EXPECT_EQ(node.attr().at("num_args").i(), 1);
+      EXPECT_EQ(node.input(2), "add_const");
+
+      const auto fused_ops = node.attr().at("fused_ops").list().s();
+      ASSERT_EQ(fused_ops.size(), 1);
+      EXPECT_EQ(fused_ops[0], "BiasAdd");
+      found++;
+    }
+  }
+  EXPECT_EQ(1, found);
+
+  auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
+  ASSERT_EQ(tensors_expected.size(), 1);
+  auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+  ASSERT_EQ(tensors.size(), 1);
+  test::ExpectClose(tensors[0], tensors_expected[0], 1e-6);
+}
+
+// Do not fuse matmul with add when addend has higher rank than matmul output
+TEST_F(RemapperTest, DoNotFuseMatmulWithAddHigherRank) {
+  if (!IsMKLEnabled()) GTEST_SKIP() << "Test only applicable to MKL.";
+
+  using ::tensorflow::ops::Placeholder;
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+
+  auto lhs_shape = ops::Placeholder::Shape({8, 32});
+  auto rhs_shape = ops::Placeholder::Shape({32, 64});
+
+  auto lhs = Placeholder(s.WithOpName("lhs"), DT_FLOAT, lhs_shape);
+  auto rhs = Placeholder(s.WithOpName("rhs"), DT_FLOAT, rhs_shape);
+
+  auto matmul = ops::MatMul(s.WithOpName("matmul"), lhs, rhs);
+  auto add_const = ops::Const(s.WithOpName("add_const"), 1.0f, {1, 1, 1, 64});
+  auto add = ops::Add(s.WithOpName("add"), matmul, add_const);
+  auto fetch = ops::Identity(s.WithOpName("fetch"), add);
+
+  auto lhs_t = GenerateTensorWithSetRandom<DT_FLOAT>({8, 32});
+  auto rhs_t = GenerateTensorWithSetRandom<DT_FLOAT>({32, 64});
+
+  GrapplerItem item;
+  item.fetch = {"fetch"};
+  item.feed = {{"lhs", lhs_t}, {"rhs", rhs_t}};
+  TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+
+  for (int i = 0; i < item.graph.node_size(); ++i) {
+    item.graph.mutable_node(i)->set_device("/device:CPU:0");
+  }
+
+  Remapper optimizer(RewriterConfig::AGGRESSIVE);
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  int fused_found = 0;
+  for (const NodeDef& node : output.node()) {
+    if (node.op() == "_FusedMatMul") {
+      fused_found++;
+    }
+  }
+  EXPECT_EQ(0, fused_found);
+}
+
 class RemapperFuseSoftplusTanhMul : public RemapperTest {
  public:
   template <DataType DTYPE>

--- a/tensorflow/core/kernels/conv_ops_fused_impl.h
+++ b/tensorflow/core/kernels/conv_ops_fused_impl.h
@@ -375,12 +375,19 @@ struct LaunchFusedConv2DOp<GPUDevice, T> {
     const int64_t out_cols = GetTensorDim(*output, params.data_format, 'W');
     const int64_t out_depths = GetTensorDim(*output, params.data_format, 'C');
 
-    // Bias of the following dimensions: [ output_depth ]
+    // Bias of the following dimensions: [ output_depth ] or [ 1, ..., 1, output_depth ]
     const Tensor& bias = context->input(2);
-    OP_REQUIRES(context, bias.dims() == 1,
+    OP_REQUIRES(context, bias.dims() >= 1,
                 absl::InvalidArgumentError(absl::StrCat(
-                    "bias must be 1-dimensional", bias.shape().DebugString())));
-    OP_REQUIRES(context, bias.dim_size(0) == out_depths,
+                    "bias must be at least 1-dimensional", bias.shape().DebugString())));
+    for (int i = 0; i < bias.dims() - 1; ++i) {
+      OP_REQUIRES(context, bias.dim_size(i) == 1,
+                  absl::InvalidArgumentError(
+                      absl::StrCat("For bias_dims > 1, all except the "
+                                   "last dimension must be 1, got: ",
+                                   bias.shape().DebugString())));
+    }
+    OP_REQUIRES(context, bias.dim_size(bias.dims() - 1) == out_depths,
                 absl::InvalidArgumentError(
                     absl::StrCat("bias depth must be equal to out depth",
                                  bias.shape().DebugString())));

--- a/tensorflow/core/kernels/fused_eigen_output_kernels.h
+++ b/tensorflow/core/kernels/fused_eigen_output_kernels.h
@@ -414,9 +414,19 @@ absl::Status InitBiasAddArgs(OpKernelContext* context, BiasAddArgs<T>* args,
   // Bias of the following dimensions: [ output_depth ]
   const Tensor& bias = context->input(2);
 
-  if (bias.dims() != 1)
+  if (bias.dims() < 1) {
     return absl::InvalidArgumentError(
-        absl::StrCat("bias must be 1-dimensional", bias.shape().DebugString()));
+        absl::StrCat("bias must be at least 1-dimensional",
+                     bias.shape().DebugString()));
+  }
+  for (int i = 0; i < bias.dims() - 1; ++i) {
+    if (bias.dim_size(i) != 1) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("For bias_dims > 1, all except the last dimension "
+                       "must be 1, got: ",
+                       bias.shape().DebugString()));
+    }
+  }
 
   const auto data_ptr = [](const Tensor& tensor) -> const T* {
     return reinterpret_cast<const T*>(tensor.tensor_data().data());

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -453,10 +453,18 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     // + <other pointwise operations>. Therefore, the bias tensor is required.
     const Tensor& bias = context->input(2);
 
-    if (bias.dims() != 1) {
+    if (bias.dims() < 1) {
       OP_REQUIRES_OK(context, absl::InvalidArgumentError(
-                                  absl::StrCat("bias must be 1-dimensional",
+                                  absl::StrCat("bias must be at least 1-dimensional",
                                                bias.shape().DebugString())));
+    }
+    for (int i = 0; i < bias.dims() - 1; ++i) {
+      if (bias.dim_size(i) != 1) {
+        OP_REQUIRES_OK(context, absl::InvalidArgumentError(
+                                    absl::StrCat("For bias_dims > 1, all except the "
+                                                 "last dimension must be 1, got: ",
+                                                 bias.shape().DebugString())));
+      }
     }
 
     auto a_ptr = AsDeviceMemory(a.template flat<T>().data(),

--- a/tensorflow/core/kernels/matmul_op_test.cc
+++ b/tensorflow/core/kernels/matmul_op_test.cc
@@ -288,6 +288,44 @@ class FusedMatMulOpTest : public OpsTestBase {
                              run_fused);
   }
 
+  // Verifies that computing MatMul+BiasAdd with 2D bias [1, N] is supported
+  // and matches the 1D bias computation.
+  void VerifyMatMulWith2DBias(int m, int k, int n, bool transpose_a,
+                              bool transpose_b) {
+    VLOG(2) << "=== VerifyMatMulWith2DBias (" << m << ", " << k << ", " << n
+            << ", " << (int)transpose_a << ", " << (int)transpose_b << ") ===";
+
+    DataType dtype = DataTypeToEnum<T>::v();
+    Tensor lhs(dtype, {transpose_a ? k : m, transpose_a ? m : k});
+    lhs.flat<T>() = lhs.flat<T>().setRandom();
+
+    Tensor rhs(dtype, {transpose_b ? n : k, transpose_b ? k : n});
+    rhs.flat<T>() = rhs.flat<T>().setRandom();
+
+    Tensor bias_1d(dtype, {n});
+    bias_1d.flat<T>() = bias_1d.flat<T>().setRandom();
+
+    Tensor bias_2d(dtype, {1, n});
+    std::copy_n(bias_1d.flat<T>().data(), n, bias_2d.flat<T>().data());
+
+    Tensor matmul;
+    Tensor fused_matmul;
+
+    RunMatMulWithBias(lhs, rhs, bias_1d, transpose_a, transpose_b, &matmul,
+                      /*allow_gpu_device=*/true);
+    bool skipped = false;
+    RunFusedMatMulOp(lhs, rhs, {bias_2d}, {"BiasAdd"}, transpose_a,
+                     transpose_b, &fused_matmul, /*allow_gpu_device=*/true,
+                     &skipped);
+    if (!skipped) {
+      ASSERT_EQ(matmul.dtype(), fused_matmul.dtype());
+      ASSERT_EQ(matmul.shape(), fused_matmul.shape());
+      double atol = this->kTValueType == DT_HALF ? 1e-3 : 1e-5;
+      double rtol = this->kTValueType == DT_HALF ? 1e-3 : -1.0;
+      test::ExpectClose(matmul, fused_matmul, atol, rtol);
+    }
+  }
+
   // Verifies that computing MatMul+BiasAdd+{Activation} in a graph is identical
   // to FusedMatMul.
   void VerifyConv2DWithBiasAndActivation(int m, int k, int n, bool transpose_a,
@@ -402,11 +440,19 @@ TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul1x256x1WithActivation) {
   }
 }
 
+TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul2DBias) {
+  this->VerifyMatMulWith2DBias(8, 32, 64, false, false);
+  this->VerifyMatMulWith2DBias(8, 32, 64, true, false);
+  this->VerifyMatMulWith2DBias(8, 32, 64, false, true);
+  this->VerifyMatMulWith2DBias(8, 32, 64, true, true);
+}
+
 REGISTER_TYPED_TEST_SUITE_P(FusedMatMulWithBiasOpTest,       //
                             MatMul256x128x64,                //
                             MatMul1x256x256,                 //
                             MatMul256x256x1,                 //
                             MatMul1x256x1,                   //
+                            MatMul2DBias,                    //
                             MatMul256x128x64WithActivation,  //
                             MatMul1x256x256WithActivation,   //
                             MatMul256x256x1WithActivation,   //

--- a/tensorflow/python/grappler/remapper_test.py
+++ b/tensorflow/python/grappler/remapper_test.py
@@ -337,6 +337,25 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
     fused_op = ['_FusedConv2D']
     self._VerifyValues(out, False, fused_op, epilog_ops)
 
+  @test_util.run_deprecated_v1
+  def test_matmul_transpose_a_broadcast_bias_add(self):
+    """Test MatMul(transpose_a=True) + Add([1, N]) fusion."""
+    ops.reset_default_graph()
+    k, m, n = (4, 8, 16)
+    x = _input([k, m])
+    w = _weight([k, n])
+    b = constant_op.constant(0.5, shape=[1, n], dtype=dtypes.float32)
+
+    y = math_ops.matmul(x, w, transpose_a=True)
+    out = math_ops.add(y, b)
+
+    if test_util.IsMklEnabled():
+      fused_op = ['_MklNativeFusedMatMul', '_MklFusedMatMul', '_FusedMatMul']
+      epilog_ops = [b'BiasAdd']
+      self._VerifyValues(out, False, fused_op, epilog_ops)
+    else:
+      self._VerifyNoFusion(out)
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Fixes #126661

### Description
Adding a `[1, N]` tensor to the result of a `MatMul` (specifically when `transpose_a=True`) or `Conv2D` succeeds in eager execution via broadcasting. However, when wrapped in `tf.function`, graph execution crashes with:
```text
W0000 00:00:1788378737.932106 29856 op_kernel.cc:1858] OP_REQUIRES failed at matmul_op_fused.cc:136 : INVALID_ARGUMENT: bias must be 1-dimensional[1,7]
InvalidArgumentError: Graph execution error:
Detected at node Add: bias must be 1-dimensional[1,7] [[{{node Add}}]]
```

### Root Cause
1. In Grappler Remapper (`remapper.cc:705-725`), `IsBiasSemanticAdd` matches an `Add` node with an addend having shape `[1, N]` (since all leading dimensions before the channel dimension are 1). Remapper replaces the node with `_FusedMatMul` (or `_FusedConv2D`), passing the `[1, N]` tensor as the bias operand.
2. In `mkl_layout_pass.cc`, `FusedMatMulRewrite` skips rewriting `_FusedMatMul` to `_MklNativeFusedMatMul` when `transpose_a=True` to avoid reorder overhead. On GPU or non-oneDNN builds, the op also remains `_FusedMatMul`.
3. In `fused_eigen_output_kernels.h`, `InitBiasAddArgs` strictly checked `if (bias.dims() != 1)` and failed with `InvalidArgumentError`. Similarly, the GPU fused MatMul and Conv2D kernels strictly asserted `bias.dims() == 1`. However, the memory layout of any `[1, ..., 1, N]` tensor is contiguous and identical to a 1D vector of length `N`. In oneDNN's `mkl_matmul_op_fused.cc` and `mkl_conv_ops.h`, this relaxed check had already been implemented.

### Solution
1. **Eigen CPU Kernel**: In `fused_eigen_output_kernels.h`, updated `InitBiasAddArgs` to allow `bias.dims() >= 1` as long as all leading dimensions before the last (channel) dimension are 1.
2. **GPU Kernels**: In `matmul_op_fused.cc` and `conv_ops_fused_impl.h`, updated GPU `LaunchFusedMatMulOp` and `FusedConv2D` bias validation to accept `bias.dims() >= 1` with leading ones.
3. **Grappler Remapper Guard**: In `remapper.cc:711`, added `if (bcast_shape.dim_size() > shape.dim_size()) return false;` to prevent fusing when the broadcast shape would expand the output tensor's rank.
4. **Tests**:
   - Added `FuseMatmulTransposeAWithAdd` and `DoNotFuseMatmulWithAddHigherRank` in `remapper_test.cc`.
   - Added `VerifyMatMulWith2DBias` and `MatMul2DBias` in `matmul_op_test.cc` testing all 4 transpose combinations (`FF`, `TF`, `FT`, `TT`) with `[1, N]` bias.
   - Added `test_matmul_transpose_a_broadcast_bias_add` in `remapper_test.py`.
