### PR TITLE
Preserve sigmoid gradients for large positive inputs

### DIFF
--- a/tensorflow/python/eager/pywrap_gradient_exclusions.cc
+++ b/tensorflow/python/eager/pywrap_gradient_exclusions.cc
@@ -50,7 +50,7 @@ auto OpGradientInfoInit(const T &a) {
 
 absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
     const tensorflow::string &op_name) {
-  static std::array<OpIndexInfo, 364> a = {{
+  static std::array<OpIndexInfo, 363> a = {{
       {"Acosh"},
       {"AllToAll", 1, {0}},
       {"ApproximateEqual"},

--- a/tensorflow/python/eager/pywrap_gradient_exclusions.cc
+++ b/tensorflow/python/eager/pywrap_gradient_exclusions.cc
@@ -295,7 +295,6 @@ absl::optional<tensorflow::gtl::FlatSet<int>> OpGradientUnusedInputIndices(
       {"SerializeTensor"},
       {"SetSize"},
       {"Shape"},
-      {"Sigmoid"},
       {"Size"},
       {"Slice", 1, {2}},
       {"Softmax"},

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -1258,6 +1258,10 @@ def _SigmoidGrad(op: ops.Operation, grad):
   """Returns grad * sigmoid(x) * (1 - sigmoid(x))."""
   y = op.outputs[0]  # y = sigmoid(x)
   with ops.control_dependencies([grad]):
+    if y.dtype.is_floating:
+      # For large positive x, y rounds to 1 even when the derivative is
+      # representable. Use sigmoid(-x) instead of the cancellation-prone 1 - y.
+      return grad * (y * math_ops.sigmoid(-op.inputs[0]))
     y = math_ops.conj(y)
     return gen_math_ops.sigmoid_grad(y, grad)
 

--- a/tensorflow/python/ops/math_grad_test.py
+++ b/tensorflow/python/ops/math_grad_test.py
@@ -60,6 +60,91 @@ class InferGradientReductionAxes(test.TestCase, parameterized.TestCase):
     self.assertEqual(expected_y_axes, y_axes1)
 
 
+@test_util.run_all_in_graph_and_eager_modes
+class SigmoidGradTest(test.TestCase, parameterized.TestCase):
+
+  @parameterized.parameters(
+      (dtypes.float16, [0., 1., 5., 10.], 3e-3),
+      (dtypes.bfloat16, [0., 1., 5., 20.], 2e-2),
+      (dtypes.float32, [0., 1., 17., 50., 80.], 2e-6),
+      (dtypes.float64, [0., 1., 37.42994775023705, 50., 700.], 1e-12),
+  )
+  def testGradientInBothTails(self, dtype, positive_values, rtol):
+    values = np.array([positive_values, -np.array(positive_values)])
+    x = constant_op.constant(values, dtype=dtype)
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = math_ops.sigmoid(x)
+    grad = tape.gradient(y, x)
+    # Evaluate the reference in float64 without subtracting from a rounded 1.
+    values = self.evaluate(x).astype(np.float64)
+    exp_neg_abs = np.exp(-np.abs(values))
+    expected = exp_neg_abs / (1. + exp_neg_abs)**2
+    actual = self.evaluate(grad)
+    self.assertAllClose(expected, actual, rtol=rtol, atol=0.)
+    self.assertAllClose(actual[0], actual[1], rtol=rtol, atol=0.)
+
+  def testReportedFloat64Gradient(self):
+    x = constant_op.constant(37.42994775023705, dtype=dtypes.float64)
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = math_ops.sigmoid(x)
+    self.assertAllClose(
+        5.551115123125775e-17, tape.gradient(y, x), rtol=1e-12, atol=0.)
+
+  def testHigherDerivatives(self):
+    values = np.array([-50., -1., 0., 1., 50.])
+    x = constant_op.constant(values, dtype=dtypes.float64)
+    with backprop.GradientTape() as third_tape:
+      third_tape.watch(x)
+      with backprop.GradientTape() as second_tape:
+        second_tape.watch(x)
+        with backprop.GradientTape() as first_tape:
+          first_tape.watch(x)
+          y = math_ops.sigmoid(x)
+        first = first_tape.gradient(y, x)
+      second = second_tape.gradient(first, x)
+    third = third_tape.gradient(second, x)
+    exp_neg_abs = np.exp(-np.abs(values))
+    expected_first = exp_neg_abs / (1. + exp_neg_abs)**2
+    expected_second = -expected_first * np.tanh(values / 2.)
+    expected_third = expected_first * (1. - 6. * expected_first)
+    self.assertAllClose(expected_second, second, rtol=1e-12, atol=0.)
+    self.assertAllClose(expected_third, third, rtol=1e-12, atol=0.)
+
+  def testUpstreamGradient(self):
+    values = np.array([-50., 0., 50.])
+    x = constant_op.constant(values, dtype=dtypes.float64)
+    upstream = constant_op.constant([-2., 0., 3.], dtype=dtypes.float64)
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = math_ops.sigmoid(x)
+    grad = tape.gradient(y, x, output_gradients=upstream)
+    exp_neg_abs = np.exp(-np.abs(values))
+    expected = [-2., 0., 3.] * (exp_neg_abs / (1. + exp_neg_abs)**2)
+    self.assertAllClose(expected, grad, rtol=1e-12, atol=0.)
+
+  def testNonFiniteInputs(self):
+    x = constant_op.constant([-np.inf, np.inf, np.nan], dtype=dtypes.float64)
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = math_ops.sigmoid(x)
+    self.assertAllEqual([0., 0., np.nan], tape.gradient(y, x))
+
+  @parameterized.parameters(dtypes.complex64, dtypes.complex128)
+  def testComplexGradient(self, dtype):
+    values = np.array([-1. + 0.5j, 0. - 1.j, 1. + 0.5j])
+    x = constant_op.constant(values, dtype=dtype)
+    upstream = constant_op.constant([1. + 2.j, -1.j, -2. + 1.j], dtype=dtype)
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      y = math_ops.sigmoid(x)
+    grad = tape.gradient(y, x, output_gradients=upstream)
+    sigmoid = 1. / (1. + np.exp(-values))
+    expected = np.conj(sigmoid * (1. - sigmoid)) * self.evaluate(upstream)
+    self.assertAllClose(expected, grad, rtol=2e-6, atol=0.)
+
+
 class SquaredDifferenceOpTest(test.TestCase):
 
   def _testGrad(self, left_shape, right_shape):


### PR DESCRIPTION
Sigmoid's gradient currently uses `y * (1 - y)`, where `y` is the forward output. For large positive inputs, `y` rounds to 1 and the gradient becomes zero even when the derivative is representable. Both reported float64 examples reproduce this: `37.42994775023705` should produce approximately `5.551115123125775e-17`, and `50` should produce approximately `1.928749847963918e-22`.

Use `y * sigmoid(-x)` for real floating-point inputs and retain the input in the gradient tape. The complex gradient keeps its existing conjugation behavior. This requires retaining the input and evaluating an additional sigmoid during backpropagation.

The branch is rebased onto master at `9249619229ae8a439dc885a85764c934332f61f8`. Master already removed the `Sqrt` input-exclusion entry, so removing `Sigmoid` reduces the input table from 364 to **363** entries. The output table remains at 490. The declared array sizes match the actual initializer counts, avoiding a trailing null operation name during map initialization.

Regression coverage includes both reports, positive/negative tail symmetry for float16, bfloat16, float32 and float64, second/third derivatives, upstream gradients, infinities/NaN, and complex gradients.

Validation after the rebase and array-size correction on macOS arm64:

- Compiled the actual C++ exclusions source and exercised both lookup maps against TensorFlow 2.21.0's native framework library. The rebased 364-size/363-entry version reproduces SIGSEGV (exit -11); the corrected version passes, including sigmoid retention and known/unknown operation lookups.
- Checked both complete tables for matching declared/initialized counts, unique operation names, and sigmoid input/output retention: 363 inputs and 490 outputs.
- Reran the sigmoid regression class: all 10 actual test methods pass in graph/eager modes, with one inherited non-test skipped. The harness loads the changed Python gradient over TensorFlow 2.21.0 and explicitly retains sigmoid inputs because the installed wheel has the old compiled exclusion table.
- `git diff --check` passes.

Attempted `bazel test //tensorflow/python/eager:gradient_input_output_exclusions_test` with Bazel 7.7.0, macOS arm64 configuration, and Python 3.11. It is blocked before test execution while fetching `llvm-raw`: `mlir_symbol_table_windows.patch` fails to apply to `mlir/include/mlir/IR/SymbolTable.h` near line 463 (`CONTENT_DOES_NOT_MATCH_TARGET`). The full Bazel generator/test and integrated source-build validation therefore still need CI; they are not claimed as local passes.

Fixes #126060.
Fixes #126631.
