### PR TITLE
Validate dtype before capturing eager tensors

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -696,6 +696,7 @@ class _EagerTensorBase(
   def __tf_tensor__(
       self, dtype: Optional[dtypes.DType] = None, name: Optional[str] = None
       ) -> tensor_lib.Tensor:
+    tensor = super().__tf_tensor__(dtype, name)
     if not context.executing_eagerly():
       graph = get_default_graph()
       if not graph.building_function:
@@ -705,7 +706,7 @@ class _EagerTensorBase(
                 "building a function.",
                 name=name))
       return graph.capture(self, name=name)
-    return super().__tf_tensor__(dtype, name)
+    return tensor
 
   def _capture_as_const(self, name) -> Optional[tensor_lib.Tensor]:
     """Capture the EagerTensor to a graph constant tensor."""

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -914,6 +914,19 @@ class OperationTest(test_util.TensorFlowTestCase):
     with self.assertRaises(ValueError):
       ops.convert_to_tensor(tensor, dtype=dtypes.int32)
 
+  def testConvertCapturedEagerTensorToInvalidDtype(self):
+    tensor = constant_op.constant(42, dtype=dtypes.int32)
+
+    @def_function.function
+    def convert():
+      return ops.convert_to_tensor(tensor, dtype=dtypes.int64)
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "Tensor conversion requested dtype int64 for Tensor with dtype int32",
+    ):
+      convert()
+
   @test_util.run_in_graph_and_eager_modes
   def testConvertToTensorProtocol(self):
     class TensorCompatible:


### PR DESCRIPTION
Fixes #125537.

Captured eager tensors currently bypass `Tensor.__tf_tensor__` dtype validation while a `tf.function` is traced. This makes APIs such as `SparseTensor` accept an incompatible captured tensor in graph mode even though the same call correctly fails in eager mode.

Run the shared tensor validation before graph capture so incompatible requested dtypes fail consistently, while compatible captures keep their existing behavior. Add a focused regression covering conversion of a captured int32 eager tensor with an int64 requirement.

Validation:
- `python3 -m py_compile tensorflow/python/framework/ops.py tensorflow/python/framework/ops_test.py`
- `git diff --check`

A targeted Bazel run was unavailable on the local host.