### PR TITLE
Validate FusedPadConv2D input rank before dimension access

### DIFF
--- a/tensorflow/core/kernels/conv_ops_fused_image_transform.cc
+++ b/tensorflow/core/kernels/conv_ops_fused_image_transform.cc
@@ -649,6 +649,10 @@ class FusedResizeConv2DUsingGemmOp : public OpKernel {
     // Input tensor is of the following dimensions:
     // [ batch, in_rows, in_cols, in_depth ]
     const Tensor& input = context->input(0);
+    OP_REQUIRES(
+        context, input.dims() == 4,
+        absl::InvalidArgumentError(absl::StrCat(
+            "input must be 4-dimensional: ", input.shape().DebugString())));
     OP_REQUIRES(context, (input.shape().num_elements() > 0),
                 absl::InvalidArgumentError("Input tensor can't be empty"));
 
@@ -764,10 +768,6 @@ class FusedResizeConv2DUsingGemmOp : public OpKernel {
     const Tensor& filter = context->input(filter_index);
 
     // For 2D convolution, there should be 4 dimensions.
-    OP_REQUIRES(
-        context, padded_shape.dims() == 4,
-        absl::InvalidArgumentError(absl::StrCat("input must be 4-dimensional",
-                                                padded_shape.DebugString())));
     OP_REQUIRES(
         context, filter.dims() == 4,
         absl::InvalidArgumentError(absl::StrCat(

--- a/tensorflow/core/kernels/conv_ops_test.cc
+++ b/tensorflow/core/kernels/conv_ops_test.cc
@@ -367,6 +367,28 @@ TEST_F(FusedResizePadConvOpTest, NoResizePadOnlySymmetricComparative) {
                                         "SAME", DT_FLOAT);
 }
 
+TEST_F(FusedResizePadConvOpTest, InvalidInputRank) {
+  TF_ASSERT_OK(NodeDefBuilder("fused_pad_conv_op", "FusedPadConv2D")
+                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(DT_INT32))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("T", DT_FLOAT)
+                   .Attr("mode", "REFLECT")
+                   .Attr("strides", {1, 1, 1, 1})
+                   .Attr("padding", "VALID")
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+  AddInputFromArray<float>(TensorShape({3, 2}), {0, 0, 0, 0, 0, 0});
+  AddInputFromArray<int32_t>(TensorShape({4, 2}),
+                             {0, 0, 1, 1, 1, 1, 0, 0});
+  AddInputFromArray<float>(TensorShape({2, 2, 1, 1}), {0, 0, 0, 0});
+
+  const absl::Status status = RunOpKernel();
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_NE(status.message().find("input must be 4-dimensional"),
+            std::string::npos);
+}
+
 class ConvOpTest : public OpsTestBase {
  protected:
   void HandwrittenConv() {


### PR DESCRIPTION
Fixes #125505.

`FusedPadConv2D` currently reads dimensions 2 and 3 while initializing its no-resize path before validating that the input is rank 4. A lower-rank input therefore reaches TensorShape's fatal bounds check instead of returning a TensorFlow error.

Move the existing rank requirement ahead of all dimension access and report the malformed input shape as an `InvalidArgument` status. Add a kernel regression for the reported rank-2 input and verify the operation returns the expected status rather than aborting.

Validation:
- `git diff --check`
- Source-level review of both resize and no-resize paths

The `conv_ops_test` target is unavailable on this macOS host (`no_mac_arm64`), so the focused kernel test is included for CI.