### PR TITLE
Match NumPy isinf/isneginf/isposinf behavior for complex inputs

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1105,6 +1105,14 @@ def isinf(x):
   x = np_array_ops.asarray(x)
   if x.dtype.is_floating:
     return _scalar(math_ops.is_inf, x, True)
+  if x.dtype.is_complex:
+    # Match NumPy: a complex value is infinite if either its real or its
+    # imaginary part is infinite. The IsInf kernel has no complex variant,
+    # so check the two parts separately.
+    return math_ops.logical_or(
+        _scalar(math_ops.is_inf, math_ops.real(x), True),
+        _scalar(math_ops.is_inf, math_ops.imag(x), True),
+    )
   return np_array_ops.zeros_like(x, dtypes.bool)
 
 
@@ -1114,6 +1122,12 @@ def isneginf(x):
   x = np_array_ops.asarray(x)
   if x.dtype.is_floating:
     return x == np_array_ops.full_like(x, -np.inf)
+  if x.dtype.is_complex:
+    # Match NumPy, which rejects complex inputs as ambiguous.
+    raise TypeError(
+        f'This operation is not supported for {x.dtype.name} values '
+        'because it would be ambiguous.'
+    )
   return np_array_ops.zeros_like(x, dtypes.bool)
 
 
@@ -1123,6 +1137,12 @@ def isposinf(x):
   x = np_array_ops.asarray(x)
   if x.dtype.is_floating:
     return x == np_array_ops.full_like(x, np.inf)
+  if x.dtype.is_complex:
+    # Match NumPy, which rejects complex inputs as ambiguous.
+    raise TypeError(
+        f'This operation is not supported for {x.dtype.name} values '
+        'because it would be ambiguous.'
+    )
   return np_array_ops.zeros_like(x, dtypes.bool)
 
 

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -379,6 +379,34 @@ class MathTest(test.TestCase, parameterized.TestCase):
         np.isclose(a, b, rtol=1e-6, atol=0.5),
     )
 
+  def testIsinf(self):
+    x = np.array([1.0, np.inf, -np.inf, np.nan], np.float64)
+    self.match(np_math_ops.isinf(x), np.isinf(x))
+    self.match(np_math_ops.isinf(np.array([1, 2])),
+               np.isinf(np.array([1, 2])))
+    # NumPy supports complex inputs: True if either part is infinite.
+    c = np.array([1 + 2j, complex(np.inf, 0), complex(0, np.inf),
+                  complex(np.nan, 0)])
+    self.match(np_math_ops.isinf(c), np.isinf(c))
+
+  def testIsneginf(self):
+    x = np.array([1.0, np.inf, -np.inf, np.nan], np.float64)
+    self.match(np_math_ops.isneginf(x), np.isneginf(x))
+    self.match(np_math_ops.isneginf(np.array([1, 2])),
+               np.isneginf(np.array([1, 2])))
+    # NumPy rejects complex inputs as ambiguous.
+    with self.assertRaisesRegex(TypeError, 'ambiguous'):
+      np_math_ops.isneginf(np.array([1 + 2j]))
+
+  def testIsposinf(self):
+    x = np.array([1.0, np.inf, -np.inf, np.nan], np.float64)
+    self.match(np_math_ops.isposinf(x), np.isposinf(x))
+    self.match(np_math_ops.isposinf(np.array([1, 2])),
+               np.isposinf(np.array([1, 2])))
+    # NumPy rejects complex inputs as ambiguous.
+    with self.assertRaisesRegex(TypeError, 'ambiguous'):
+      np_math_ops.isposinf(np.array([1 + 2j]))
+
   @parameterized.named_parameters(
       ('isclose_int32', np_math_ops.isclose, np.int32),
       ('allclose_int32', np_math_ops.allclose, np.int32),


### PR DESCRIPTION
NumPy's `isinf` supports complex inputs, returning `True` when either the real or imaginary part is infinite, while `isneginf` and `isposinf` reject complex inputs as ambiguous. The `tf.experimental.numpy` implementations instead silently returned all-`False` arrays for complex inputs.

This PR matches NumPy's behavior:
- `isinf`: compute the result on the real and imaginary parts separately (the `IsInf` kernel has no complex variant).
- `isneginf` / `isposinf`: raise `TypeError` for complex inputs, like NumPy.

Tests cover float, integer, and complex inputs for all three functions.

Checks: `py_compile`, Pylint, and `git diff --check` pass locally. Bazel is unavailable in the local checkout, so the focused Bazel test could not be run.
