### PR TITLE
Fix out-of-bounds Slice folding to a silently truncated constant

### DIFF
--- a/tensorflow/core/grappler/costs/graph_properties.cc
+++ b/tensorflow/core/grappler/costs/graph_properties.cc
@@ -1837,15 +1837,31 @@ class SymbolicShapeRefiner {
           int64_t size = (slice_size->dtype() == DT_INT32
                               ? slice_size->flat<int32_t>()(0)
                               : slice_size->flat<int64_t>()(0));
-          ShapeHandle result;
-          if (size == -1) {
-            TF_RETURN_IF_ERROR(ic->Subshape(input, start, &result));
-          } else {
-            int64_t end = start + size;
-            TF_RETURN_IF_ERROR(ic->Subshape(input, start, end, &result));
+          // Bounds-check before propagating the value. Subshape() clamps an
+          // out-of-range endpoint down to the rank and reads a negative start
+          // as an offset from the end. Without this check an out-of-bounds
+          // Slice is folded into a constant whose value is silently truncated
+          // and whose shape contradicts the one Slice's own shape function
+          // inferred for it. Decline to propagate rather than returning an
+          // error: a failure here aborts InferStatically for the whole graph.
+          const int64_t rank = ic->Rank(input);
+          // Written as size <= rank - start rather than start + size <= rank:
+          // size may be int64, so start + size can overflow. The short-circuit
+          // guarantees 0 <= start <= rank, so rank - start cannot overflow.
+          const bool in_bounds =
+              start >= 0 && start <= rank &&
+              (size == -1 || (size >= 0 && size <= rank - start));
+          if (in_bounds) {
+            ShapeHandle result;
+            if (size == -1) {
+              TF_RETURN_IF_ERROR(ic->Subshape(input, start, &result));
+            } else {
+              int64_t end = start + size;
+              TF_RETURN_IF_ERROR(ic->Subshape(input, start, end, &result));
+            }
+            c->output_tensors_as_shapes.resize(1);
+            c->output_tensors_as_shapes[0] = result;
           }
-          c->output_tensors_as_shapes.resize(1);
-          c->output_tensors_as_shapes[0] = result;
         }
       } else if (IsStridedSlice(node)) {
         ShapeHandle input = c->input_tensors_as_shapes_to_propagate[0];

--- a/tensorflow/core/grappler/costs/graph_properties_test.cc
+++ b/tensorflow/core/grappler/costs/graph_properties_test.cc
@@ -2219,6 +2219,54 @@ TEST_F(GraphPropertiesTest, StridedSliceOfShapeWithShrinkAxisMask) {
   }
 }
 
+TEST_F(GraphPropertiesTest, SliceOfShapeWithOutOfBoundsSize) {
+  tensorflow::Scope scope = tensorflow::Scope::NewRootScope();
+  Output placeholder =
+      ops::Placeholder(scope.WithOpName("input_placeholder"), DT_FLOAT,
+                       ops::Placeholder::Shape(TensorShape({5, 480, 40, 1})));
+  auto input_shape = ops::Shape(scope.WithOpName("input_shape"), placeholder);
+
+  Output begin = ops::Const(scope.WithOpName("begin"), {1}, {1});
+  // Subshape() reads a negative start as an offset from the end, but Slice
+  // requires begin >= 0, so a negative begin must be declined as well.
+  Output neg_begin = ops::Const(scope.WithOpName("neg_begin"), {-1}, {1});
+  // begin + size is 5, one past the end of the rank-4 shape being sliced.
+  Output bad_size = ops::Const(scope.WithOpName("bad_size"), {4}, {1});
+  Output good_size = ops::Const(scope.WithOpName("good_size"), {3}, {1});
+
+  Output bad_slice =
+      ops::Slice(scope.WithOpName("bad_slice"), input_shape, begin, bad_size);
+  Output neg_slice = ops::Slice(scope.WithOpName("neg_slice"), input_shape,
+                                neg_begin, good_size);
+  Output good_slice =
+      ops::Slice(scope.WithOpName("good_slice"), input_shape, begin, good_size);
+
+  GrapplerItem item;
+  TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
+
+  GraphProperties properties(item);
+  TF_ASSERT_OK(properties.InferStatically(
+      /*assume_valid_feeds=*/false,
+      /*aggressive_shape_inference=*/false,
+      /*include_tensor_values=*/true));
+
+  // No value may be propagated for the out-of-bounds Slice. Propagating one
+  // would fold the Slice into a constant that Subshape() had silently
+  // truncated to the available extent, and whose shape would contradict the
+  // shape Slice's own shape function inferred for it.
+  EXPECT_FALSE(properties.GetOutputProperties("bad_slice").at(0).has_value());
+
+  // Nor for a negative begin, which Slice rejects but Subshape() would read
+  // as an offset from the end.
+  EXPECT_FALSE(properties.GetOutputProperties("neg_slice").at(0).has_value());
+
+  // An in-bounds Slice must still have its value propagated.
+  EXPECT_TRUE(properties.GetOutputProperties("good_slice").at(0).has_value());
+  const auto good_value =
+      properties.GetOutputProperties("good_slice").at(0).value();
+  ExpectTensorValues({480, 40, 1}, good_value);
+}
+
 TEST_F(GraphPropertiesTest, ValuePropagationThroughArithmeticOps) {
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   Output a = ops::Const(s.WithOpName("a"), {5, 7}, {2});

--- a/tensorflow/python/kernel_tests/array_ops/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/slice_op_test.py
@@ -211,6 +211,25 @@ class SliceTest(test.TestCase):
         TypeError, "must be integers or slices, not tuple"):
       self.evaluate(func(input_val))
 
+  def testOutOfBoundsSizeWithConstantInput(self):
+    # An out-of-bounds size is rejected by the Slice kernel in eager execution,
+    # and must be rejected the same way inside a tf.function. Grappler folded a
+    # Slice over a constant into a Const whose value was silently clamped to
+    # the available extent, so the traced version returned a truncated tensor
+    # instead of raising.
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                r"Expected size\[0\] in \[0, 3\]"):
+      self.evaluate(array_ops.slice(constant_op.constant([0, 1, 2, 3]),
+                                    [1], [4]))
+
+    @def_function.function
+    def func():
+      return array_ops.slice(constant_op.constant([0, 1, 2, 3]), [1], [4])
+
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                r"Expected size\[0\] in \[0, 3\]"):
+      self.evaluate(func())
+
   def _testSliceMatrixDim0(self, x, begin, size):
     tf_ans = self.evaluate(array_ops.slice(x, [begin, 0], [size, x.shape[1]]))
     np_ans = x[begin:begin + size, :]


### PR DESCRIPTION
Fixes #125544.

## Problem

`tf.slice` with an out-of-bounds size returns a wrong value under a plain `tf.function`, while eager
execution and `jit_compile=True` both raise `InvalidArgumentError`.

```python
def f():
    return tf.reduce_sum(tf.slice(tf.range(0, 4), [1], [4]))

f()                                 # eager: InvalidArgumentError
tf.function(f, jit_compile=True)()  # xla:   InvalidArgumentError
tf.function(f)()                    # plain: returns 6
```

The traced version also disagrees with its own shape inference. Inside the function the static shape
is `(4,)`, but the value produced at run time has shape `(3,)`, so a downstream op that trusted the
inferred shape reads a smaller tensor than it was promised.

## Root cause

`SymbolicShapeRefiner::MaybeUpdateNodeContextOutput` in `graph_properties.cc` propagates a `Slice`'s
value as a `ShapeHandle`. For a non-negative size it computes `end = start + size` and calls
`InferenceContext::Subshape(input, start, end, ...)`. `Subshape` clamps an out-of-range endpoint down
to the rank, so `end = 5` becomes `4` and the propagated value is a 3-element shape instead of an
error. Constant folding then materializes that value and replaces the `Slice` with a `Const`.

That branch is not gated on `aggressive_shape_inference`, which is why the default `tf.function`
pipeline reaches it. It requires int32 or int64 `begin` and `size` tensors holding one element each,
so the effect is confined to 1-D integer slices.

## Fix

Bounds-check `start` and `size` against the rank before propagating the value. When the slice is out
of bounds, decline to propagate rather than returning an error: a failure here aborts
`InferStatically` for the whole graph, which would switch off constant folding everywhere instead of
for this one node.

With no value propagated, the `Slice` node stays in the graph and its kernel raises the same
`InvalidArgumentError` that eager execution and XLA already raise.

The check also rejects a negative `start`, since `Subshape` reads a negative start as an offset from
the end while `Slice` requires a non-negative begin. That is the same clamping defect in the same two
lines.

It covers one more case as a side effect. A `size` below `-1` previously made `Subshape` return an
error, and that error propagates out of `InferStatically`, which switches off constant folding for
the whole graph rather than for the single node that caused it.

## Compatibility

This does not tighten any contract. Today the fold produces a value that contradicts both the op's
registered shape function and the `Slice` kernel's own validation, and the identical graph already
raises in eager execution, under `jit_compile=True`, and with constant folding disabled. The only
behavior that changes is a wrong answer becoming the error the op already documents.

## Test

`graph_properties_test.cc` gains a case asserting that an out-of-bounds `Slice` and a negative-begin
`Slice` have no propagated output value, alongside an in-bounds `Slice` in the same graph that still
has one, so the guard cannot pass by rejecting everything.

`slice_op_test.py` gains a regression test covering the reported behavior in both eager and traced
execution.

## Out of scope

`SliceHelper` in `common_shape_fns.cc` still infers `(4,)` here, because it takes the requested size
at face value. After this change that inaccuracy is no longer reachable as a wrong result: the node
raises at execution time, so nothing consumes a tensor through the mismatched shape. Tightening the
shape function would turn a run-time `InvalidArgumentError` into a construction-time `ValueError` for
every `Slice` in every graph, including SavedModel import and the converters, so I left it alone. I
can send it as a separate PR if you would like it.

## Verification

I did not build locally, so the C++ has not been compiled and neither new test has run against a
patched build. Runtime verification is left to the TensorFlow presubmit CI, which builds and runs
`graph_properties_test` and `slice_op_test`.

Checked against the released 2.21.0 wheel:

- The reported behavior and the static-versus-runtime shape mismatch both reproduce.
- The new `slice_op_test.py` case runs against the wheel: its eager assertion passes and its
  `tf.function` assertion fails with `InvalidArgumentError not raised`, which is what this change is
  meant to flip.

Checked separately, without TensorFlow: I re-expressed the bounds predicate in Python and compared it
against reference slice semantics over 3,200 combinations of `start`, `size` and `rank`, including the
int64 boundary values, with no mismatch in either direction. It admits no out-of-bounds slice, and it
rejects nothing that is in bounds, so valid folding is unaffected.
