### PR TITLE
Fix TopK GPU loop index overflow

### DIFF
--- a/tensorflow/core/kernels/topk_op_gpu.h
+++ b/tensorflow/core/kernels/topk_op_gpu.h
@@ -238,12 +238,12 @@ __device__ void heapTopK(const T* __restrict__ input, int length, int k,
   // Now iterate over the remaining items.
   // If an item is smaller than the min element, it is not amongst the top k.
   // Otherwise, replace the min element with it and push upwards.
-  for (int index = heap_end_index; index < length; index += step_size) {
+  for (int64_t index = heap_end_index; index < length; index += step_size) {
     // We prefer elements with lower indices. This is given here.
     // Later elements automatically have higher indices, so can be discarded.
     if (input[index] > heap.root().value) {
       // This element should replace the min.
-      heap.replace_root({index, input[index]}, k);
+      heap.replace_root({static_cast<int>(index), input[index]}, k);
     }
   }
 


### PR DESCRIPTION
The TopK GPU kernel used a 32-bit loop index. When the index was close to
INT32_MAX, adding the thread stride could wrap it to a negative value and
make the kernel read outside the tensor.

I changed the loop index to int64 so adding the stride does not overflow.
The output index stays int32 because TopK checks that the input length
does not exceed INT32_MAX.

I did not add a test because reproducing this requires an input with
INT32_MAX doubles, which is about 17 GB.

Fixes #109523