### PR TITLE
Update configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1016,11 +1016,15 @@ def set_hermetic_cuda_compute_capabilities(environ_cp):
         hermetic_cuda_compute_capabilities.split()
     )
     for compute_capability in hermetic_cuda_compute_capabilities.split(','):
-      m = re.match('[0-9]+.[0-9]+', compute_capability)
+      # Anchored with fullmatch (rather than the previous unanchored
+      # re.match with an unescaped '.') so inputs like '7.0foo' or
+      # 'sm_70xyz' are correctly rejected instead of silently accepted,
+      # and malformed input like '3a5' no longer crashes float().
+      m = re.fullmatch(r'[0-9]+\.[0-9]+', compute_capability)
       if not m:
         # We now support sm_35,sm_50,sm_60,compute_70.
-        sm_compute_match = re.match('(sm|compute)_?([0-9]+[0-9]+)',
-                                    compute_capability)
+        sm_compute_match = re.fullmatch(r'(sm|compute)_?([0-9]+)',
+                                        compute_capability)
         if not sm_compute_match:
           print('Invalid compute capability: %s' % compute_capability)
           all_valid = False


### PR DESCRIPTION
#### Description

Fixes a validation bug in `set_hermetic_cuda_compute_capabilities`. The
regex used to validate each comma-separated CUDA compute capability token
was unanchored and had an unescaped `.`:

    re.match('[0-9]+.[0-9]+', compute_capability)

Because `re.match` only anchors at the start of the string, malformed
input like `'7.0foo'` or `'sm_70xyz'` was incorrectly accepted as valid.
Because the `.` matched any character rather than a literal dot, inputs
like `'3a5'` passed the initial check but then crashed with an unhandled
`ValueError` at `float(m.group(0))`.

Switched both this pattern and the `sm_xy`/`compute_xy` fallback pattern
to `re.fullmatch` with an escaped `\.`, so the whole string must match
end-to-end. Malformed input is now cleanly rejected with the existing
"Invalid compute capability" message instead of crashing or being
silently accepted. Also simplified `([0-9]+[0-9]+)` to `([0-9]+)` in the
`sm|compute` pattern — the original was two adjacent one-or-more-digit
groups, which is equivalent to a single one-or-more-digit group and
doesn't change what it matches.

No other lines changed. Verified against `'7.0'`, `'sm_70'`, `'sm70'`,
`'compute_70'`, `'compute70'` (all still accepted) and `'7.0foo'`,
`'3a5'`, `'3-5'`, `'sm_70xyz'`, `''` (all now correctly rejected, no
crash).

#### Scope
Patch: Bug Fix