### PR TITLE
Validate axis bounds in experimental.numpy roll and flip

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1518,6 +1518,17 @@ def flip(m, axis=None):  # pylint: disable=missing-docstring
   if np_utils.isscalar(axis):
     axis = [axis]
 
+  maybe_rank = m.shape.rank
+  if maybe_rank is not None:
+    for ax in axis:
+      if isinstance(ax, (int, np.integer)):
+        normalized = ax + maybe_rank if ax < 0 else ax
+        if normalized < 0 or normalized >= maybe_rank:
+          raise ValueError(
+              f'Argument `axis` (received axis={ax}) is out of bounds '
+              f'for input {m} of rank {maybe_rank}.'
+          )
+
   axis = np_utils._canonicalize_axes(axis, array_ops.rank(m))  # pylint: disable=protected-access
 
   return array_ops.reverse(m, axis)
@@ -1541,6 +1552,17 @@ def roll(a, shift, axis=None):  # pylint: disable=missing-docstring
   a = asarray(a)
 
   if axis is not None:
+    maybe_rank = a.shape.rank
+    if maybe_rank is not None:
+      axes = axis if isinstance(axis, (tuple, list, np.ndarray)) else (axis,)
+      for ax in axes:
+        if isinstance(ax, (int, np.integer)):
+          normalized = ax + maybe_rank if ax < 0 else ax
+          if normalized < 0 or normalized >= maybe_rank:
+            raise ValueError(
+                f'Argument `axis` (received axis={ax}) is out of bounds '
+                f'for input {a} of rank {maybe_rank}.'
+            )
     return manip_ops.roll(a, shift, axis)
 
   # If axis is None, the roll happens as a 1-d tensor.

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -16,6 +16,7 @@
 # pylint: disable=g-direct-tensorflow-import
 
 import builtins
+import collections
 import enum
 import functools
 import math
@@ -1552,9 +1553,9 @@ def roll(a, shift, axis=None):  # pylint: disable=missing-docstring
   a = asarray(a)
 
   if axis is not None:
+    axes = axis if isinstance(axis, collections.abc.Iterable) else (axis,)
     maybe_rank = a.shape.rank
     if maybe_rank is not None:
-      axes = axis if isinstance(axis, (tuple, list, np.ndarray)) else (axis,)
       for ax in axes:
         if isinstance(ax, (int, np.integer)):
           normalized = ax + maybe_rank if ax < 0 else ax
@@ -1563,6 +1564,9 @@ def roll(a, shift, axis=None):  # pylint: disable=missing-docstring
                 f'Argument `axis` (received axis={ax}) is out of bounds '
                 f'for input {a} of rank {maybe_rank}.'
             )
+    # NumPy broadcasts a scalar shift across multiple axes.
+    if np_utils.isscalar(shift) and len(axes) > 1:
+      shift = [shift] * len(axes)
     return manip_ops.roll(a, shift, axis)
 
   # If axis is None, the roll happens as a 1-d tensor.

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -16,7 +16,7 @@
 # pylint: disable=g-direct-tensorflow-import
 
 import builtins
-import collections
+import collections.abc
 import enum
 import functools
 import math

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -1350,6 +1350,40 @@ class ArrayMethodsTest(test.TestCase):
     _test(a, axis=[0, 2])
     _test(a, axis=(0, 1, 2))
     _test(a, axis=range(3))
+    # Out-of-bounds axes raise like NumPy.
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.flip(a, axis=3)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.flip(a, axis=-4)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.flip(a, axis=(0, 3))
+
+  def testRoll(self):
+    np.random.seed(0)
+    random_seed.set_seed(0)
+
+    def _test(*args, **kwargs):
+      expected = np.roll(*args, **kwargs)
+      raw_ans = np_array_ops.roll(*args, **kwargs)
+      self.assertAllEqual(expected, raw_ans)
+
+    a = np.random.rand(2, 3, 4)
+
+    # No axis flattens the input before rolling.
+    _test(a, 1)
+    _test(a, -2)
+    # A single axis, including negative values.
+    _test(a, 1, axis=0)
+    _test(a, 2, axis=-1)
+    # A tuple of axes.
+    _test(a, 1, axis=(0, 2))
+    # Out-of-bounds axes raise like NumPy.
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.roll(a, 1, axis=3)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.roll(a, 1, axis=-4)
+    with self.assertRaisesRegex(ValueError, 'out of bounds'):
+      np_array_ops.roll(a, 1, axis=(0, 3))
 
   def testNdim(self):
     self.assertAllEqual(0, np_array_ops.ndim(0.5))

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -1375,8 +1375,10 @@ class ArrayMethodsTest(test.TestCase):
     # A single axis, including negative values.
     _test(a, 1, axis=0)
     _test(a, 2, axis=-1)
-    # A tuple of axes.
+    # A tuple of axes, with a scalar shift broadcast to each axis.
     _test(a, 1, axis=(0, 2))
+    # Other iterables of axes (e.g. range) work too.
+    _test(a, 1, axis=range(3))
     # Out-of-bounds axes raise like NumPy.
     with self.assertRaisesRegex(ValueError, 'out of bounds'):
       np_array_ops.roll(a, 1, axis=3)


### PR DESCRIPTION
NumPy raises `AxisError` when `axis` is out of bounds for `np.roll` and `np.flip`, but the `tf.experimental.numpy` implementations passed the axis straight through to the underlying kernels, producing confusing runtime failures instead.

This PR adds static bounds validation for statically known ranks so invalid axes raise a clear `ValueError` early, matching NumPy's error behavior (and consistent with the validation added for `moveaxis`, `take_along_axis`, `repeat`, `concatenate`, etc.).

Changes:
- `np_array_ops.flip`: validate each axis against the statically known rank.
- `np_array_ops.roll`: validate each axis against the statically known rank.
- Tests for valid and out-of-bounds axes (positive, negative, and tuple axes).

Checks: `py_compile`, Pylint, and `git diff --check` pass locally. Bazel is unavailable in the local checkout, so the focused Bazel test could not be run.
