### PR TITLE
Validate diagonal rank and scalar k in diag and matrix_diag

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/diag_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/diag_op_test.py
@@ -538,6 +538,10 @@ class MatrixDiagTest(test.TestCase):
   def testInvalidShape(self):
     with self.assertRaisesRegex(ValueError, "must be at least rank 1"):
       array_ops.matrix_diag(0)
+    with self.assertRaisesRegex(ValueError, "must have at least rank 2"):
+      array_ops.matrix_diag([1, 2], k=[1, 2])
+    with self.assertRaisesRegex(ValueError, "must have at least rank 2"):
+      array_ops.matrix_diag([1, 2], k=(-1, 1))
 
   @test_util.run_deprecated_v1
   def testInvalidShapeAtEval(self):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2269,6 +2269,16 @@ def matrix_diag(diagonal,
   if hasattr(diagonal, "dtype") and diagonal.dtype == "bool":
     padding_value = bool(padding_value)
 
+  diagonal_tensor = ops.convert_to_tensor(diagonal, name="diagonal")
+  diag_shape = diagonal_tensor.get_shape()
+  if diag_shape.ndims is not None and diag_shape.ndims < 2:
+    k_val = tensor_util.constant_value(ops.convert_to_tensor(k))
+    if (k_val is not None and np.ndim(k_val) == 1 and len(k_val) == 2 and
+        k_val[0] != k_val[1]):
+      raise ValueError(
+          f"diagonal must have at least rank 2 when k specifies multiple "
+          f"diagonals, received diagonal with shape {diag_shape} and k = {k}")
+
   return gen_array_ops.matrix_diag_v3(
       diagonal=diagonal,
       k=k,

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -328,6 +328,11 @@ def diag(v, k=0):  # pylint: disable=missing-docstring
       [v_rank],
   )
 
+  if isinstance(k, core_tf_types.Tensor) and k.shape.ndims is None:
+    control_flow_assert.Assert(math_ops.equal(array_ops.rank(k), 0), [k])
+  elif not isscalar(k):
+    raise ValueError(f'k must be an integer scalar, got {k}')
+
   def _diag(v, k):
     return np_utils.cond(
         math_ops.equal(array_ops.size(v), 0),

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -530,6 +530,28 @@ class ArrayCreationTest(test.TestCase):
     # 3-d arrays
     run_test(np.arange(8).reshape((2, 2, 2)).tolist())
 
+  def testDiagInvalidK(self):
+    v = [1, 2]
+    invalid_ks = [
+        [1, 2],
+        np.array([1, 2]),
+        constant_op.constant([1, 2]),
+    ]
+    for k in invalid_ks:
+      with self.assertRaises(ValueError):
+        np_array_ops.diag(v, k=k)
+
+  def testDiagFlatInvalidK(self):
+    v = [1, 2]
+    invalid_ks = [
+        [1, 2],
+        np.array([1, 2]),
+        constant_op.constant([1, 2]),
+    ]
+    for k in invalid_ks:
+      with self.assertRaises(ValueError):
+        np_array_ops.diagflat(v, k=k)
+
   def match_shape(self, actual, expected, msg=None):
     if msg:
       msg = 'Shape match failed for: {}. Expected: {} Actual: {}'.format(


### PR DESCRIPTION
### Problem
Passing a non-scalar `k` to `tf.experimental.numpy.diag` or `tf.experimental.numpy.diagflat` delegates to `array_ops.matrix_diag` without verifying scalar offset requirements. When `k` specifies a band of diagonals (`k[0] != k[1]`) and `diagonal` has rank 1, `MatrixDiagOp::Compute` indexes dimension `diag_rank - 2 = -1`, tripping a fatal C++ assertion (`Check failed: d >= 0 (-1 vs. 0)`) and aborting the interpreter.

### Solution
Add validation in `tf.experimental.numpy.diag` ensuring `k` is an integer scalar to match NumPy semantics and prevent non-scalar inputs from propagating to backend kernels. In `array_ops.matrix_diag`, validate that `diagonal` has rank >= 2 when `k` specifies multiple diagonals, raising a descriptive `ValueError` instead of crashing.

Fixes #69471