### PR TITLE
Propagate onednn async build in Tensorflow and compatibility fixes for newer XLA

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -133,6 +133,7 @@ use_repo(
     "nvshmem",
     "onednn",
     "onednn_async",
+    "onednn_async_aarch64",
     "pthreadpool",
     "raft",
     "riegeli",

--- a/tensorflow/compiler/tf2xla/kernels/xla_call_module_loader.cc
+++ b/tensorflow/compiler/tf2xla/kernels/xla_call_module_loader.cc
@@ -436,7 +436,7 @@ absl::Status XlaCallModuleLoader::LoadModule(
     // another XlaCallModuleOp.
     mlir::StatusScopedDiagnosticHandler diag_handler(context_);
     mlir::PassManager pm(module_->getContext());
-    pm.addPass(mlir::sdy::createInlineMeshesPass());
+    pm.addPass(mlir::sdy::createLiftInlinedMeshesPass());
     if (failed(pm.run(*module_))) {
       return absl::InternalError(
           absl::StrCat("Shardy inline meshes pass failed: ",

--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -243,7 +243,7 @@ cc_library(
     hdrs = ["casts.h"],
     deps = [
         ":platform",
-        "@tsl//tsl/platform:casts",
+        "@xla//third_party/tsl/tsl/platform:casts",
     ],
 )
 

--- a/tensorflow/core/platform/casts.h
+++ b/tensorflow/core/platform/casts.h
@@ -16,6 +16,6 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_PLATFORM_CASTS_H_
 #define TENSORFLOW_CORE_PLATFORM_CASTS_H_
 
-#include "tsl/platform/casts.h"  // INLINER_FORWARD_TO
+#include "third_party/tsl/tsl/platform/casts.h"  // INLINER_FORWARD_TO
 
 #endif  // TENSORFLOW_CORE_PLATFORM_CASTS_H_


### PR DESCRIPTION
Depends on moving Tensorflow to a newer third_party xla as per 
 https://github.com/openxla/xla/pull/48616 