### PR TITLE
Fix SIGABRT when a string constant reaches DeviceCompilationClusterSignature

### DIFF
--- a/tensorflow/compiler/jit/BUILD
+++ b/tensorflow/compiler/jit/BUILD
@@ -1719,6 +1719,7 @@ cc_library(
     deps = [
         "//tensorflow/compiler/tf2xla:xla_compiler",
         "//tensorflow/core:framework",
+        "//tensorflow/core/framework:tensor_proto_cc",
         "//tensorflow/core/platform:types",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/status:statusor",

--- a/tensorflow/compiler/jit/device_compilation_cluster_signature.cc
+++ b/tensorflow/compiler/jit/device_compilation_cluster_signature.cc
@@ -24,11 +24,23 @@ limitations under the License.
 #include "tensorflow/compiler/tf2xla/xla_compiler.h"
 #include "tensorflow/core/framework/function.h"
 #include "tensorflow/core/framework/node_def_util.h"
+#include "tensorflow/core/framework/tensor.pb.h"
+#include "tensorflow/core/framework/types.h"
 
 namespace tensorflow {
 namespace {
 using Signature = DeviceCompilationClusterSignature;
 using TensorTypeAndShape = Signature::TensorTypeAndShape;
+
+// Returns bytes that can be hashed and compared for equality for any dtype.
+std::string HashableTensorBytes(const Tensor& t) {
+  if (DataTypeCanUseMemcpy(t.dtype())) {
+    return std::string(t.tensor_data());
+  }
+  TensorProto proto;
+  t.AsProtoTensorContent(&proto);
+  return proto.SerializeAsString();
+}
 
 // Functor that converts a Signature's arg to a human readable string.
 struct SignatureHumanStringAppender {
@@ -48,7 +60,7 @@ struct SignatureHumanStringAppender {
 struct SignatureNotEqual {
   bool operator()(const Tensor& arg, const Tensor& other) {
     return arg.dtype() != other.dtype() || arg.shape() != other.shape() ||
-           arg.tensor_data() != other.tensor_data();
+           HashableTensorBytes(arg) != HashableTensorBytes(other);
   }
   bool operator()(const TensorTypeAndShape& arg,
                   const TensorTypeAndShape& other) {
@@ -69,8 +81,8 @@ struct SignatureHashCombiner {
   uint64_t h;
   uint64_t operator()(const Tensor& arg) {
     h = Hash64Combine(h, std::hash<int>()(static_cast<int>(arg.dtype())));
-    h = Hash64Combine(
-        h, Hash64(arg.tensor_data().data(), arg.tensor_data().size()));
+    std::string bytes = HashableTensorBytes(arg);
+    h = Hash64Combine(h, Hash64(bytes.data(), bytes.size()));
     for (int dim = 0; dim < arg.dims(); ++dim) {
       h = Hash64Combine(h, std::hash<int>()(arg.dim_size(dim)));
     }

--- a/tensorflow/compiler/jit/device_compilation_cluster_signature_test.cc
+++ b/tensorflow/compiler/jit/device_compilation_cluster_signature_test.cc
@@ -69,6 +69,23 @@ TEST(DeviceCompilationClusterSignatureTest, SignatureEquality) {
   }
 }
 
+TEST(DeviceCompilationClusterSignatureTest, StringConstantDoesNotCrash) {
+  NameAttrList fn;
+  fn.set_name("afunction");
+  std::vector<XlaCompiler::Argument> args(1);
+  args[0].kind = XlaCompiler::Argument::kConstant;
+  args[0].type = DT_STRING;
+  Tensor t(DT_STRING, TensorShape({2}));
+  t.flat<tstring>()(0) = "hi";
+  t.flat<tstring>()(1) = "cat";
+  args[0].constant_value = t;
+
+  TF_ASSERT_OK_AND_ASSIGN(DeviceCompilationClusterSignature s1,
+                          DeviceCompilationClusterSignature::Build(fn, args));
+  EXPECT_TRUE(s1 == s1);
+  EXPECT_EQ(SignatureHash()(s1), SignatureHash()(s1));
+}
+
 TEST(DeviceCompilationClusterSignatureTest, SignatureUniqueness) {
   NameAttrList fn;
   fn.set_name("afunction");


### PR DESCRIPTION
Fixes #120244

## Root cause
`DeviceCompilationClusterSignature`'s hash/equality functors (in `device_compilation_cluster_signature.cc`) call `Tensor::tensor_data()` unconditionally on any constant-valued XLA compile argument. `tensor_data()` has `CHECK(DataTypeCanUseMemcpy(dtype()))` inside it, and `DT_STRING` (along with `DT_RESOURCE`/`DT_VARIANT`) is excluded from the memcpy-able set — so a string constant reaching this code aborts the process (`SIGABRT`) instead of raising a catchable TF exception. Reproduced locally with the exact repro from #120244.

## Fix
Added `HashableTensorBytes()`, which uses `tensor_data()` for memcpy-safe dtypes (unchanged behavior/performance for the common numeric case) and falls back to a serialized `TensorProto` for everything else. Used it in both `SignatureNotEqual::operator()` and `SignatureHashCombiner::operator()`.

## Testing
Added `StringConstantDoesNotCrash` to `device_compilation_cluster_signature_test.cc`, building a signature from a `DT_STRING` constant and asserting it doesn't crash and is self-consistent.
