### PR TITLE
Fix DynamicStitch GPU index overflow

### DIFF
--- a/tensorflow/core/kernels/dynamic_stitch_op.cc
+++ b/tensorflow/core/kernels/dynamic_stitch_op.cc
@@ -168,15 +168,15 @@ class DynamicStitchOpImplBase : public OpKernel {
 
 template <typename T>
 void DynamicStitchGPUImpl(const Eigen::GpuDevice& gpu_device,
-                          int32_t slice_size, int32_t first_dim_size,
+                          int64_t slice_size, int32_t first_dim_size,
                           const GpuDeviceArrayStruct<int>& input_indices,
                           const GpuDeviceArrayStruct<const T*>& input_ptrs,
                           T* output);
-#define REGISTER_GPU(T)                                           \
-  extern template void DynamicStitchGPUImpl(                      \
-      const Eigen::GpuDevice& gpu_device, const int32 slice_size, \
-      const int32 first_dim_size,                                 \
-      const GpuDeviceArrayStruct<int32>& input_indices,           \
+#define REGISTER_GPU(T)                                             \
+  extern template void DynamicStitchGPUImpl(                        \
+      const Eigen::GpuDevice& gpu_device, const int64_t slice_size, \
+      const int32 first_dim_size,                                   \
+      const GpuDeviceArrayStruct<int32>& input_indices,             \
       const GpuDeviceArrayStruct<const T*>& input_ptrs, T* output);
 
 TF_CALL_int32(REGISTER_GPU);
@@ -213,7 +213,7 @@ class DynamicStitchOpGPU : public DynamicStitchOpImplBase<T> {
       // last of duplicated indices, it could instead be done of the GPU
       // implicitly using atomics to make sure the last index is the final
       // write.
-      const int slice_size = merged->flat_outer_dims<T>().dimension(1);
+      const int64_t slice_size = merged->flat_outer_dims<T>().dimension(1);
       GpuDeviceArrayOnHost<int32_t> indices_flat(c, first_dim_size);
       GpuDeviceArrayOnHost<const T*> data_flat(c, data_elements_size);
       OP_REQUIRES_OK(c, indices_flat.Init());

--- a/tensorflow/core/kernels/dynamic_stitch_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/dynamic_stitch_op_gpu.cu.cc
@@ -17,6 +17,8 @@ limitations under the License.
 
 #define EIGEN_USE_GPU
 
+#include <type_traits>
+
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/kernels/gpu_device_array_gpu.h"
@@ -29,16 +31,18 @@ using GPUDevice = Eigen::GpuDevice;
 namespace {
 
 template <typename T>
-__global__ void DynamicStitchKernel(const int32_t slice_size,
-                                    const int32_t output_size,
+__global__ void DynamicStitchKernel(const int64_t slice_size,
+                                    const int64_t output_size,
                                     GpuDeviceArrayStruct<int32_t> input_indices,
                                     GpuDeviceArrayStruct<const T*> input_ptrs,
                                     T* output) {
   int32_t* data_indices = GetGpuDeviceArrayOnDevice(&input_indices);
   const T** data_ptrs = GetGpuDeviceArrayOnDevice(&input_ptrs);
-  GPU_1D_KERNEL_LOOP(output_index, output_size) {
-    const int32_t slice_id = output_index / slice_size;
-    const int32_t slice_offset = output_index % slice_size;
+  for (int64_t output_index : GpuGridRangeX<int64_t>(output_size)) {
+    static_assert(std::is_same<decltype(output_index), int64_t>::value,
+                  "Expected int64_t index");
+    const int64_t slice_id = output_index / slice_size;
+    const int64_t slice_offset = output_index % slice_size;
     const int32_t input_index = data_indices[slice_id];
     if (input_index != -1) {
       output[output_index] = ldg(data_ptrs[input_index] + slice_offset);
@@ -50,13 +54,15 @@ __global__ void DynamicStitchKernel(const int32_t slice_size,
 
 template <typename T>
 void DynamicStitchGPUImpl(const Eigen::GpuDevice& gpu_device,
-                          const int32_t slice_size,
+                          const int64_t slice_size,
                           const int32_t first_dim_size,
                           const GpuDeviceArrayStruct<int>& input_indices,
                           const GpuDeviceArrayStruct<const T*>& input_ptrs,
                           T* output) {
-  const int32_t output_size = first_dim_size * slice_size;
-  auto config = GetGpuLaunchConfig(output_size, gpu_device);
+  const int64_t output_size = static_cast<int64_t>(first_dim_size) * slice_size;
+  auto config_or = GetGpuLaunchConfig64(output_size, gpu_device);
+  TF_CHECK_OK(config_or.status());
+  const GpuLaunchConfig64& config = *config_or;
 
   TF_CHECK_OK(GpuLaunchKernel(DynamicStitchKernel<T>, config.block_count,
                               config.thread_per_block, 0, gpu_device.stream(),
@@ -64,11 +70,11 @@ void DynamicStitchGPUImpl(const Eigen::GpuDevice& gpu_device,
                               input_ptrs, output));
 }
 
-#define REGISTER_GPU(T)                                           \
-  template void DynamicStitchGPUImpl(                             \
-      const Eigen::GpuDevice& gpu_device, const int32 slice_size, \
-      const int32 first_dim_size,                                 \
-      const GpuDeviceArrayStruct<int32>& input_indices,           \
+#define REGISTER_GPU(T)                                             \
+  template void DynamicStitchGPUImpl(                               \
+      const Eigen::GpuDevice& gpu_device, const int64_t slice_size, \
+      const int32 first_dim_size,                                   \
+      const GpuDeviceArrayStruct<int32>& input_indices,             \
       const GpuDeviceArrayStruct<const T*>& input_ptrs, T* output);
 
 TF_CALL_int32(REGISTER_GPU);


### PR DESCRIPTION
DynamicStitch used 32-bit indexes for output sizes near INT32_MAX. The grid-stride loop could wrap to a negative value and read outside the input index buffer.

Changed the output size, loop index, and slice offsets to 64-bit values.

Fixes #103996