### PR TITLE
fix(tf2xla): register EuclideanNorm reduction OpKernel

### DIFF
--- a/tensorflow/compiler/jit/mark_for_compilation_pass.cc
+++ b/tensorflow/compiler/jit/mark_for_compilation_pass.cc
@@ -2023,7 +2023,7 @@ GetAllowlistTable() {
             "Snapshot", "_EagerConst"}},
           // clang-format off
     {"RED",
-     {"All", "Any", "Min", "Max", "Mean", "Prod", "Sum"}},
+     {"All", "Any", "Min", "Max", "Mean", "Prod", "Sum", "EuclideanNorm"}},
           // clang-format on
           {"PWRED",
            {"ArgMax", "ArgMin", "DiagPart", "Softmax",

--- a/tensorflow/compiler/tests/reduce_ops_test.py
+++ b/tensorflow/compiler/tests/reduce_ops_test.py
@@ -179,6 +179,21 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
         result = sess.run(out, {a: test_input, index: [1]})
       self.assertAllEqual([max_value], result)
 
+  def testReduceEuclideanNorm(self, index_dtype):
+
+    def reference_euclidean_norm(dtype, inp, axis):
+      inp = inp.astype(dtype)
+      return np.sqrt(np.sum(inp * np.conj(inp), axis)).astype(dtype)
+
+    for dtype in [np.float32, np.float64]:
+      self._testReduction(
+          math_ops.reduce_euclidean_norm,
+          functools.partial(reference_euclidean_norm, dtype),
+          dtype,
+          self.REAL_DATA,
+          index_dtype,
+      )
+
   def testReduceAll(self, index_dtype):
     self._testReduction(math_ops.reduce_all, np.all, np.bool_, self.BOOL_DATA,
                         index_dtype)

--- a/tensorflow/compiler/tf2xla/kernels/BUILD
+++ b/tensorflow/compiler/tf2xla/kernels/BUILD
@@ -883,6 +883,7 @@ tf_kernel_library(
         "@xla//xla:xla_data_proto_cc",
         "@xla//xla/hlo/builder:xla_builder",
         "@xla//xla/hlo/builder/lib:constants",
+        "@xla//xla/hlo/builder/lib:math",
     ],
 )
 

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
@@ -28,6 +28,8 @@ limitations under the License.
 #include "xla/hlo/builder/xla_builder.h"
 #include "xla/shape.h"
 #include "xla/xla_data.pb.h"
+#include "xla/hlo/builder/lib/math.h"
+#include "xla/primitive_util.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/op_requires.h"
 #include "tensorflow/core/framework/types.pb.h"
@@ -218,6 +220,45 @@ class AnyOp : public XlaReductionOp {
 
 REGISTER_XLA_OP(Name("Any").CompileTimeConstantInput("reduction_indices"),
                 AnyOp);
+
+class EuclideanNormOp : public XlaReductionOp {
+ public:
+  explicit EuclideanNormOp(OpKernelConstruction* ctx)
+      : XlaReductionOp(ctx,
+                       XlaHelpers::SumAccumulationType(ctx->input_type(0))) {}
+  xla::XlaOp InitialValue(xla::XlaBuilder* builder) override {
+    return xla::Zero(builder, xla_reduction_type_);
+  }
+
+  xla::XlaOp PreprocessInput(xla::XlaBuilder* /*builder*/,
+                             const xla::XlaOp& data) override {
+    return xla::Mul(data, xla::MaybeConjugate(data, true));
+  }
+
+  void BuildReducer(xla::XlaBuilder* builder, const xla::XlaOp& scalar_lhs,
+                    const xla::XlaOp& scalar_rhs) override {
+    xla::Add(scalar_lhs, scalar_rhs);
+  }
+
+  xla::XlaOp BuildFinalizer(
+      xla::XlaBuilder* /*builder*/, const xla::XlaOp& input,
+      const xla::XlaOp& reduce_output,
+      const std::vector<int64_t>& dimensions_to_reduce) override {
+    if (xla::primitive_util::IsIntegralType(xla_reduction_type_)) {
+      // XLA only supports float and complex sqrt.
+      // Thus, cast integral type to F32 for computation.
+      return XlaHelpers::ConvertElementType(
+          xla::Sqrt(xla::ConvertElementType(reduce_output, xla::F32)),
+          input_type(0));
+    }
+    return XlaHelpers::ConvertElementType(xla::Sqrt(reduce_output),
+                                          input_type(0));
+  }
+};
+
+REGISTER_XLA_OP(
+    Name("EuclideanNorm").CompileTimeConstantInput("reduction_indices"),
+    EuclideanNormOp);
 
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.h
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.h
@@ -52,6 +52,13 @@ class XlaReductionOp : public XlaOpKernel {
                             const xla::XlaOp& scalar_lhs,
                             const xla::XlaOp& scalar_rhs) = 0;
 
+  // Applies a transformation to the input of the reduction. The desired
+  // computation should be added to 'builder'. Argument 'data' is the original
+  // input of the reduction. Returns the transformed reduction input.
+  // Defaults to returning 'data'.
+  virtual xla::XlaOp PreprocessInput(xla::XlaBuilder* builder,
+                                     const xla::XlaOp& data);
+
   // Applies a transformation to the output of the reduction. The desired
   // computation should be added to 'builder'. Argument 'input' is the original
   // input of the reduction; 'reduce_output' is the output of the reduction.

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops_common.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops_common.cc
@@ -49,6 +49,12 @@ XlaReductionOp::XlaReductionOp(OpKernelConstruction* ctx,
       ctx, DataTypeToPrimitiveType(reduction_type_, &xla_reduction_type_));
 }
 
+// The default pre-processor directly returns the data. This can be overridden.
+xla::XlaOp XlaReductionOp::PreprocessInput(xla::XlaBuilder* /*builder*/,
+                                           const xla::XlaOp& data) {
+  return data;
+}
+
 // The default finalizer converts the results back into the input type. This can
 // be overridden.
 xla::XlaOp XlaReductionOp::BuildFinalizer(
@@ -128,6 +134,7 @@ void XlaReductionOp::Compile(XlaOpKernelContext* ctx) {
   CHECK_OK(DataTypeToPrimitiveType(reduction_type_, &type));
 
   auto data = xla::ConvertElementType(ctx->Input(0), type);
+  auto processed_input = PreprocessInput(b, data);
   // Call virtual method to get the initial value.
   auto initial = xla::ConvertElementType(InitialValue(b), type);
   // Make two scalar parameters of the desired type for the lambda.
@@ -137,7 +144,8 @@ void XlaReductionOp::Compile(XlaOpKernelContext* ctx) {
   BuildReducer(&r, rx, ry);
   xla::XlaComputation reduction_computation = r.Build().value();
 
-  auto reduce = xla::Reduce(data, initial, reduction_computation, xla_axes);
+  auto reduce =
+      xla::Reduce(processed_input, initial, reduction_computation, xla_axes);
   auto finalized = BuildFinalizer(b, data, reduce, xla_axes);
   auto result = keep_dims_ ? xla::Reshape(finalized, final_shape) : finalized;
   ctx->SetOutput(0, result);


### PR DESCRIPTION
## Why
In commit 8e01ae829bb88ff197c2e6b8c3ad1668fd2b9fa5 (August 2020), an inverted commit during an automated import accidentally removed the `EuclideanNormOp` kernel registration, the `PreprocessInput` hook on `XlaReductionOp`, and `testReduceEuclideanNorm` from `tf2xla`.

Since then, compiling any graph containing `tf.math.reduce_euclidean_norm` under XLA (`jit_compile=True`) fails with `InvalidArgumentError: Detected unsupported operations when trying to compile graph ... on XLA_CPU_JIT: EuclideanNorm (No registered 'EuclideanNorm' OpKernel for XLA_CPU_JIT devices compatible with node)`.

This patch restores the `PreprocessInput` extension point to `XlaReductionOp` and registers the `EuclideanNorm` reduction OpKernel in `tf2xla`.

## Scope
- In `tensorflow/compiler/tf2xla/kernels/reduction_ops.h`, added `virtual xla::XlaOp PreprocessInput(xla::XlaBuilder* builder, const xla::XlaOp& data)` with default pass-through behavior.
- In `tensorflow/compiler/tf2xla/kernels/reduction_ops_common.cc`, implemented default `PreprocessInput` and called it in `XlaReductionOp::Compile` prior to the reduction computation.
- In `tensorflow/compiler/tf2xla/kernels/reduction_ops.cc`, implemented and registered `EuclideanNormOp` using `xla::Mul(data, xla::MaybeConjugate(data, true))` in `PreprocessInput`, `xla::Add` in `BuildReducer`, and `xla::Sqrt` in `BuildFinalizer`.
- In `tensorflow/compiler/tests/reduce_ops_test.py`, restored `testReduceEuclideanNorm` covering `float32` and `float64`.

## Blast Radius
This change affects the XLA lowering path for `EuclideanNorm`. Standard non-XLA execution paths are unaffected. Existing reductions (`Sum`, `Prod`, `Min`, `Max`, `Mean`, `All`, `Any`) inherit the default `PreprocessInput` pass-through with no behavioral changes.

## Verification
- Minimal reproduction script verified red before change with `InvalidArgumentError: No registered 'EuclideanNorm' OpKernel for XLA_CPU_JIT devices`.
- Unit test in `tensorflow/compiler/tests/reduce_ops_test.py` validates reduction across axes against a NumPy reference implementation for `float32` and `float64`.