### PR TITLE
Fix int32 overflow in ScatterNd accumulated output index (CPU + GPU)

### DIFF
--- a/tensorflow/core/kernels/scatter_nd_op.cc
+++ b/tensorflow/core/kernels/scatter_nd_op.cc
@@ -911,6 +911,30 @@ absl::Status PrepareAndValidateInputs(const TensorShape& params_shape,
                    ? indices_shape.dim_size(indices_shape.dims() - 1)
                    : 1;
 
+  // Check that the product of the leading ("batch") dimensions --
+  // params_shape[0, *slice_dim) -- fits in Index. This product determines
+  // the per-dimension strides ScatterNdFunctor uses to compute the
+  // accumulated linear output offset. Unlike slice_size (the product of the
+  // trailing dimensions, checked below), it was previously validated only
+  // for dim_size(0) in isolation, just above -- dims 1..(*slice_dim - 1),
+  // and their product, were never checked. A shape whose individual leading
+  // dimensions each fit in Index but whose product does not (e.g.
+  // [1, 46342, 46341] with a 3-D indices tensor) passed validation while
+  // silently overflowing Index inside the functor, turning the computed
+  // output offset negative and reading/writing outside Toutput's
+  // allocation.
+  int64_t batch_volume_big = 1;
+  for (int64_t i = 0; i < *slice_dim; ++i) {
+    batch_volume_big *= params_shape.dim_size(i);
+    if (batch_volume_big > std::numeric_limits<Index>::max()) {
+      return errors::InvalidArgument(
+          "Product of the leading (batch) dimensions of params_shape=",
+          params_shape.DebugString(), " is too large for ",
+          DataTypeString(DataTypeToEnum<Index>::v()),
+          " indexing: exceeds ", std::numeric_limits<Index>::max());
+    }
+  }
+
   // Calculate the number of elements that make up each slice of our updated
   // tensor. This allows us to work with flattened tensors and copy over whole
   // slices at a time.

--- a/tensorflow/core/kernels/scatter_nd_op_cpu_impl.h
+++ b/tensorflow/core/kernels/scatter_nd_op_cpu_impl.h
@@ -21,6 +21,7 @@ limitations under the License.
 #define EIGEN_USE_THREADS
 
 #include <atomic>
+#include <cstdint>
 
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 
@@ -118,7 +119,18 @@ struct ScatterNdFunctor<CPUDevice, T, Index, OP, IXDIM> {
 
     const Eigen::DenseIndex batch_size = Tindices.dimension(0);
 
-    Index batch_strides[IXDIM];
+    // batch_strides and the accumulated linear index below are computed in
+    // int64_t regardless of Index's width. output_shape_prefix entries are
+    // int64 (Eigen::DenseIndex), and their product (and the subsequent
+    // per-dimension accumulation into the linear output offset) can exceed
+    // INT32_MAX for legitimately large output shapes; narrowing either the
+    // stride table or the accumulator to a 32-bit Index silently truncates
+    // that value, which can turn `i` negative and read/write outside
+    // Toutput's allocation. FastBoundsCheck below only validates each raw
+    // per-dimension index against its own dimension size -- it does not (and
+    // cannot, on its own) catch overflow of the accumulated product, so both
+    // of these must stay wide enough to hold the true value.
+    int64_t batch_strides[IXDIM];
     if (IXDIM > 0) {
       batch_strides[IXDIM - 1] = 1;
     }
@@ -128,12 +140,12 @@ struct ScatterNdFunctor<CPUDevice, T, Index, OP, IXDIM> {
     }
 
     for (Eigen::DenseIndex loc = 0; loc < batch_size; ++loc) {
-      Index i = 0;
+      int64_t i = 0;
       bool out_of_bounds = false;
       for (int dim = 0; dim < IXDIM; ++dim) {
         const Index ix_d = internal::SubtleMustCopy(Tindices(loc, dim));
         out_of_bounds |= !FastBoundsCheck(ix_d, output_shape_prefix[dim]);
-        i += ix_d * batch_strides[dim];
+        i += static_cast<int64_t>(ix_d) * batch_strides[dim];
       }
       if (TF_PREDICT_FALSE(out_of_bounds)) {
         error_loc = loc;

--- a/tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc
@@ -103,14 +103,22 @@ __global__ void ScatterNdOpKernel(
   auto update = LeftUpdate<T, op>();
 
   GPU_1D_KERNEL_LOOP(index, num_indices) {
-    Index i = 0;
+    // i accumulates the linear output offset in int64_t regardless of
+    // Index's width. batch_strides is already int64, so each `ix_d *
+    // batch_strides[dim] * slice_size` term is computed correctly -- but
+    // narrowing the accumulator itself back to a 32-bit Index would silently
+    // truncate it on every `+=`, which can turn `i` negative and make
+    // `out + i` a write outside the output buffer. FastBoundsCheck below only
+    // validates each raw per-dimension index against its own dimension size;
+    // it does not catch overflow of the accumulated product.
+    int64_t i = 0;
     bool out_of_bounds = false;
 #pragma unroll
     for (int dim = 0; dim < IXDIM; ++dim) {
       int offset = (IXDIM * index + dim);
       const Index ix_d = internal::SubtleMustCopy(ldg(indices + offset));
       out_of_bounds |= !FastBoundsCheck(ix_d, output_shape_prefix[dim]);
-      i += ix_d * batch_strides[dim] * slice_size;
+      i += static_cast<int64_t>(ix_d) * batch_strides[dim] * slice_size;
     }
     if (!out_of_bounds) {
 #pragma unroll

--- a/tensorflow/core/kernels/scatter_nd_op_test.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_test.cc
@@ -540,6 +540,29 @@ TEST_F(ScatterNdOpTest, Error_IndexOutOfRange) {
       << s;
 }
 
+TEST_F(ScatterNdOpTest, Error_BatchDimensionProductOverflowsIndex) {
+  MakeOp(DT_FLOAT, DT_INT32);
+
+  // None of the individual leading ("batch") dimensions of this shape
+  // exceeds INT32_MAX, and neither does dim_size(0) alone, but their
+  // product (46342 * 46341 = 2,147,534,622) does. Before the accompanying
+  // fix, PrepareAndValidateInputs never checked that product, so this shape
+  // passed validation and the corresponding stride computation in
+  // ScatterNdFunctor silently overflowed Index (int32), turning the
+  // accumulated output offset negative and reading/writing outside the
+  // output tensor's allocation. This must now be rejected during
+  // validation -- before any output tensor is allocated -- so this test
+  // stays cheap regardless of how large the (rejected) shape is.
+  AddInputFromArray<int32_t>(TensorShape({1, 3}), {0, 0, 0});
+  AddInputFromArray<float>(TensorShape({1}), {1});
+  AddInputFromArray<int32_t>(TensorShape({3}), {1, 46342, 46341});
+  absl::Status s = RunOpKernel();
+  EXPECT_FALSE(s.ok());
+  EXPECT_TRUE(absl::StrContains(s.ToString(),
+                                "Product of the leading (batch) dimensions"))
+      << s;
+}
+
 class ScatterNdOpErrorOnBadIndicesTest : public OpsTestBase {
  protected:
   void MakeOp(DataType variable_type, DataType index_type) {


### PR DESCRIPTION
Fixes #127164

`ScatterNdFunctor` computes the linear output offset for each index tuple by accumulating per-dimension strides. For the int32-`Index` variant, both the stride table and the accumulator were declared as the narrow `Index` type on CPU, and the accumulator alone was still narrow on GPU (its stride table was already `int64_t`). A legitimate output shape whose individual leading ("batch") dimensions each fit in int32, but whose product does not (e.g. `[1, 46342, 46341]`), was never rejected by `PrepareAndValidateInputs` — only `dim_size(0)` was checked in isolation, never the product of the leading dimensions. That combination let the accumulated offset silently overflow to a negative value, used directly as a memory offset into the output tensor.

Live-verified: `tf.raw_ops.ScatterNd(indices=[[0, 46341, 0]], updates=[42], shape=[1, 46342, 46341])` crashes `tensorflow==2.21.0` with `SIGBUS`/`EXC_BAD_ACCESS`, symbolicated directly to `ScatterNdFunctor<..., int, ADD, 3>::operator()`. Details in #127164.

## Changes

- `scatter_nd_op.cc`: `PrepareAndValidateInputs` now validates the product of the leading dimensions (`params_shape[0, slice_dim)`) against `Index`'s range, matching the existing check already done for the trailing (`slice_size`) dimensions. This is the primary fix — it rejects the dangerous shape before either kernel runs, and applies to both CPU and GPU dispatch since it's shared, device-templated validation code.
- `scatter_nd_op_cpu_impl.h`: widen the CPU functor's `batch_strides` table and accumulator to `int64_t` (defense in depth).
- `scatter_nd_op_gpu.cu.cc`: widen the GPU kernel's accumulator to `int64_t` — its stride table was already `int64_t`, but the accumulator that consumes it wasn't, so the identical class of overflow reproduced one step later (defense in depth).
- `scatter_nd_op_test.cc`: regression test asserting the previously-missing batch-dimension-product check is enforced. The rejection happens during validation, before any output tensor is allocated, so the test stays cheap regardless of the (rejected) shape's size.