### PR TITLE
Preserve float64 sparse xent tail gradients

### DIFF
--- a/tensorflow/core/kernels/sparse_xent_op.h
+++ b/tensorflow/core/kernels/sparse_xent_op.h
@@ -17,6 +17,8 @@ limitations under the License.
 #define TENSORFLOW_CORE_KERNELS_SPARSE_XENT_OP_H_
 // Functor definition for SparseXentOp, must be compilable by nvcc.
 
+#include <type_traits>
+
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -125,6 +127,44 @@ class SparseXentGradGenerator {
   const Index max_depth_;
 };
 
+// Masks or replaces the labeled component of an already-computed gradient.
+template <typename T, typename Index, bool kReplaceLabel>
+class SparseXentStableGradGenerator {
+ public:
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE SparseXentStableGradGenerator(
+      typename TTypes<const T, 2>::Tensor32Bit gradients,
+      typename TTypes<const T, 1>::Tensor32Bit non_label_sums,
+      typename TTypes<const Index, 1>::Tensor32Bit labels,
+      const Index max_depth)
+      : gradients_(gradients),
+        non_label_sums_(non_label_sums),
+        labels_(labels),
+        max_depth_(max_depth) {}
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE T
+  operator()(const Eigen::array<int, 2>& coords) const {
+    const int batch = coords[0];
+    const int depth = coords[1];
+    const Index label = tensorflow::internal::SubtleMustCopy(labels_(batch));
+    if (!FastBoundsCheck(label, max_depth_)) {
+      return Eigen::NumTraits<T>::quiet_NaN();
+    }
+    if (TF_PREDICT_FALSE(depth == label)) {
+      if (kReplaceLabel) {
+        return -non_label_sums_(batch);
+      }
+      return T(0.0);
+    }
+    return gradients_(coords);
+  }
+
+ private:
+  typename TTypes<const T, 2>::Tensor32Bit gradients_;
+  typename TTypes<const T, 1>::Tensor32Bit non_label_sums_;
+  typename TTypes<const Index, 1>::Tensor32Bit labels_;
+  const Index max_depth_;
+};
+
 }  // namespace generator
 
 namespace functor {
@@ -222,6 +262,26 @@ struct SparseXentEigenImpl {
         backprop.dimension(1) /* max_depth */);
     To32Bit(backprop).device(d) =
         To32Bit(backprop).generate(sparse_xent_grad_gen);
+
+    // In float64, p(label) can round to 1 while other class probabilities are
+    // still finite. Compute the labeled component from those probabilities so
+    // the small gradient signal is retained.
+    if (std::is_same<T, double>::value) {
+      generator::SparseXentStableGradGenerator<T, Index, false>
+          non_label_grad_gen(
+              sparse_xent_helpers::To32BitConst<T>(backprop),
+              sparse_xent_helpers::To32BitConst<T>(scratch), To32Bit(labels),
+              backprop.dimension(1) /* max_depth */);
+      To32Bit(scratch).device(d) =
+          To32Bit(backprop).generate(non_label_grad_gen).sum(along_class);
+
+      generator::SparseXentStableGradGenerator<T, Index, true> stable_grad_gen(
+          sparse_xent_helpers::To32BitConst<T>(backprop),
+          sparse_xent_helpers::To32BitConst<T>(scratch), To32Bit(labels),
+          backprop.dimension(1) /* max_depth */);
+      To32Bit(backprop).device(d) =
+          To32Bit(backprop).generate(stable_grad_gen);
+    }
   }
 };
 

--- a/tensorflow/python/kernel_tests/sparse_ops/BUILD
+++ b/tensorflow/python/kernel_tests/sparse_ops/BUILD
@@ -390,6 +390,7 @@ py_library(
         "//tensorflow/python/ops:gradient_checker_v2",
         "//tensorflow/python/ops:nn_grad",
         "//tensorflow/python/ops:nn_ops",
+        "//tensorflow/python/ops:nn_ops_gen",
         "//tensorflow/python/platform:client_testlib",
         "//third_party/py/numpy",
     ],

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_xent_op_test_base.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_xent_op_test_base.py
@@ -25,6 +25,7 @@ from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import ops as ops_lib
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_nn_ops
 from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import nn_ops
 import tensorflow.python.ops.nn_grad  # pylint: disable=unused-import
@@ -54,7 +55,8 @@ class SparseXentOpTestBase(test.TestCase):
     labels_mat = np.zeros_like(probs).astype(probs.dtype)
     labels_mat[np.arange(batch_size), labels] = 1.0
     gradient = (probs - labels_mat)
-    loss = -np.sum(labels_mat * np.log(probs + 1.0e-20), axis=1)
+    loss = np.negative(
+        np.sum(labels_mat * np.log(probs + 1.0e-20), axis=1))
     return loss, gradient
 
   def _testXent(self, np_labels, np_logits):
@@ -186,6 +188,19 @@ class SparseXentOpTestBase(test.TestCase):
           np_labels=np.array([0, 3]).astype(label_dtype),
           np_logits=np.array([[1., 1., 1., 1.], [1., 2., 3.,
                                                  4.]]).astype(np.float64))
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDoublePreservesSmallGradient(self):
+    tail_probability = 5.551115123125776e-17
+    for label_dtype in np.int32, np.int64:
+      _, gradient = gen_nn_ops.sparse_softmax_cross_entropy_with_logits(
+          labels=np.array([0], dtype=label_dtype),
+          features=np.array([[37.42994775023705, 0.0]], dtype=np.float64))
+      gradient = self.evaluate(gradient)
+      self.assertAllClose(
+          [[-tail_probability, tail_probability]], gradient, rtol=1e-14,
+          atol=0)
+      self.assertEqual(gradient[0, 0], -gradient[0, 1])
 
   def testHalf(self):
     for label_dtype in np.int32, np.int64:


### PR DESCRIPTION
## Summary

- derive the labeled float64 gradient from the sum of the other class probabilities
- preserve finite tail gradients when the labeled probability rounds to one
- leave lower-precision and GPU execution paths unchanged

Fixes #126636.

## Testing

- `bazel build //tensorflow/core/kernels:sparse_xent_op`
- added graph/eager regression coverage for `int32` and `int64` labels