### PR TITLE
Reject negative GPU NMS output sizes

### DIFF
--- a/tensorflow/core/kernels/image/non_max_suppression_op.cu.cc
+++ b/tensorflow/core/kernels/image/non_max_suppression_op.cu.cc
@@ -484,6 +484,9 @@ absl::Status CheckValidInputs(const Tensor& boxes, const Tensor& scores,
         max_output_size.shape().DebugString(), " (Shape must be rank 0 but is ",
         "rank ", max_output_size.dims(), ")"));
   }
+  if (max_output_size.scalar<int>()() < 0) {
+    return absl::InvalidArgumentError("max_output_size must be non-negative");
+  }
   if (!TensorShapeUtils::IsScalar(iou_threshold.shape())) {
     return absl::InvalidArgumentError(absl::StrCat(
         "iou_threshold must be 0-D, got shape ",

--- a/tensorflow/core/kernels/image/non_max_suppression_op_gpu_test.cc
+++ b/tensorflow/core/kernels/image/non_max_suppression_op_gpu_test.cc
@@ -213,6 +213,18 @@ TEST_F(NonMaxSuppressionV2GPUOpTest, TestInvalidIOUThreshold) {
       << s;
 }
 
+TEST_F(NonMaxSuppressionV2GPUOpTest, TestInvalidMaxOutputSize) {
+  MakeOp();
+  AddInputFromArray<float>(TensorShape({1, 4}), {0, 0, 1, 1});
+  AddInputFromArray<float>(TensorShape({1}), {.9f});
+  AddInputFromArray<int>(TensorShape({}), {-1});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+
+  absl::Status s = RunOpKernel();
+  ASSERT_FALSE(s.ok());
+  EXPECT_TRUE(absl::StrContains(s.message(), "must be non-negative")) << s;
+}
+
 TEST_F(NonMaxSuppressionV2GPUOpTest, TestEmptyInput) {
   MakeOp();
   AddInputFromArray<float>(TensorShape({0, 4}), {});
@@ -446,6 +458,19 @@ TEST_F(NonMaxSuppressionV3GPUOpTest, TestInvalidIOUThreshold) {
       << s;
 }
 
+TEST_F(NonMaxSuppressionV3GPUOpTest, TestInvalidMaxOutputSize) {
+  MakeOp();
+  AddInputFromArray<float>(TensorShape({1, 4}), {0, 0, 1, 1});
+  AddInputFromArray<float>(TensorShape({1}), {.9f});
+  AddInputFromArray<int>(TensorShape({}), {-1});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+
+  absl::Status s = RunOpKernel();
+  ASSERT_FALSE(s.ok());
+  EXPECT_TRUE(absl::StrContains(s.message(), "must be non-negative")) << s;
+}
+
 TEST_F(NonMaxSuppressionV3GPUOpTest, TestEmptyInput) {
   MakeOp();
   AddInputFromArray<float>(TensorShape({0, 4}), {});
@@ -537,6 +562,19 @@ TEST_F(NonMaxSuppressionV4GPUOpTest, DifferentInputAndThresholdTypesWorks) {
   test::ExpectTensorEqual<int>(expected_indices, *GetOutput(0));
   Tensor expected_num_valid = test::AsScalar<int>(2);
   test::ExpectTensorEqual<int>(expected_num_valid, *GetOutput(1));
+}
+
+TEST_F(NonMaxSuppressionV4GPUOpTest, TestInvalidMaxOutputSize) {
+  MakeOp();
+  AddInputFromArray<float>(TensorShape({1, 4}), {0, 0, 1, 1});
+  AddInputFromArray<float>(TensorShape({1}), {.9f});
+  AddInputFromArray<int>(TensorShape({}), {-1});
+  AddInputFromArray<float>(TensorShape({}), {.5f});
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+
+  absl::Status s = RunOpKernel();
+  ASSERT_FALSE(s.ok());
+  EXPECT_TRUE(absl::StrContains(s.message(), "must be non-negative")) << s;
 }
 
 #endif


### PR DESCRIPTION
## Summary

- Validate negative `max_output_size` values in the shared GPU NMS input checker before allocation.
- Apply the validation consistently to NonMaxSuppression V2, V3, and V4, matching the CPU kernels recoverable invalid-argument behavior.
- Add regression coverage for all three GPU operations.

Fixes #95760

## Validation

- `git diff --check`
- Added focused GPU unit coverage for V2, V3, and V4.
- A GPU Bazel environment is unavailable locally, so the targeted test was not run.