### PR TITLE
Fix the Windows build by reading slim model weights through LLVM's portable file API

### DIFF
--- a/tensorflow/compiler/mlir/lite/python/slim_model_importer.cc
+++ b/tensorflow/compiler/mlir/lite/python/slim_model_importer.cc
@@ -15,17 +15,13 @@ limitations under the License.
 
 #include "tensorflow/compiler/mlir/lite/python/slim_model_importer.h"
 
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
 #include <algorithm>
-#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -35,11 +31,13 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -70,33 +68,34 @@ using ::mlir::ModuleOp;
 using ::mlir::OwningOpRef;
 using ::mlir::func::FuncOp;
 
-absl::Status PreadAll(int fd, char* dst, size_t count, size_t offset) {
+absl::Status ReadAll(llvm::sys::fs::file_t fd, char* dst, size_t count,
+                     size_t offset) {
   size_t total_read = 0;
   while (total_read < count) {
-    // Read in chunks of at most 1GB to remain well within POSIX SSIZE_MAX
-    // limits.
+    // Read in chunks of at most 1GB to remain well within the limits of the
+    // platform's positional read.
     size_t chunk_size =
         std::min<size_t>(count - total_read, 1024 * 1024 * 1024);
-    ssize_t bytes_read =
-        pread(fd, dst + total_read, chunk_size, offset + total_read);
-    if (bytes_read < 0) {
-      if (errno == EINTR) continue;
-      return absl::InternalError(absl::StrCat("pread failed at offset ",
-                                              offset + total_read,
-                                              " (errno=", errno, ")"));
+    llvm::Expected<size_t> bytes_read = llvm::sys::fs::readNativeFileSlice(
+        fd, llvm::MutableArrayRef<char>(dst + total_read, chunk_size),
+        offset + total_read);
+    if (!bytes_read) {
+      return absl::InternalError(
+          absl::StrCat("Read failed at offset ", offset + total_read, ": ",
+                       llvm::toString(bytes_read.takeError())));
     }
-    if (bytes_read == 0) {
+    if (*bytes_read == 0) {
       return absl::InternalError(absl::StrCat(
           "Unexpected EOF while reading weight at offset ", offset + total_read,
           ": read ", total_read, " of ", count, " bytes"));
     }
-    total_read += static_cast<size_t>(bytes_read);
+    total_read += *bytes_read;
   }
   return absl::OkStatus();
 }
 
 absl::Status InjectMappedArg(FuncOp func, int arg_idx, size_t offset,
-                             int weights_fd, size_t file_size,
+                             llvm::sys::fs::file_t weights_fd, size_t file_size,
                              llvm::DenseMap<uint64_t, mlir::Attribute>& cache) {
   if (arg_idx < 0 || arg_idx >= (int)func.getNumArguments()) {
     return absl::InvalidArgumentError(
@@ -128,16 +127,15 @@ absl::Status InjectMappedArg(FuncOp func, int arg_idx, size_t offset,
       auto blob = mlir::HeapAsmResourceBlob::allocate(
           packed_bytes, /*align=*/64, /*dataIsMutable=*/true);
       auto status =
-          PreadAll(weights_fd, const_cast<char*>(blob.getData().data()),
-                   packed_bytes, offset);
+          ReadAll(weights_fd, const_cast<char*>(blob.getData().data()),
+                  packed_bytes, offset);
       if (!status.ok()) return status;
       std::string blob_name = absl::StrCat("dense_resource_off_", offset);
       attr = mlir::DenseResourceElementsAttr::get(shaped_type, blob_name,
                                                   std::move(blob));
     } else {
       std::vector<char> small_buf(packed_bytes);
-      auto status =
-          PreadAll(weights_fd, small_buf.data(), packed_bytes, offset);
+      auto status = ReadAll(weights_fd, small_buf.data(), packed_bytes, offset);
       if (!status.ok()) return status;
       attr = mlir::DenseElementsAttr::getFromRawBuffer(
           shaped_type, llvm::ArrayRef<char>(small_buf.data(), packed_bytes));
@@ -153,7 +151,8 @@ absl::Status InjectMappedArg(FuncOp func, int arg_idx, size_t offset,
   return absl::OkStatus();
 }
 
-absl::Status InjectWeights(ModuleOp module, int weights_fd, size_t file_size,
+absl::Status InjectWeights(ModuleOp module, llvm::sys::fs::file_t weights_fd,
+                           size_t file_size,
                            const llvm::json::Object& metadata) {
   llvm::DenseMap<uint64_t, mlir::Attribute> cache;
 
@@ -310,25 +309,25 @@ absl::StatusOr<OwningOpRef<ModuleOp>> LoadSlimModel(
       llvm::StringRef(model_dir.data(), model_dir.size()));
   llvm::sys::path::append(weights_path_buf, "params.bin");
   std::string weights_path = std::string(weights_path_buf.str());
-  int weights_fd = open(weights_path.c_str(), O_RDONLY);
-  if (weights_fd < 0) {
-    if (errno != ENOENT) {
-      return absl::InternalError(absl::StrCat("Failed to open weights file '",
-                                              weights_path, "' (errno=", errno,
-                                              ")"));
+  llvm::Expected<llvm::sys::fs::file_t> weights_fd =
+      llvm::sys::fs::openNativeFileForRead(weights_path);
+  if (!weights_fd) {
+    std::error_code ec = llvm::errorToErrorCode(weights_fd.takeError());
+    if (ec != std::errc::no_such_file_or_directory) {
+      return absl::InternalError(absl::StrCat(
+          "Failed to open weights file '", weights_path, "': ", ec.message()));
     }
   } else {
-    struct stat st;
-    if (fstat(weights_fd, &st) != 0) {
-      close(weights_fd);
-      return absl::InternalError(absl::StrCat("Failed to fstat weights file '",
-                                              weights_path, "' (errno=", errno,
-                                              ")"));
+    uint64_t file_size = 0;
+    if (std::error_code ec =
+            llvm::sys::fs::file_size(weights_path, file_size)) {
+      llvm::sys::fs::closeFile(*weights_fd);
+      return absl::InternalError(absl::StrCat(
+          "Failed to stat weights file '", weights_path, "': ", ec.message()));
     }
-    size_t file_size = st.st_size;
-    auto status =
-        InjectWeights(*combined_module, weights_fd, file_size, *metadata_obj);
-    close(weights_fd);
+    auto status = InjectWeights(*combined_module, *weights_fd,
+                                static_cast<size_t>(file_size), *metadata_obj);
+    llvm::sys::fs::closeFile(*weights_fd);
     if (!status.ok()) return status;
   }
 


### PR DESCRIPTION
## The failure

`build-windows-x86 / build-and-test` fails on every pull request:

```
tensorflow/compiler/mlir/lite/python/slim_model_importer.cc(20,10): fatal error: 'unistd.h' file not found
```

[slim_model_importer.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/mlir/lite/python/slim_model_importer.cc) includes `<unistd.h>`, `<fcntl.h>` and `<sys/stat.h>`. None of the three exists under MSVC, so the file has not compiled on Windows since it started reading `params.bin`. That takes out `//tensorflow/compiler/mlir/lite/python:slim_model_importer` and everything above it, which on the CI matrix is the whole Windows job.

## What this changes

The POSIX surface in this file is four calls: a `pread` loop in `PreadAll()`, and `open`/`fstat`/`close` on `params.bin`. `llvm/Support/FileSystem.h` covers all four portably, and `@llvm-project//llvm:Support` is already a dependency of the target, so this needs no BUILD change and no new dependency.

| Was | Is |
| --- | --- |
| `pread` | `llvm::sys::fs::readNativeFileSlice()` |
| `open(O_RDONLY)` | `llvm::sys::fs::openNativeFileForRead()` |
| `fstat` | `llvm::sys::fs::file_size()` |
| `close` | `llvm::sys::fs::closeFile()` |

`readNativeFileSlice()` is a positional read: `pread()` on Unix, `ReadFile()` with an `OVERLAPPED` offset on Windows. It retries on `EINTR` itself, so the loop keeps only its 1GB chunking and its short-read and EOF handling. The `ENOENT` test that makes a missing `params.bin` non-fatal becomes a comparison against `std::errc::no_such_file_or_directory`. The `int` file descriptor becomes an `llvm::sys::fs::file_t`, which is that same `int` on Unix and a `HANDLE` on Windows, through the two helpers that carry it.

Error messages now report `ec.message()` instead of a bare `errno` number. No test asserts on their text.

The alternative was to guard the includes and hand-roll `_open`/`_lseeki64`/`_read` for Windows. That duplicates platform code, and `_read` is not positional, so it would need synchronisation the `pread` version never did.

## What I checked, and what I did not

I have no Windows machine. What I did check is that the four LLVM calls behave as the replaced POSIX ones do: compiled in isolation against LLVM and run over real files, a 13-byte `params.bin` reads back whole, a positional read at a non-zero offset returns the expected tail rather than the head, a 1MB file reads back whole, and a missing path lands in the `ENOENT` branch without an error. Formatting is `clang-format --style=Google` over the touched lines only.

What that does not cover is the Windows behaviour itself, which is the point of the change. The Windows presubmit on this pull request is the real test.

Drafted with assistance from Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
