### PR TITLE
Use SoftplusGrad for stable higher derivatives

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -844,6 +844,7 @@ cuda_py_strict_test(
     size = "small",
     srcs = ["softplus_op_test.py"],
     deps = [
+        "//tensorflow/python/eager:backprop",
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:for_generated_wrappers",
         "//tensorflow/python/framework:test_lib",

--- a/tensorflow/python/kernel_tests/nn_ops/softplus_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/softplus_op_test.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 
+from tensorflow.python.eager import backprop as backprop_lib
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import test_util
@@ -115,6 +116,21 @@ class SoftplusTest(test.TestCase):
           x, [2, 5], grad, [2, 5], x_init_value=x_init)
     print("softplus (float) gradient of gradient err = ", err)
     self.assertLess(err, 5e-5)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDoubleGradGradPreservesSmallValue(self):
+    x = constant_op.constant(37.42994775023705, dtype=dtypes.float64)
+    with backprop_lib.GradientTape() as outer_tape:
+      outer_tape.watch(x)
+      with backprop_lib.GradientTape() as inner_tape:
+        inner_tape.watch(x)
+        y = nn_ops.softplus(x)
+      grad = inner_tape.gradient(y, x)
+    grad_grad = outer_tape.gradient(grad, x)
+
+    self.assertAllClose(
+        5.551115123125775e-17, self.evaluate(grad_grad), rtol=1e-14,
+        atol=0)
 
   @test_util.run_deprecated_v1
   def testGradGradGrad(self):

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -483,7 +483,7 @@ def _SeluGrad(op: ops.Operation, grad):
 
 @ops.RegisterGradient("Softplus")
 def _SoftplusGrad(op: ops.Operation, grad):
-  return grad * math_ops.sigmoid(op.inputs[0])
+  return gen_nn_ops.softplus_grad(grad, op.inputs[0])
 
 
 @ops.RegisterGradient("SoftplusGrad")


### PR DESCRIPTION
## Summary

- route the Python Softplus gradient through the existing `SoftplusGrad` op
- retain finite float64 second derivatives when the first derivative rounds to one
- align Python autodiff with the existing C++ gradient implementation

Fixes #126635.

## Testing

- `python3 -m py_compile tensorflow/python/ops/nn_grad.py tensorflow/python/kernel_tests/nn_ops/softplus_op_test.py`
- added graph/eager regression coverage for the reported float64 input