### PR TITLE
Fix ResourceScatterUpdate GPU out-of-bounds write

### DIFF
--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -1212,6 +1212,19 @@ class ResourceScatterUpdateOp : public OpKernel {
                     "updates.shape ", updates.shape().DebugString(),
                     ", indices.shape ", indices.shape().DebugString(),
                     ", params.shape ", params->shape().DebugString())));
+    for (int d = 0; d < updates.dims(); ++d) {
+      const int64_t expected_dim =
+          d < indices.dims()
+              ? indices.dim_size(d)
+              : params->dim_size(d - indices.dims() + 1);
+      OP_REQUIRES(c, updates.dim_size(d) == expected_dim,
+                  absl::InvalidArgumentError(absl::StrCat(
+                      "Must have updates.shape = indices.shape + "
+                      "params.shape[1:] or updates.shape = [], got ",
+                      "updates.shape ", updates.shape().DebugString(),
+                      ", indices.shape ", indices.shape().DebugString(),
+                      ", params.shape ", params->shape().DebugString())));
+    }
 
     // Check that we have enough index space
     const int64_t N_big = indices.NumElements();

--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -1214,9 +1214,8 @@ class ResourceScatterUpdateOp : public OpKernel {
                     ", params.shape ", params->shape().DebugString())));
     for (int d = 0; d < updates.dims(); ++d) {
       const int64_t expected_dim =
-          d < indices.dims()
-              ? indices.dim_size(d)
-              : params->dim_size(d - indices.dims() + 1);
+          d < indices.dims() ? indices.dim_size(d)
+                             : params->dim_size(d - indices.dims() + 1);
       OP_REQUIRES(c, updates.dim_size(d) == expected_dim,
                   absl::InvalidArgumentError(absl::StrCat(
                       "Must have updates.shape = indices.shape + "

--- a/tensorflow/core/kernels/scatter_functor_gpu.cu.h
+++ b/tensorflow/core/kernels/scatter_functor_gpu.cu.h
@@ -92,12 +92,14 @@ __global__ void ScatterOpCustomKernel(T* __restrict__ params,
   GPU_1D_KERNEL_LOOP(i, updates_size) {
     int indices_i = i / update_block;
     int updates_i = i;
-    int param_first_index = indices[indices_i];
+    Index param_first_index = indices[indices_i];
     if (!(param_first_index >= 0 && param_first_index < first_dim_size)) {
       // Ignore indices that are out of range.
       continue;
     }
-    int64_t params_i = param_first_index * update_block + (i % update_block);
+    const int64_t params_i =
+        static_cast<int64_t>(param_first_index) * update_block +
+        (i % update_block);
     body(&params[params_i], ldg(updates + updates_i));
   }
 }
@@ -113,13 +115,15 @@ __global__ void ScatterScalarOpCustomKernel(T* __restrict__ params,
   ScatterOpKernelBody<T, op> body;
   GPU_1D_KERNEL_LOOP(i, synthesized_updates_size) {
     int indices_i = i / update_block;
-    int param_first_index = indices[indices_i];
+    Index param_first_index = indices[indices_i];
     const T update_val = *update;
     if (!(param_first_index >= 0 && param_first_index < first_dim_size)) {
       // Ignore indices that are out of range.
       continue;
     }
-    int params_i = param_first_index * update_block + (i % update_block);
+    const int64_t params_i =
+        static_cast<int64_t>(param_first_index) * update_block +
+        (i % update_block);
     body(&params[params_i], update_val);
   }
 }

--- a/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
@@ -1523,29 +1523,32 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     # and XLA auto-clustering execution (where the error is realized in the xla
     # op kernel) which is triggered when running in eager op as function mode.
     with self.assertRaisesRegex(
-        Exception, r"Must have updates\.shape|shape.*2.*3|RET_CHECK failure"):
+        Exception, r"Must have updates\.shape|shape.*2.*3|RET_CHECK failure"
+    ):
       state_ops.scatter_update(v, [0, 1], [0, 1, 2])
 
   @test_util.run_in_graph_and_eager_modes
   def testScatterUpdateInvalidInnerShape(self):
     v = resource_variable_ops.ResourceVariable(
-        array_ops.zeros([10, 0]), shape=tensor_shape.TensorShape(None))
+        array_ops.zeros([10, 0]), shape=tensor_shape.TensorShape(None)
+    )
     self.evaluate(variables.global_variables_initializer())
-    with self.assertRaisesRegex(errors.InvalidArgumentError,
-                                r"Must have updates\.shape"):
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError, r"Must have updates\.shape"
+    ):
       self.evaluate(
           resource_variable_ops.resource_scatter_update(
               v.handle,
               constant_op.constant(-1, dtype=dtypes.int64),
-              array_ops.zeros([5])))
+              array_ops.zeros([5]),
+          )
+      )
 
   @test_util.run_gpu_only
   def testScatterUpdateDoesNotNarrowInt64Index(self):
     with context.eager_mode(), ops.device("gpu:0"):
-      index = constant_op.constant(
-          [np.iinfo(np.int64).min], dtype=dtypes.int64)
-      for updates in (constant_op.constant(2.0),
-                      constant_op.constant([2.0])):
+      index = constant_op.constant([np.iinfo(np.int64).min], dtype=dtypes.int64)
+      for updates in (constant_op.constant(2.0), constant_op.constant([2.0])):
         v = resource_variable_ops.ResourceVariable([1.0])
         resource_variable_ops.resource_scatter_update(v.handle, index, updates)
         self.assertAllEqual([1.0], v.numpy())

--- a/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
@@ -1522,8 +1522,33 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     # eager execution (where the error is realized during kernel execution),
     # and XLA auto-clustering execution (where the error is realized in the xla
     # op kernel) which is triggered when running in eager op as function mode.
-    with self.assertRaisesRegex(Exception, r"shape.*2.*3|RET_CHECK failure"):
+    with self.assertRaisesRegex(
+        Exception, r"Must have updates\.shape|shape.*2.*3|RET_CHECK failure"):
       state_ops.scatter_update(v, [0, 1], [0, 1, 2])
+
+  @test_util.run_in_graph_and_eager_modes
+  def testScatterUpdateInvalidInnerShape(self):
+    v = resource_variable_ops.ResourceVariable(
+        array_ops.zeros([10, 0]), shape=tensor_shape.TensorShape(None))
+    self.evaluate(variables.global_variables_initializer())
+    with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                r"Must have updates\.shape"):
+      self.evaluate(
+          resource_variable_ops.resource_scatter_update(
+              v.handle,
+              constant_op.constant(-1, dtype=dtypes.int64),
+              array_ops.zeros([5])))
+
+  @test_util.run_gpu_only
+  def testScatterUpdateDoesNotNarrowInt64Index(self):
+    with context.eager_mode(), ops.device("gpu:0"):
+      index = constant_op.constant(
+          [np.iinfo(np.int64).min], dtype=dtypes.int64)
+      for updates in (constant_op.constant(2.0),
+                      constant_op.constant([2.0])):
+        v = resource_variable_ops.ResourceVariable([1.0])
+        resource_variable_ops.resource_scatter_update(v.handle, index, updates)
+        self.assertAllEqual([1.0], v.numpy())
 
   @test_util.disable_xla("b/208334252")  # XLA doesn't have a deterministic impl
   def testScatterAddDeterministic(self):


### PR DESCRIPTION
ResourceScatterUpdate converted int64 indices to int before checking them.
This could turn an invalid index into a valid one and write outside the tensor.

I removed the int conversion, checked that the values match the variable
shape, and added tests for both problems.

Fixes #104080