### PR TITLE
Preserve float64 log-softmax tail gradients

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -827,6 +827,7 @@ cuda_py_strict_test(
     size = "medium",
     srcs = ["softmax_op_test.py"],
     deps = [
+        "//tensorflow/python/eager:backprop",
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:errors",
         "//tensorflow/python/framework:for_generated_wrappers",

--- a/tensorflow/python/kernel_tests/nn_ops/softmax_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/softmax_op_test.py
@@ -19,9 +19,11 @@ import unittest
 import numpy as np
 
 
+from tensorflow.python.eager import backprop as backprop_lib
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
+from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
@@ -162,6 +164,22 @@ class SoftmaxTest(test.TestCase):
     self._testSoftmax(
         np.array([[1., 1., 1., 1.], [1., 2., 3., 4.]]).astype(np.float64))
     self._testOverflow()
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testLogSoftmaxDoubleGradientPreservesSmallGradient(self):
+    logits = constant_op.constant(
+        [37.42994775023705, 0.0], dtype=dtypes.float64)
+    cotangent = constant_op.constant([1.0, 0.0], dtype=dtypes.float64)
+    with backprop_lib.GradientTape() as tape:
+      tape.watch(logits)
+      output = nn_ops.log_softmax(logits)
+      objective = math_ops.reduce_sum(output * cotangent)
+    gradient = self.evaluate(tape.gradient(objective, logits))
+
+    tail_probability = 5.551115123125776e-17
+    self.assertAllClose(
+        [tail_probability, -tail_probability], gradient, rtol=1e-14, atol=0)
+    self.assertEqual(gradient[0], -gradient[1])
 
   @unittest.skipUnless(test.is_built_with_gpu_support(),
                        "Test only applicable when running on GPUs")

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -336,7 +336,11 @@ def _LogSoftmaxGrad(op: ops.Operation, grad):
     The gradients w.r.t. the input.
   """
   softmax = math_ops.exp(op.outputs[0])
-  return grad - math_ops.reduce_sum(grad, -1, keepdims=True) * softmax
+  result = grad - math_ops.reduce_sum(grad, -1, keepdims=True) * softmax
+  if result.dtype == dtypes.float64:
+    # Remove the zero-sum residual left by cancellation at saturated logits.
+    result = result - math_ops.reduce_sum(result, -1, keepdims=True) * softmax
+  return result
 
 
 @ops.RegisterGradient("BiasAdd")


### PR DESCRIPTION
## Summary

- remove the row-sum rounding residual from float64 log-softmax VJPs
- preserve finite tail components when the dominant softmax probability rounds to one
- leave other data types unchanged

Fixes #126630.

## Testing

- `python3 -m py_compile tensorflow/python/ops/nn_grad.py tensorflow/python/kernel_tests/nn_ops/softmax_op_test.py`
- added graph/eager regression coverage for the reported float64 input