### PR TITLE
Fix missing output_feature_dimension validation in UniformQuantizedConvolution

### DIFF
--- a/tensorflow/core/util/quantization/uniform_quant_ops_params.cc
+++ b/tensorflow/core/util/quantization/uniform_quant_ops_params.cc
@@ -152,7 +152,7 @@ UniformQuantizedConvolutionParams::ValidateOrFillParamsAndValidateShape(
     TF_RETURN_IF_ERROR(
         ValidDim(dims, dimension_numbers_.output_batch_dimension()));
     TF_RETURN_IF_ERROR(
-        ValidDim(dims, dimension_numbers_.output_batch_dimension()));
+        ValidDim(dims, dimension_numbers_.output_feature_dimension()));
     TF_RETURN_IF_ERROR(ValidSpatialDimensions(
         dims, dimension_numbers_.output_spatial_dimensions()));
   }

--- a/tensorflow/core/util/quantization/uniform_quant_ops_params_test.cc
+++ b/tensorflow/core/util/quantization/uniform_quant_ops_params_test.cc
@@ -108,6 +108,44 @@ TEST(UniformQuantizedConvolutionParamsTest,
               ElementsAreArray({1, 2}));
 }
 
+TEST(UniformQuantizedConvolutionParamsTest,
+     ValidateOrFillParamsAndValidateShapeInvalidOutputFeatureDimension) {
+  UniformQuantizedConvolutionDimensionNumbersAttr dimension_numbers;
+  ASSERT_TRUE(TextFormat::ParseFromString(R"pb(
+                                            input_batch_dimension: 0
+                                            input_feature_dimension: 3
+                                            input_spatial_dimensions: 1
+                                            input_spatial_dimensions: 2
+                                            kernel_output_feature_dimension: 3
+                                            kernel_input_feature_dimension: 2
+                                            kernel_spatial_dimensions: 0
+                                            kernel_spatial_dimensions: 1
+                                            output_batch_dimension: 0
+                                            output_feature_dimension: 10
+                                            output_spatial_dimensions: 1
+                                            output_spatial_dimensions: 2
+                                          )pb",
+                                          &dimension_numbers));
+  UniformQuantizedConvolutionParams params(/*window_strides=*/{2, 2},
+                                           /*lhs_dilation=*/{3, 3},
+                                           /*rhs_dilation=*/{4, 4},
+                                           dimension_numbers,
+                                           /*feature_group_count=*/2,
+                                           /*batch_group_count=*/1,
+                                           /*padding=*/"EXPLICIT",
+                                           /*padding_list=*/{1, 1, 2, 2});
+  // output_feature_dimension (10) is out of bounds for a 4-D lhs shape and
+  // must be rejected. Regression test for a copy-paste bug where
+  // output_batch_dimension was validated twice and output_feature_dimension
+  // was never validated at all, allowing out-of-bounds writes downstream in
+  // CalculateOutputShape().
+  EXPECT_FALSE(
+      params
+          .ValidateOrFillParamsAndValidateShape(/*lhs_shape=*/{2, 3, 4, 2},
+                                                /*rhs_shape=*/{2, 3, 1, 2})
+          .ok());
+}
+
 TEST(UniformQuantizedConvolutionParamsTest, CalculateOutputShapeDefaultAttr) {
   UniformQuantizedConvolutionDimensionNumbersAttr dimension_numbers;
   UniformQuantizedConvolutionParams params(/*window_strides=*/{},


### PR DESCRIPTION
Fixes #127080

`ValidateOrFillParamsAndValidateShape()` validated `output_batch_dimension` twice instead of validating `output_batch_dimension` and `output_feature_dimension` — a copy-paste bug. Every other paired dimension attr in this function (`input_batch_dimension`/`input_feature_dimension`, `kernel_input_feature_dimension`/`kernel_output_feature_dimension`) already follows the correct pattern.

Because of this, `output_feature_dimension` was never range-checked before being used as a vector index in `CalculateOutputShape()`, which can write out of bounds for an out-of-range value.

## Changes

- `uniform_quant_ops_params.cc`: one-line fix, `output_batch_dimension()` → `output_feature_dimension()` in the second validation call.
- `uniform_quant_ops_params_test.cc`: adds `ValidateOrFillParamsAndValidateShapeInvalidOutputFeatureDimension`, a regression test asserting an out-of-range `output_feature_dimension` is rejected by `ValidateOrFillParamsAndValidateShape()`.