### PR TITLE
Handle zero-element batch slices safely

### DIFF
--- a/tensorflow/core/framework/batch_util_test.cc
+++ b/tensorflow/core/framework/batch_util_test.cc
@@ -21,6 +21,30 @@ limitations under the License.
 namespace tensorflow {
 namespace {
 
+TEST(CopyElementToSliceTest, ZeroElementSlice) {
+  Tensor element(DT_FLOAT, {0, 3});
+  Tensor parent(DT_FLOAT, {2, 0, 3});
+
+  auto status = batch_util::CopyElementToSlice(element, &parent, 1);
+  EXPECT_EQ(error::OK, status.code());
+}
+
+TEST(CopySliceToElementTest, ZeroElementSlice) {
+  Tensor parent(DT_FLOAT, {2, 0, 3});
+  Tensor element(DT_FLOAT, {0, 3});
+
+  auto status = batch_util::CopySliceToElement(parent, &element, 1);
+  EXPECT_EQ(error::OK, status.code());
+}
+
+TEST(MaybeMoveSliceToElementTest, ZeroElementSlice) {
+  Tensor parent(DT_FLOAT, {2, 0, 3});
+  Tensor element(DT_FLOAT, {0, 3});
+
+  auto status = batch_util::MaybeMoveSliceToElement(&parent, &element, 1);
+  EXPECT_EQ(error::OK, status.code());
+}
+
 TEST(CopyContiguousSlicesTest, CompatibleShape) {
   Tensor src(DT_FLOAT, {7, 1, 2});
   Tensor dst(DT_FLOAT, {9, 2, 1});

--- a/tensorflow/core/util/batch_util.cc
+++ b/tensorflow/core/util/batch_util.cc
@@ -185,6 +185,7 @@ absl::Status CopyElementToSlice(const Tensor& element, Tensor* parent,
                                 int64_t index) {
   TF_RETURN_IF_ERROR(ValidateInput(*parent, element, index));
   const int64_t num_values = element.NumElements();
+  if (num_values == 0) return absl::OkStatus();
 #define HANDLE_TYPE(T)                                              \
   case DataTypeToEnum<T>::value: {                                  \
     T* src = element.base<T>();                                     \
@@ -207,6 +208,7 @@ absl::Status CopySliceToElement(const Tensor& parent, Tensor* element,
                                 int64_t index) {
   TF_RETURN_IF_ERROR(ValidateInput(parent, *element, index));
   const int64_t num_values = element->NumElements();
+  if (num_values == 0) return absl::OkStatus();
 
 #define HANDLE_TYPE(T)                                      \
   case DataTypeToEnum<T>::value: {                          \
@@ -382,6 +384,7 @@ absl::Status MaybeMoveSliceToElement(Tensor* parent, Tensor* element,
                                      int64_t index) {
   TF_RETURN_IF_ERROR(ValidateInput(*parent, *element, index));
   const int64_t num_values = element->NumElements();
+  if (num_values == 0) return absl::OkStatus();
 
 #define HANDLE_TYPE(T)                                      \
   case DataTypeToEnum<T>::value: {                          \


### PR DESCRIPTION
## Summary

- Treat validated zero-element slices as no-op copies before accessing tensor buffers.
- Cover copy-to-slice, slice-to-element, and move-to-element helpers.
- Allow queue batching to handle tensors whose non-leading dimensions include zero without undefined pointer operations.

Fixes #108489

## Validation

- `git diff --check`
- Added focused unit coverage for all three zero-element slice helpers.
- Bazel is unavailable locally, so the targeted test was not run.