### PR TITLE
Prevent overflow when rounding BFC allocation sizes

### DIFF
--- a/third_party/xla/xla/tsl/framework/bfc_allocator.cc
+++ b/third_party/xla/xla/tsl/framework/bfc_allocator.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <cstdint>
 #include <cstdlib>
 #include <deque>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -524,6 +525,12 @@ void* BFCAllocator::AllocateRawInternal(size_t alignment, size_t num_bytes,
                                         AllocationEnd allocation_end) {
   if (ABSL_PREDICT_FALSE(num_bytes == 0)) {
     VLOG(2) << "tried to allocate 0 bytes";
+    return nullptr;
+  }
+  if (ABSL_PREDICT_FALSE(
+          num_bytes > std::numeric_limits<size_t>::max() -
+                          (kMinAllocationSize - 1))) {
+    VLOG(2) << "allocation size cannot be safely rounded: " << num_bytes;
     return nullptr;
   }
   // First, always allocate memory of at least kMinAllocationSize

--- a/third_party/xla/xla/tsl/framework/bfc_allocator_test.cc
+++ b/third_party/xla/xla/tsl/framework/bfc_allocator_test.cc
@@ -153,6 +153,17 @@ TEST(BFCAllocatorTest, DefaultAlignment) {
   alloc.DeallocateRaw(ptr);
 }
 
+TEST(BFCAllocatorTest, RejectsAllocationWhoseRoundedSizeWouldOverflow) {
+  BFCAllocator::Options opts;
+  opts.allow_retry_on_failure = false;
+  BFCAllocator alloc(std::make_unique<FakeSubAllocator>(),
+                     /*total_memory=*/1 << 20, /*name=*/"test", opts);
+
+  EXPECT_EQ(alloc.AllocateRaw(
+                kAlignment, std::numeric_limits<size_t>::max() - 1),
+            nullptr);
+}
+
 TEST(BFCAllocatorTest, OomLogsAllocationAnnotations) {
   BFCAllocator::Options opts;
   opts.allow_growth = false;


### PR DESCRIPTION
BFC rounds every request up to its minimum allocation size. Requests close to SIZE_MAX can overflow that calculation to zero, allowing an undersized allocation to proceed and corrupt allocator metadata.

Reject sizes that cannot be rounded safely before consulting allocator bins. A focused BFC allocator test covers the overflow boundary without reserving a large buffer.

Fixes #108904

Tested: git diff --check