### PR TITLE
Zero the FFT output when the input is empty but fft_length is not

### DIFF
--- a/tensorflow/core/kernels/fft_ops.cc
+++ b/tensorflow/core/kernels/fft_ops.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
 #include "absl/log/check.h"
@@ -240,7 +241,12 @@ class FFTBase : public OpKernel {
     }
 
     if (input_shape.num_elements() == 0) {
-      DCHECK_EQ(0, output_shape.num_elements());
+      // With an explicit fft_length the output can be non-empty even though
+      // the input is empty. It is then the transform of pure zero padding,
+      // so it is all zeros; fill it rather than returning it uninitialized.
+      if (output_shape.num_elements() != 0) {
+        ZeroOutput(ctx, out);
+      }
       return;
     }
 
@@ -255,6 +261,9 @@ class FFTBase : public OpKernel {
   // The function that actually computes the FFT.
   virtual void DoFFT(OpKernelContext* ctx, const Tensor& in,
                      uint64_t* fft_shape, Tensor* out) = 0;
+
+  // Fills `out` with zeros on the device the kernel runs on.
+  virtual void ZeroOutput(OpKernelContext* ctx, Tensor* out) = 0;
 };
 
 class FFTNBase : public OpKernel {
@@ -365,7 +374,12 @@ class FFTNBase : public OpKernel {
     }
 
     if (input_shape.num_elements() == 0) {
-      DCHECK_EQ(0, output_shape.num_elements());
+      // With an explicit fft_length the output can be non-empty even though
+      // the input is empty. It is then the transform of pure zero padding,
+      // so it is all zeros; fill it rather than returning it uninitialized.
+      if (output_shape.num_elements() != 0) {
+        ZeroOutput(ctx, out);
+      }
       return;
     }
     DoFFTN(ctx, in, fft_shape.data(), axes_shape.data(), out);
@@ -379,6 +393,9 @@ class FFTNBase : public OpKernel {
   virtual void DoFFTN(OpKernelContext* ctx, const Tensor& in,
                       uint64_t* fft_shape, int32_t* axes_shape,
                       Tensor* out) = 0;
+
+  // Fills `out` with zeros on the device the kernel runs on.
+  virtual void ZeroOutput(OpKernelContext* ctx, Tensor* out) = 0;
 };
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
@@ -404,6 +421,10 @@ class FFTCPU : public FFTBase {
 
     OP_REQUIRES_OK(ctx, DuccFftImpl(ctx->eigen_device<CPUDevice>(), in, out,
                                     fft_shape, axes, Forward));
+  }
+
+  void ZeroOutput(OpKernelContext* ctx, Tensor* out) override {
+    memset(out->data(), 0, out->TotalBytes());
   }
 };
 
@@ -664,6 +685,14 @@ class FFTGPUBase : public FFTBase {
   // ever hitting this limit in practice.
   static constexpr size_t kFftPlanCacheCapacity = 512;
 
+  void ZeroOutput(OpKernelContext* ctx, Tensor* out) override {
+    auto* stream = ctx->op_device_context()->stream();
+    OP_REQUIRES(ctx, stream, absl::InternalError("No GPU stream available."));
+    stream_executor::DeviceAddressBase out_memory(out->data(),
+                                                  out->TotalBytes());
+    OP_REQUIRES_OK(ctx, stream->MemZero(&out_memory, out->TotalBytes()));
+  }
+
   void DoFFT(OpKernelContext* ctx, const Tensor& in, uint64_t* fft_shape,
              Tensor* out) override {
     auto* stream = ctx->op_device_context()->stream();
@@ -848,6 +877,14 @@ class FFTNGPUBase : public FFTNBase {
   // since the scratch space is provided externally.  We don't anticipate
   // ever hitting this limit in practice.
   static constexpr size_t kFftPlanCacheCapacity = 512;
+
+  void ZeroOutput(OpKernelContext* ctx, Tensor* out) override {
+    auto* stream = ctx->op_device_context()->stream();
+    OP_REQUIRES(ctx, stream, absl::InternalError("No GPU stream available."));
+    stream_executor::DeviceAddressBase out_memory(out->data(),
+                                                  out->TotalBytes());
+    OP_REQUIRES_OK(ctx, stream->MemZero(&out_memory, out->TotalBytes()));
+  }
 
   void DoFFTN(OpKernelContext* ctx, const Tensor& in, uint64_t* fft_shape,
               int32_t* axes_shape, Tensor* out) override {

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -509,6 +509,24 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
           feed_dict=feed_dict,
       )
 
+  def testEmptyInputWithFftLengthIsZero(self):
+    # Regression test for GitHub issue 126898. The input is empty along the
+    # transform axes but fft_length pads them, so the output is not empty and
+    # is the transform of pure zero padding, which is all zeros. The kernel
+    # used to return that output uninitialized.
+    result = self._tf_fft(np.zeros((2, 2, 0), np.float32), 1, fft_length=[16])
+    self.assertEqual(result.dtype, np.complex64)
+    self.assertAllEqual(result, np.zeros((2, 2, 9), np.complex64))
+
+    result = self._tf_fft(
+        np.zeros((2, 0, 0), np.float32), 2, fft_length=[8, 16])
+    self.assertAllEqual(result, np.zeros((2, 8, 9), np.complex64))
+
+    result = self._tf_ifft(
+        np.zeros((2, 2, 0), np.complex64), 1, fft_length=[16])
+    self.assertEqual(result.dtype, np.float32)
+    self.assertAllEqual(result, np.zeros((2, 2, 16), np.float32))
+
   def testIRFFTZeroOrNegativeLengthRaisesError(self):
     x = array_ops.ones([1], dtype=dtypes.complex64)
     with self.assertRaisesRegex(ValueError, r"fft_length\[-1\] must be > 0"):


### PR DESCRIPTION
Fixes #126898.

## Problem

`tf.signal.rfft(tf.zeros((2, 2, 0)), fft_length=[16])` returns a `[2, 2, 9]` tensor whose contents are intermittently garbage (denormals, huge values, `nan`). The output is never written.

The empty-input early return shared by `FFTBase::Compute` and `FFTNBase::Compute` assumes an empty input implies an empty output, and says so:

```cpp
if (input_shape.num_elements() == 0) {
  DCHECK_EQ(0, output_shape.num_elements());
  return;
}
```

With an explicit `fft_length` the output shape comes from `fft_length`, so the output can be non-empty while the input is empty. The `DCHECK` is compiled out in release builds, so the kernel returns the freshly allocated output without ever writing it. The Python wrapper deliberately skips padding empty tensors (`_maybe_pad_for_rfft`, "Edge case: skip padding empty tensors"), which is how the empty input reaches the kernel through the public API; `tf.raw_ops` callers reach it directly, so the kernel is the right place to fix it.

Reproduced on TF 2.21.0 (CPU): for `rfft2d` on a `[2, 0, 0]` input with `fft_length=[8, 16]`, 142 of the 144 output values are stale memory such as `2.76e+20+1.79e+31j`; the 1-D case in the report reproduces intermittently depending on what the allocator hands back, matching the reporter's 7 of 100 trials.

## Fix

Such an output is the transform of pure zero padding, so it is all zeros. When the input is empty and the output is not, fill the output with zeros instead of returning it uninitialized. The zeroing goes through a new `ZeroOutput` virtual implemented per device, since the base classes serve both the DUCC CPU kernel (`memset`) and the cuFFT kernels (`Stream::MemZero`); cuFFT could not have been handed the empty input directly, as its plan would receive a zero `inembed`, so removing the early return was not an option. The truly empty-output case keeps its early return.

## Test

`testEmptyInputWithFftLengthIsZero` in `fft_ops_test.py` covers `rfft`, `rfft2d`, and `irfft` on inputs that are empty along the transform axes with a positive `fft_length`, asserting all-zero output of the expected shape and dtype. Against the current wheel it fails in both graph and eager mode on the `rfft2d` case with the stale buffer contents above, and the test target is a CUDA test, so CI also exercises the `MemZero` path.
