### PR TITLE
docs(core): fix spelling typos in common_runtime comments

### DIFF
--- a/tensorflow/core/common_runtime/arg_ret_placement.h
+++ b/tensorflow/core/common_runtime/arg_ret_placement.h
@@ -98,7 +98,7 @@ absl::Status WeakSetAllocAttrsForRets(
     std::vector<AllocatorAttributes>& alloc_attrs);
 
 // Set the contents of alloc_attrs for args (inputs to functions, "_Arg" ops)
-// for a single device funtion based on dtype. Raises an error if an int32 arg
+// for a single device function based on dtype. Raises an error if an int32 arg
 // does not have expected full_type information. If an error raised about bad
 // full time information causes a breakage, changing
 // `SingleDeviceSetAllocAttrsForArgs` to `WeakSingleDeviceSetAllocAttrsForArgs`

--- a/tensorflow/core/common_runtime/eager/context_distributed_manager.cc
+++ b/tensorflow/core/common_runtime/eager/context_distributed_manager.cc
@@ -838,7 +838,7 @@ absl::Status UpdateContextWithServerDef(EagerContext* context,
     if (sg.ok()) {
       // Create remote contexts on the newly added workers only if the master
       // has collected all device information from them (i.e., the
-      // GetAllRemoteDevices call returns succussfully). Note that in rare cases
+      // GetAllRemoteDevices call returns successfully). Note that in rare cases
       // GetAllRemoteDevices can still fail even with RPCs configured to wait
       // until the remote workers to become alive. If the master creates remote
       // contexts on the workers whose devices are still not collected, those

--- a/tensorflow/core/common_runtime/eager/eager_executor.cc
+++ b/tensorflow/core/common_runtime/eager/eager_executor.cc
@@ -265,7 +265,7 @@ void EagerExecutor::NodeDone(const core::RefCountPtr<NodeItem>& item,
       // Remove item if it exists in unfinished_nodes_.
       // With async execution, if two separate nodes failed and enter this
       // callback, then the second node might not find itself in
-      // unfinished_nodes_ in the following senario:
+      // unfinished_nodes_ in the following scenario:
       //   1) Callback of the first failed node clears unfinished_nodes_
       //   2) ClearError is called and executor status_ is set to OK
       //   3) Callback of the second failed node is triggered

--- a/tensorflow/core/common_runtime/function.cc
+++ b/tensorflow/core/common_runtime/function.cc
@@ -682,7 +682,7 @@ absl::Status FunctionLibraryRuntimeImpl::CreateKernel(
   // are always on device memory. Now, having TFT_SHAPE_TENSOR full type
   // information specifies host memory and unspecified or other full type
   // information specifies device memory. Full type information can be set to
-  // match the orginal behavior, manually for manual placement or by using type
+  // match the original behavior, manually for manual placement or by using type
   // inference over function body to derive the correct input/output memory
   // types.
   MemoryTypeVector input_memory_types;


### PR DESCRIPTION
## Description

Fixes several spelling mistakes in comments across the TensorFlow codebase.

### Changes

Corrected typos in comments in:

- `tensorflow/core/common_runtime/eager/context_distributed_manager.cc`
- `tensorflow/core/common_runtime/eager/eager_executor.cc`
- `tensorflow/core/common_runtime/function.cc`
- `tensorflow/core/common_runtime/eager/...?` 

The changes are documentation-only and do not affect runtime behavior.

### Testing

No tests were added or modified since these changes only correct comments/typos.