### PR TITLE
Skip dense suffix expansion for empty ragged values

### DIFF
--- a/tensorflow/core/kernels/ragged_tensor_to_sparse_kernel.cc
+++ b/tensorflow/core/kernels/ragged_tensor_to_sparse_kernel.cc
@@ -60,8 +60,10 @@ class RaggedTensorToSparseOp : public OpKernel {
     // - `index_middle` is the index in the last ragged dimension.
     // - `index_suffix` is the index in the dense value dimensions.
     std::vector<int64_t> index_prefix(rt_nested_splits_len);
-    std::vector<std::vector<int64_t>> index_suffixes =
-        MakeIndexSuffixes(rt_dense_values_in.shape());
+    std::vector<std::vector<int64_t>> index_suffixes;
+    if (rt_dense_values_in.NumElements() != 0) {
+      index_suffixes = MakeIndexSuffixes(rt_dense_values_in.shape());
+    }
 
     // Allocate the `sparse_indices` output tensor.
     const int64_t nvals =

--- a/tensorflow/core/kernels/ragged_tensor_to_sparse_kernel_test.cc
+++ b/tensorflow/core/kernels/ragged_tensor_to_sparse_kernel_test.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <limits>
+
 #include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/node_def_builder.h"
 #include "tensorflow/core/framework/shape_inference.h"
@@ -86,6 +88,23 @@ TEST_F(RaggedTensorToSparseTest, EmptyRows) {
                                test::AsTensor<int>({1, 2, 3, 4, 5, 6}));
   test::ExpectTensorEqual<int64_t>(*GetOutput(kSparseDenseShapeOutput),
                                    test::AsTensor<int64_t>({5, 4}));
+}
+
+TEST_F(RaggedTensorToSparseTest, EmptyValuesWithLargeDenseSuffix) {
+  constexpr int64_t kSuffixSize = std::numeric_limits<int32_t>::max();
+  BuildRaggedTensorToSparseGraph<int>(
+      {{0}},                           // splits
+      TensorShape({0, kSuffixSize}),  // values.shape
+      {});                            // values
+  TF_ASSERT_OK(RunOpKernel());
+  test::ExpectTensorEqual<int64_t>(
+      *GetOutput(kSparseIndicesOutput),
+      test::AsTensor<int64_t>({}, TensorShape({0, 3})));
+  test::ExpectTensorEqual<int>(*GetOutput(kSparseValuesOutput),
+                               test::AsTensor<int>({}));
+  test::ExpectTensorEqual<int64_t>(
+      *GetOutput(kSparseDenseShapeOutput),
+      test::AsTensor<int64_t>({0, 0, kSuffixSize}));
 }
 
 TEST_F(RaggedTensorToSparseTest, OneSplits_Values2D) {


### PR DESCRIPTION
Fixes #126130.

`RaggedTensorToSparse` materializes the Cartesian product of every dense suffix dimension before calculating the output size. When the dense values tensor has zero elements, none of those suffixes can contribute an output index, but a large logical suffix still consumes substantial time and memory.

Skip suffix generation whenever the dense values tensor is empty. The existing output path then produces empty indices and values while preserving the complete sparse dense shape. Add a regression with a zero-element tensor whose logical suffix is `INT32_MAX`; it exercises the fast path without allocating the suffix.

Validation:
- `git diff --check`
- Focused source-level review of empty rank-1 and rank-N value paths

The local host does not have Bazel available, so the focused kernel test is included for CI.