### PR TITLE
Accept tuple field paths in proto splitter utilities

### DIFF
--- a/tensorflow/tools/proto_splitter/util.py
+++ b/tensorflow/tools/proto_splitter/util.py
@@ -48,8 +48,9 @@ def get_field(
 
   Args:
     proto: Parent proto of any message type.
-    fields: List of string/int/map key fields, e.g. ["nodes", "attr", "value"]
-      can represent `proto.nodes.attr["value"]`.
+    fields: A string/int/map key field or a sequence of them, e.g.
+      ["nodes", "attr", "value"] can represent
+      `proto.nodes.attr["value"]`.
 
   Returns:
     Tuple of (
@@ -71,8 +72,9 @@ def get_field_tag(
 
   Args:
     proto: Parent proto of any message type.
-    fields: List of string/int/map key fields, e.g. ["nodes", "attr", "value"]
-      can represent `proto.nodes.attr["value"]`.
+    fields: A string/int/map key field or a sequence of them, e.g.
+      ["nodes", "attr", "value"] can represent
+      `proto.nodes.attr["value"]`.
 
   Returns:
     A list of FieldIndex protos with the same length as `fields`.
@@ -95,8 +97,9 @@ def _walk_fields(proto: message.Message, fields: FieldTypes):
 
   Args:
     proto: Parent proto of any message type.
-    fields: List of string/int/map key fields, e.g. ["nodes", "attr", "value"]
-      can represent `proto.nodes.attr["value"]`.
+    fields: A string/int/map key field or a sequence of them, e.g.
+      ["nodes", "attr", "value"] can represent
+      `proto.nodes.attr["value"]`.
 
   Yields:
     Tuple of (
@@ -105,7 +108,9 @@ def _walk_fields(proto: message.Message, fields: FieldTypes):
       Key into this map field (or None),
       Index into this repeated field (or None))
   """
-  if not isinstance(fields, list):
+  if isinstance(fields, Sequence) and not isinstance(fields, (str, bytes)):
+    fields = list(fields)  # pyrefly: ignore[bad-assignment]
+  else:
     fields = [fields]  # pyrefly: ignore[bad-assignment]
 
   field_proto = proto

--- a/tensorflow/tools/proto_splitter/util_test.py
+++ b/tensorflow/tools/proto_splitter/util_test.py
@@ -67,6 +67,16 @@ class UtilTest(test.TestCase):
     self.assertEqual(True, ret[3].map_key.boolean)
     self.assertEqual(3, ret[4].field)
 
+  def test_get_field_tag_accepts_tuple(self):
+    proto = test_message_pb2.ManyFields()
+
+    ret = util.get_field_tag(proto, ("field_one", "repeated_field", 15))
+
+    self.assertLen(ret, 3)
+    self.assertEqual(1, ret[0].field)
+    self.assertEqual(2, ret[1].field)
+    self.assertEqual(15, ret[2].index)
+
   def test_get_field_tag_invalid(self):
     proto = test_message_pb2.ManyFields()
     with self.assertRaisesRegex(KeyError, "Unable to find field 'not_a_field'"):
@@ -129,6 +139,30 @@ class UtilTest(test.TestCase):
 
     field, _ = util.get_field(proto, ["nested_map_bool", True, "string_field"])
     self.assertEqual("string_true", field)
+
+  def test_get_field_empty_tuple(self):
+    proto = test_message_pb2.ManyFields()
+
+    field, field_desc = util.get_field(proto, ())
+
+    self.assertIs(proto, field)
+    self.assertIsNone(field_desc)
+
+  def test_get_field_accepts_tuple(self):
+    proto = test_message_pb2.ManyFields(
+        field_one=test_message_pb2.ManyFields(
+            repeated_field=[test_message_pb2.ManyFields()]
+        )
+    )
+
+    field, field_desc = util.get_field(
+        proto, ("field_one", "repeated_field")
+    )
+
+    self.assertIsInstance(field, Iterable)
+    self.assertLen(field, 1)
+    self.assertEqual("repeated_field", field_desc.name)
+    self.assertProtoEquals(proto.field_one.repeated_field, field)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


The proto splitter utilities declare `FieldTypes` as accepting any `Sequence` of string, integer, or boolean field components. However, `_walk_fields()` only recognized lists and wrapped tuples as a single field value.

This caused tuple field paths such as `("field_one", "repeated_field")` to fail with `TypeError`. Empty tuples also failed even though empty lists correctly return the original proto.

This change:

- Normalizes non-string, non-bytes sequences to a list of field components.
- Preserves scalar field handling.
- Adds coverage for tuple field paths, empty tuples, and `get_field_tag()` with tuples.
- Updates the relevant argument documentation.
