### PR TITLE
Fix ResizeBilinear GPU index overflow

### DIFF
--- a/tensorflow/core/kernels/image/resize_bilinear_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/image/resize_bilinear_op_gpu.cu.cc
@@ -296,7 +296,7 @@ __global__ void LegacyResizeBilinearKernel(
     const int x = idx % out_width;
     idx /= out_width;
     const int y = idx % out_height;
-    const int b = idx / out_height;
+    const int64_t b = idx / out_height;
 
     const float in_y = y * height_scale;
     const int top_y_index = floorf(in_y);

--- a/tensorflow/core/kernels/image/resize_bilinear_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/image/resize_bilinear_op_gpu.cu.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <type_traits>
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 


### PR DESCRIPTION
The ResizeBilinear GPU kernel calculated input offsets with a 32-bit batch
index. For inputs with more than INT32_MAX elements, the offset could
overflow and read outside the tensor.

I changed the batch index to int64 so the input offset does not overflow.

I did not add a test because reproducing this requires an input with more
than INT32_MAX elements.

Fixes #109518