### PR TITLE
Fix complex powers with zero exponent

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -79,6 +79,35 @@ struct functor_traits<safe_scalar_binary_pow_op<Scalar, Exponent>> {
   enum { Cost = 5 * NumTraits<Scalar>::MulCost, PacketAccess = false };
 };
 
+template <typename T, bool IsComplex = NumTraits<T>::IsComplex>
+struct tf_scalar_pow_op;
+
+template <typename T>
+struct tf_scalar_pow_op<T, /*IsComplex=*/false> : scalar_pow_op<T, T> {};
+
+template <typename T>
+struct functor_traits<tf_scalar_pow_op<T, /*IsComplex=*/false>>
+    : functor_traits<scalar_pow_op<T, T>> {};
+
+template <typename T>
+struct tf_scalar_pow_op<T, /*IsComplex=*/true> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& base,
+                                                     const T& exponent) const {
+    if (exponent == T(0)) {
+      return T(1);
+    }
+    return scalar_pow_op<T, T>()(base, exponent);
+  }
+};
+
+template <typename T>
+struct functor_traits<tf_scalar_pow_op<T, /*IsComplex=*/true>> {
+  enum {
+    Cost = functor_traits<scalar_pow_op<T, T>>::Cost + NumTraits<T>::AddCost,
+    PacketAccess = false,
+  };
+};
+
 template <typename T, typename DivOrMod>
 struct safe_div_or_mod_op {
   static_assert(std::is_integral<T>::value, "Integer type expected");
@@ -1172,7 +1201,7 @@ struct truncate_div_real
     : base<T, Eigen::internal::google_truncate_div_real<T>> {};
 
 template <typename T>
-struct pow : base<T, Eigen::internal::scalar_pow_op<T, T>> {};
+struct pow : base<T, Eigen::internal::tf_scalar_pow_op<T>> {};
 
 template <typename T>
 struct safe_pow : base<T, Eigen::internal::safe_scalar_binary_pow_op<T, T>> {

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
@@ -831,6 +831,23 @@ class BinaryOpTest(test.TestCase):
           error = gradient_checker.compute_gradient_error(y, [], z, [])
           self.assertLess(error, 2e-4)
 
+  def testComplexPowWithZeroExponent(self):
+    for dtype in np.complex64, np.complex128:
+      bases = np.array(
+          [
+              complex(0.0, 0.0),
+              complex(-0.0, 0.0),
+              complex(0.0, -0.0),
+              1 + 2j,
+              np.nan,
+          ],
+          dtype=dtype,
+      )
+      exponents = np.zeros_like(bases)
+      with test_util.force_cpu():
+        result = self.evaluate(math_ops.pow(bases, exponents))
+      self.assertAllEqual(result, np.ones_like(bases))
+
   def testAtan2SpecialValues(self):
     x1l, x2l = zip((+0.0, +0.0), (+0.0, -0.0), (-0.0, +0.0), (-0.0, -0.0),
                    (1.0, 0.0), (-1.0, 0.0), (1.0, -0.0), (-1.0, -0.0),


### PR DESCRIPTION
The Eigen complex power path evaluates zero to the zero power through logarithms, producing NaNs. Handle a zero complex exponent explicitly so eager execution returns one, matching NumPy and XLA, while leaving non-complex kernels on their existing functor.

Add coverage for signed zero, finite, and NaN complex bases in both complex precisions.

Fixes #117802

Tested: Python test syntax check; git diff --check