### PR TITLE
Fix the Windows link by exporting the current FlatBufferFileToMlir signature

### DIFF
--- a/tensorflow/python/_pywrap_tensorflow.def
+++ b/tensorflow/python/_pywrap_tensorflow.def
@@ -347,7 +347,7 @@ EXPORTS
  ?FileName@EventsWriter@tensorflow@@QEAA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ
  ?Find@ByChar@lts_20260526@absl@@QEBA?AV?$basic_string_view@DU?$char_traits@D@std@@@std@@V45@_K@Z
  ?FindKernelDef@tensorflow@@YA?AVStatus@lts_20260526@absl@@AEBVDeviceType@tsl@@AEBVNodeDef@1@PEAPEBVKernelDef@1@PEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z
- ?FlatBufferFileToMlir@tflite@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV23@_N@Z
+ ?FlatBufferFileToMlir@tflite@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV23@_N1AEBV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@3@@Z
  ?Flatten@swig@tensorflow@@YAPEAU_object@@PEAU3@_N@Z
  ?FlattenDictItems@tensorflow@@YAPEAU_object@@PEAU2@@Z
  ?FlattenForData@swig@tensorflow@@YAPEAU_object@@PEAU3@@Z

--- a/tensorflow/python/_pywrap_tensorflow.def
+++ b/tensorflow/python/_pywrap_tensorflow.def
@@ -541,6 +541,7 @@ EXPORTS
  ?MeshDimNames@Mesh@dtensor@tensorflow@@QEBA?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ
  ?MlirQuantizeModel@tflite@@YAPEAU_object@@PEAU2@_N1HHH1100110@Z
  ?MlirSparsifyModel@tflite@@YAPEAU_object@@PEAU2@@Z
+ ?MlirToFlatBufferFile@tflite@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV23@_N1111@Z
  ?Mul@ops@tensorflow@@YA?AVStatus@lts_20260526@absl@@PEAVAbstractContext@2@QEAVAbstractTensorHandle@2@1PEAPEAV72@PEBD3@Z
  ?MulRegisterer@gradients@tensorflow@@YAPEAVGradientFunction@12@AEBUForwardOperation@12@@Z
  ?Multiply@InferenceContext@shape_inference@tensorflow@@QEAA?AVStatus@lts_20260526@absl@@VDimensionHandle@23@UDimensionOrConstant@23@PEAV723@@Z

--- a/tensorflow/tools/def_file_filter/symbols_pybind.txt
+++ b/tensorflow/tools/def_file_filter/symbols_pybind.txt
@@ -265,6 +265,7 @@ tflite::MlirSparsifyModel
 tflite::RegisterCustomOpdefs
 tflite::RetrieveCollectedErrors
 tflite::FlatBufferFileToMlir
+tflite::MlirToFlatBufferFile
 
 [//tensorflow/core:op_gen_lib] # tf_session
 tensorflow::ApiDefMap::~ApiDefMap


### PR DESCRIPTION
`build-windows-x86 / build-and-test` currently fails at the link of `//tensorflow/python:_pywrap_tensorflow_common.dll` with a single hard error:

```
lld-link: error: <root>: undefined symbol: ?FlatBufferFileToMlir@tflite@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV23@_N@Z
```

957 of 1720 test targets then fail to build behind it. It reproduces on pull requests that touch nothing in this area, for example [proto splitter utilities](https://github.com/tensorflow/tensorflow/actions/runs/34071394999) and [KDNN sigmoid](https://github.com/tensorflow/tensorflow/actions/runs/34089727652), both ending on that exact symbol and nothing else.

## Cause

4357817bc0a gave `tflite::FlatBufferFileToMlir` two more parameters:

```c++
std::string FlatBufferFileToMlir(
    const std::string& model, bool input_is_filepath, bool bytecode = false,
    const std::vector<std::string>& cl_options = {});
```

Default arguments do not change the mangled name of the definition, so the object file now provides a different symbol than it did. `tensorflow/python/_pywrap_tensorflow.def` is maintained by hand, still spells the two-parameter form, and is fed to that DLL at [tensorflow/python/BUILD:1589](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/BUILD#L1589). Because it is an export list rather than a use, the linker reports the missing symbol at `<root>`.

## What this changes

Two commits.

The first replaces the stale entry with the mangled name of the current signature. The name was not written by hand: a file declaring the pre-4357817bc0a signature, compiled with clang targeting `x86_64-pc-windows-msvc`, reproduces the entry being removed byte for byte, and the replacement is what the same file produces for the current one. The `.def` stays sorted and the entry keeps its position.

The second exports `tflite::MlirToFlatBufferFile`, added by the same commit. `converter_python_api_wrapper.cc` calls eight functions in namespace `tflite`; the `converter_python_api` section of `symbols_pybind.txt` lists seven, and this is the one it does not. 249f61ca726 added `tflite::ConvertMlirBytecode` to both files for the same reason, so this follows it. Unlike the first commit, this one is not what the job reports today: the link fails at the export list before it reaches the wrapper, so it comes from reading the lists against the call sites rather than from a build that got that far.

## What I could not check

I have no Windows or MSVC machine, so I have not run the link. The evidence for the first commit is the failing job plus the exact round trip of the old mangled name through clang's MSVC mangler; the second rests on the call sites. The Windows presubmit on this pull request is the real test of both.
