### PR TITLE
fix: central_crop use logical_and for bounds validation

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -948,7 +948,7 @@ def central_crop(image, central_fraction):
         return image
     else:
       assert_ops = _assert(
-          math_ops.logical_or(central_fraction > 0.0, central_fraction <= 1.0),
+          math_ops.logical_and(central_fraction > 0.0, central_fraction <= 1.0),
           ValueError, 'central_fraction must be within (0, 1]')
       image = control_flow_ops.with_dependencies(assert_ops, image)
 


### PR DESCRIPTION
fix: central_crop bounds check uses logical_or instead of logical_and

`central_crop` validates `central_fraction` with `tf.logical_or(fraction <= 0.0,
fraction > 1.0)`. This condition is trivially false for all real numbers: no
value is simultaneously <= 0.0 AND > 1.0. The `or` makes the assertion always
pass, meaning invalid fractions like -0.5 or 2.0 silently proceed and produce
incorrect crops or crashes downstream.

The static-path check immediately above uses the correct `and` logic. The
dynamic-path check should match.

**Fix:** Change `tf.logical_or` to `tf.logical_and`. This correctly rejects
any fraction that is not in the range (0.0, 1.0].
