### PR TITLE
Fix heap OOB read in FractionalMaxPoolGrad - validate sequence values are non-negative

### DIFF
--- a/tensorflow/core/kernels/fractional_max_pool_op.cc
+++ b/tensorflow/core/kernels/fractional_max_pool_op.cc
@@ -344,6 +344,10 @@ class FractionalMaxPoolGradOp : public OpKernel {
       for (int64_t hs = 0; hs < height_seq_tensor.dim_size(0) - 1; ++hs) {
         // height start and end.
         const int64_t height_start = height_seq_tensor_flat(hs);
+        OP_REQUIRES(context, height_start >= 0,
+                    absl::InvalidArgumentError(absl::StrCat(
+                        "Row sequence tensor values must not be negative, got ",
+                        height_seq_tensor.DebugString())));
         int64_t height_end = overlapping_ ? height_seq_tensor_flat(hs + 1)
                                           : height_seq_tensor_flat(hs + 1) - 1;
         height_end = std::min(height_end, height_max);
@@ -354,6 +358,10 @@ class FractionalMaxPoolGradOp : public OpKernel {
               (b * output_size[1] + hs) * output_size[2] + ws;
           // width start and end.
           const int64_t width_start = width_seq_tensor_flat(ws);
+          OP_REQUIRES(context, width_start >= 0,
+                      absl::InvalidArgumentError(absl::StrCat(
+                          "Col sequence tensor values must not be negative, got ",
+                          width_seq_tensor.DebugString())));
           int64_t width_end = overlapping_ ? width_seq_tensor_flat(ws + 1)
                                            : width_seq_tensor_flat(ws + 1) - 1;
           width_end = std::min(width_end, width_max);


### PR DESCRIPTION
## Problem

FractionalMaxPoolGrad uses values from `row_pooling_sequence` and
`col_pooling_sequence` directly as array indices into the input tensor without
validating that those values are non-negative. A value of -1 produces
`in_index = -4`, causing a heap out-of-bounds read 16 bytes before the tensor
buffer, confirmed by AddressSanitizer:

  heap-buffer-overflow READ of size 4, 16 bytes before allocated region

This is a bypass of the incomplete fix for CVE-2022-41897 (commit d71090c).
That commit added NumElements > 0 and size/shape checks, but never validated
that sequence *values* are non-negative. Small values like -1 pass all five
new checks and still trigger the OOB read on TF 2.21.0.

## Fix

Add OP_REQUIRES checks for `height_start >= 0` and `width_start >= 0` before
those values are used in the inner loop. This mirrors existing validation in
`FractionalAvgPoolGrad` at `fractional_avg_pool_op.cc:354` which was never
applied to the Max variant.

## Verification

- Tested on TF 2.21.0 (Linux and Windows)
- With fix applied: `row_pooling_sequence = [-1, 2, 4]` returns
  InvalidArgumentError before any memory access
- FractionalAvgPoolGrad already passes the same test correctly