### PR TITLE
Fix month and day formatting in forward compatibility

### DIFF
--- a/tensorflow/python/compat/compat.py
+++ b/tensorflow/python/compat/compat.py
@@ -134,7 +134,7 @@ def forward_compatibility_horizon(year, month, day):
   with older binaries, new features can be gated with:
 
   ```python
-  if compat.forward_compatible(year=2018, month=08, day=01):
+  if compat.forward_compatible(year=2018, month=8, day=1):
     generate_graph_with_new_features()
   else:
     generate_graph_so_older_binaries_can_consume_it()
@@ -148,7 +148,7 @@ def forward_compatibility_horizon(year, month, day):
   from tensorflow.python.compat import compat
 
   def testMyNewFeature(self):
-    with compat.forward_compatibility_horizon(2018, 08, 02):
+    with compat.forward_compatibility_horizon(2018, 8, 2):
        # Test that generate_graph_with_new_features() has an effect
   ```
 


### PR DESCRIPTION
#### Description

Fixes invalid Python 3 syntax in the `forward_compatibility_horizon`
docstring examples in `tensorflow/python/compat/compat.py`. The examples
used leading-zero integer literals (`month=08, day=01` and
`compat.forward_compatibility_horizon(2018, 08, 02)`), which are a
`SyntaxError` in Python 3 (leading zeros are reserved for octal literals,
which require an `0o` prefix). Anyone copy-pasting these examples as
written would hit a crash. Updated both to plain integer literals
(`month=8, day=1` and `2018, 8, 2`). No behavioral or indentation changes —
the code fence indentation in this file was already correct.