### PR TITLE
Fix MatrixDiagPart GPU index overflow

### DIFF
--- a/tensorflow/core/kernels/linalg/matrix_diag_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/matrix_diag_op_gpu.cu.cc
@@ -17,6 +17,8 @@ limitations under the License.
 
 #define EIGEN_USE_GPU
 
+#include <cstdint>
+
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/linalg/matrix_diag_op.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
@@ -123,7 +125,9 @@ __global__ void MatrixDiagPartKernel(
     if (0 <= y_index && y_index < num_rows && 0 <= x_index &&
         x_index < num_cols) {
       output_ptr[index] =
-          input_ptr[batch * num_rows * num_cols + y_index * num_cols + x_index];
+          input_ptr[(static_cast<int64_t>(batch) * num_rows + y_index) *
+                        num_cols +
+                    x_index];
     } else {
       output_ptr[index] = padding_value;
     }


### PR DESCRIPTION
MatrixDiagPart calculated input offsets with 32-bit values. For tensors
with more than INT32_MAX elements, the calculation could overflow and
read outside the input tensor.

I changed the offset calculation to start with int64_t so it does not
overflow.

I didn’t add a test because reproducing the overflow requires more than
INT32_MAX elements and several gigabytes of GPU memory.

Fixes #104363