### PR TITLE
Fix L2 normalization fusion for multi-axis reductions

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -2054,6 +2054,20 @@ func.func @InvalidL2NormalizePattern3(%arg0: tensor<2x2xf32>) -> tensor<2x2xf32>
   // CHECK: return %[[RES]]
 }
 
+// CHECK-LABEL: @L2NormalizePatternAllAxesUnitLeadingDimensions
+// Reducing all dimensions is equivalent to TFL L2 normalization when every
+// leading dimension has size 1.
+func.func @L2NormalizePatternAllAxesUnitLeadingDimensions(%arg0: tensor<1x3xf32>) -> tensor<1x3xf32> {
+  %cst = arith.constant dense<[0, 1]> : tensor<2xi32>
+  %0 = "tfl.square"(%arg0) : (tensor<1x3xf32>) -> tensor<1x3xf32>
+  %1 = "tfl.sum"(%0, %cst) {keep_dims = false} : (tensor<1x3xf32>, tensor<2xi32>) -> tensor<f32>
+  %2 = "tfl.rsqrt"(%1) : (tensor<f32>) -> tensor<f32>
+  %3 = "tfl.mul"(%arg0, %2) {fused_activation_function = "NONE"} : (tensor<1x3xf32>, tensor<f32>) -> tensor<1x3xf32>
+  func.return %3: tensor<1x3xf32>
+  // CHECK: %[[RES:.*]] = "tfl.l2_normalization"(%arg0) <{fused_activation_function = "NONE"}> : (tensor<1x3xf32>) -> tensor<1x3xf32>
+  // CHECK: return %[[RES]]
+}
+
 // CHECK-LABEL: @InvalidL2NormalizePatternMultiAxis
 // Reducing all dimensions is not equivalent to TFL L2 normalization, which
 // only reduces the trailing dimension.
@@ -5248,4 +5262,3 @@ func.func @do_not_fuse_sum_mul_with_arbitrary_factor(%arg0: tensor<2x3x4xf32>) -
   // CHECK:     tfl.mul
   // CHECK-NOT: "tfl.mean"
 }
-

--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -2054,6 +2054,23 @@ func.func @InvalidL2NormalizePattern3(%arg0: tensor<2x2xf32>) -> tensor<2x2xf32>
   // CHECK: return %[[RES]]
 }
 
+// CHECK-LABEL: @InvalidL2NormalizePatternMultiAxis
+// Reducing all dimensions is not equivalent to TFL L2 normalization, which
+// only reduces the trailing dimension.
+func.func @InvalidL2NormalizePatternMultiAxis(%arg0: tensor<2x3xf32>) -> tensor<2x3xf32> {
+  %cst = arith.constant dense<[0, 1]> : tensor<2xi32>
+  %0 = "tfl.square"(%arg0) : (tensor<2x3xf32>) -> tensor<2x3xf32>
+  %1 = "tfl.sum"(%0, %cst) {keep_dims = false} : (tensor<2x3xf32>, tensor<2xi32>) -> tensor<f32>
+  %2 = "tfl.rsqrt"(%1) : (tensor<f32>) -> tensor<f32>
+  %3 = "tfl.mul"(%arg0, %2) {fused_activation_function = "NONE"} : (tensor<2x3xf32>, tensor<f32>) -> tensor<2x3xf32>
+  func.return %3: tensor<2x3xf32>
+  // CHECK: %[[SQUARE:.*]] = "tfl.square"(%arg0)
+  // CHECK: %[[SUM:.*]] = "tfl.sum"(%[[SQUARE]],
+  // CHECK: %[[RSQRT:.*]] = "tfl.rsqrt"(%[[SUM]])
+  // CHECK: %[[MUL:.*]] = tfl.mul(%arg0, %[[RSQRT]])
+  // CHECK: return %[[MUL]]
+}
+
 // CHECK-LABEL: @fuseDivIntoConv2d
 func.func @fuseDivIntoConv2d(%arg0: tensor<1x112x112x2xf32>) -> tensor<1x28x23x2xf32> {
   %cst0 = arith.constant dense<[[[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], [[[9.0, 10.0], [11.0, 12.0]], [[13.0, 14.0], [15.0, 16.0]]]]> : tensor<2x2x2x2xf32>

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
@@ -120,25 +120,13 @@ ElementsAttr ReshapeNCHWBiasToNHWC(Value v, Attribute a) {
 }
 
 bool L2NormalizeReduceAxis(Value sq_op, DenseElementsAttr axis) {
-  if (axis.getNumElements() == 0) {
+  if (axis.getNumElements() != 1) {
     return false;
   }
-  if (mlir::cast<ShapedType>(sq_op.getType()).getRank() - 1 ==
-          *axis.getValues<int>().begin() ||
-      *axis.getValues<int>().begin() == -1) {
-    return true;
-  }
-  if (mlir::cast<ShapedType>(sq_op.getType()).getRank() !=
-      axis.getNumElements()) {
-    return false;
-  }
-  auto shape = mlir::cast<ShapedType>(sq_op.getType());
-  SmallVector<int, 4> elems{axis.getValues<int>().begin(),
-                            axis.getValues<int>().end()};
-  for (int i = 0; i < shape.getRank(); ++i) {
-    if (i != elems[i]) return false;
-  }
-  return true;
+
+  const int reduce_axis = *axis.getValues<int>().begin();
+  const int64_t rank = mlir::cast<ShapedType>(sq_op.getType()).getRank();
+  return reduce_axis == rank - 1 || reduce_axis == -1;
 }
 
 // Checks if a ReshapeOp is equivalent to a `keep_dims=true` reduction by

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
@@ -120,13 +120,42 @@ ElementsAttr ReshapeNCHWBiasToNHWC(Value v, Attribute a) {
 }
 
 bool L2NormalizeReduceAxis(Value sq_op, DenseElementsAttr axis) {
-  if (axis.getNumElements() != 1) {
+  if (axis.getNumElements() == 0) {
     return false;
   }
 
-  const int reduce_axis = *axis.getValues<int>().begin();
-  const int64_t rank = mlir::cast<ShapedType>(sq_op.getType()).getRank();
-  return reduce_axis == rank - 1 || reduce_axis == -1;
+  auto shape = mlir::dyn_cast<ShapedType>(sq_op.getType());
+  if (!shape || !shape.hasRank()) {
+    return false;
+  }
+
+  const int64_t rank = shape.getRank();
+  if (axis.getNumElements() == 1) {
+    const int reduce_axis = *axis.getValues<int>().begin();
+    return reduce_axis == rank - 1 || reduce_axis == -1;
+  }
+
+  if (!shape.hasStaticShape() || shape.getNumElements() == 0) {
+    return false;
+  }
+  if (axis.getNumElements() != rank) {
+    return false;
+  }
+
+  SmallVector<int, 4> elems{axis.getValues<int>().begin(),
+                            axis.getValues<int>().end()};
+  for (int i = 0; i < rank; ++i) {
+    if (i != elems[i]) return false;
+  }
+
+  // Reducing across all dimensions is only equivalent to TFL L2 normalization
+  // (which reduces along the trailing dimension) if all leading dimensions
+  // have size 1.
+  for (int i = 0; i < rank - 1; ++i) {
+    if (shape.getDimSize(i) != 1) return false;
+  }
+
+  return true;
 }
 
 // Checks if a ReshapeOp is equivalent to a `keep_dims=true` reduction by


### PR DESCRIPTION
 ## Summary

  This change prevents the L2 normalization rewrite from fusing reductions over
  multiple axes.

  `TFL_L2_NORMALIZATION` normalizes only along the trailing dimension. The existing
  constraint also accepted an axis list containing every input dimension, which could
  change a global L2 normalization into a per-trailing-dimension normalization.

  The updated constraint:

  - requires exactly one reduction axis;
  - accepts `rank - 1` or its equivalent negative index `-1`;
  - leaves multi-axis normalization patterns unfused.

  A regression test verifies that the `square -> sum -> rsqrt -> mul` sequence is
  preserved for `axis = [0, 1]`.

  ## Testing

  ```text
  bazel test //tensorflow/compiler/mlir/lite/tests:optimize.mlir.test
```

  Fixes #118181

  Related to google-ai-edge/LiteRT#9212.
  This supersedes my earlier attempt in google-ai-edge/LiteRT#9464.