### PR TITLE
Fix GPU SwapDimension1And2InTensor3UsingTiles index overflow

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -335,6 +335,18 @@ tf_kernel_library(
     alwayslink = 1,
 )
 
+tf_cuda_only_cc_test(
+    name = "conv_2d_gpu_test",
+    size = "small",
+    srcs = ["conv_2d_gpu_test.cu.cc"],
+    features = if_cuda(["-layering_check"]),
+    deps = [
+        ":conv_2d",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+    ],
+)
+
 cc_library(
     name = "conv_2d_hdrs",
     hdrs = ["conv_2d.h"],

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -338,7 +338,10 @@ tf_kernel_library(
 tf_cuda_only_cc_test(
     name = "conv_2d_gpu_test",
     size = "small",
-    srcs = ["conv_2d_gpu_test.cu.cc"],
+    srcs = [
+        "conv_2d_gpu.h",
+        "conv_2d_gpu_test.cu.cc",
+    ],
     features = if_cuda(["-layering_check"]),
     deps = [
         ":conv_2d",

--- a/tensorflow/core/kernels/conv_2d_gpu.h
+++ b/tensorflow/core/kernels/conv_2d_gpu.h
@@ -150,10 +150,10 @@ struct Index : Array<int, IndexCount, 0> {
 };
 
 // A helper function that converts a tensor index into a flat array index.
-template <int IndexCount>
-EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE int TensorIndexToFlat(
+template <typename FlatIndex = int, int IndexCount>
+EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE FlatIndex TensorIndexToFlat(
     const Index<IndexCount>& index, const Dimension<IndexCount>& dims) {
-  int flat_index = index[0];
+  FlatIndex flat_index = index[0];
   for (int i = 1; i < IndexCount; i++) {
     flat_index = flat_index * dims[i] + index[i];
   }
@@ -320,8 +320,8 @@ __global__ void SwapDimension1And2InTensor3UsingTiles(
       input_tile_index[2] * TileSizeJ,
   };
 
-  int input_origin_flat_index =
-      TensorIndexToFlat(input_tile_origin, input_dims);
+  int64_t input_origin_flat_index =
+      TensorIndexToFlat<int64_t>(input_tile_origin, input_dims);
 
   bool full_tile = true;
   int tile_width = TileSizeJ;
@@ -350,8 +350,10 @@ __global__ void SwapDimension1And2InTensor3UsingTiles(
     // dimension of the input array.
     int ti = x / TileSizeJ;
     int tj = x % TileSizeJ;
-    int input_index = input_origin_flat_index + ti * input_dims[2] + tj;
-    int input_increment = ReadRowPerPass * input_dims[2];
+    int64_t input_index =
+        input_origin_flat_index + static_cast<int64_t>(ti) * input_dims[2] + tj;
+    int64_t input_increment =
+        static_cast<int64_t>(ReadRowPerPass) * input_dims[2];
 
     if (full_tile) {
 #pragma unroll
@@ -385,8 +387,8 @@ __global__ void SwapDimension1And2InTensor3UsingTiles(
       output_tile_index[2] * TileSizeI,
   };
 
-  int output_origin_flat_index =
-      TensorIndexToFlat(output_tile_origin, output_dims);
+  int64_t output_origin_flat_index =
+      TensorIndexToFlat<int64_t>(output_tile_origin, output_dims);
 
   constexpr int out_effective_thread_num = NumThreads / TileSizeI * TileSizeI;
 
@@ -396,8 +398,10 @@ __global__ void SwapDimension1And2InTensor3UsingTiles(
     // dimension of the output array.
     int ti = x / TileSizeI;
     int tj = x % TileSizeI;
-    int output_index = output_origin_flat_index + ti * output_dims[2] + tj;
-    int output_increment = WriteRowPerPass * output_dims[2];
+    int64_t output_index = output_origin_flat_index +
+                           static_cast<int64_t>(ti) * output_dims[2] + tj;
+    int64_t output_increment =
+        static_cast<int64_t>(WriteRowPerPass) * output_dims[2];
 
     if (full_tile) {
 #pragma unroll

--- a/tensorflow/core/kernels/conv_2d_gpu_test.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_test.cu.cc
@@ -1,0 +1,37 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/conv_2d_gpu.h"
+
+#include <cstdint>
+
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+namespace functor {
+namespace {
+
+TEST(TensorIndexToFlatTest, HandlesFlatIndexPastInt32Limit) {
+  constexpr int kDimension = 46341;
+  const Dimension<3> dims(1, kDimension, kDimension);
+  const Index<3> index(0, kDimension - 1, kDimension - 1);
+
+  EXPECT_EQ(TensorIndexToFlat<int64_t>(index, dims),
+            static_cast<int64_t>(kDimension) * kDimension - 1);
+}
+
+}  // namespace
+}  // namespace functor
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/conv_2d_gpu_test.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_test.cu.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
 #include "tensorflow/core/kernels/conv_2d_gpu.h"
 
 #include <cstdint>
@@ -35,3 +37,5 @@ TEST(TensorIndexToFlatTest, HandlesFlatIndexPastInt32Limit) {
 }  // namespace
 }  // namespace functor
 }  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
The SwapDimension1And2InTensor3UsingTiles kernel used 32-bit indexes, which overflowed for tensors with more than INT32_MAX elements and caused out-of-bounds memory access.

Changed the kernel to use 64-bit indexes and add a test that goes past INT32_MAX.

Fixes #104359
Fixes #104360
Fixes #109522