### PR TITLE
Preserve float64 SiLU second derivatives

### DIFF
--- a/tensorflow/python/ops/nn_grad_test.py
+++ b/tensorflow/python/ops/nn_grad_test.py
@@ -336,6 +336,26 @@ class SwishGradOpTest(test.TestCase):
       error = gradient_checker_v2.max_error(theoretical, numerical)
       self.assertLess(error, 1e-4)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testSwishDoubleGradientPreservesSmallComponent(self):
+    features = constant_op.constant(40.410841513445845, dtypes.float64)
+    with backprop.GradientTape() as outer_tape:
+      outer_tape.watch(features)
+      with backprop.GradientTape() as inner_tape:
+        inner_tape.watch(features)
+        output = nn_impl.swish(features)
+      first_derivative = inner_tape.gradient(output, features)
+    second_derivative = self.evaluate(
+        outer_tape.gradient(first_derivative, features)
+    )
+
+    self.assertAllClose(
+        -1.0820525268131133e-16,
+        second_derivative,
+        rtol=1e-6,
+        atol=0.0,
+    )
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -478,16 +478,26 @@ def swish(features, beta=1.0):
       # de-duped with the forward pass) and we can free the sigmoid(features)
       # expression immediately after use during the forward pass.
       with ops.control_dependencies([dy]):
-        sigmoid_features = math_ops.sigmoid(beta * features)
+        logits = beta * features
+        if features.dtype == dtypes.float64:
+          # Evaluate the smaller sigmoid tail directly. For large positive
+          # logits, `1 - sigmoid(logits)` rounds to zero and erases finite
+          # higher-order derivatives.
+          use_complement = logits >= 0
+          sigmoid_tail = math_ops.sigmoid(
+              array_ops.where_v2(use_complement, -logits, logits)
+          )
+          sigmoid_features = array_ops.where_v2(
+              use_complement, 1.0 - sigmoid_tail, sigmoid_tail
+          )
+          sigmoid_grad = sigmoid_tail * (1.0 - sigmoid_tail)
+        else:
+          sigmoid_features = math_ops.sigmoid(logits)
+          sigmoid_grad = sigmoid_features * (1.0 - sigmoid_features)
 
-      activation_grad = sigmoid_features * (
-          1.0 + (beta * features) * (1.0 - sigmoid_features)
-      )
+      activation_grad = sigmoid_features + logits * sigmoid_grad
       beta_grad = math_ops.reduce_sum(
-          dy
-          * math_ops.square(features)
-          * sigmoid_features
-          * (1.0 - sigmoid_features)
+          dy * math_ops.square(features) * sigmoid_grad
       )
       return (dy * activation_grad, beta_grad)
 


### PR DESCRIPTION
Fixes #126632.

The custom SiLU gradient currently obtains its sigmoid tail as `1 - sigmoid(logits)`. For sufficiently large positive float64 logits, that subtraction rounds to zero and removes a finite second derivative.

For float64 gradients, evaluate the smaller sigmoid tail directly from the non-positive logit and reconstruct the sigmoid value with a complement only where needed. Reuse that stable tail for both the activation and beta gradients. Other dtypes retain the existing path.

Add a graph/eager regression for the reported input and correctly rounded second derivative.

Validation:
- `python3 -m py_compile tensorflow/python/ops/nn_impl.py tensorflow/python/ops/nn_grad_test.py`
- Numerical evaluation of the stable derivative formula at the reported float64 input