### PR TITLE
Fix YNNPACK partial-output cropping for broadcast reductions

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
+++ b/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
@@ -19,6 +19,19 @@ endif()
 
 include(OverridableFetchContent)
 
+# Match the YNNPACK reduction fix in the Bazel dependency without requiring Git
+# for archive-only builds that do not enable YNNPACK.
+set(_XNNPACK_PATCH_COMMAND "")
+if(XNNPACK_BUILD_YNNPACK)
+  find_package(Git REQUIRED)
+  set(_XNNPACK_PATCH_COMMAND
+    PATCH_COMMAND "${CMAKE_COMMAND}"
+    "-DGIT_EXECUTABLE=${GIT_EXECUTABLE}"
+    "-DXNNPACK_SOURCE_DIR=<SOURCE_DIR>"
+    -P "${CMAKE_CURRENT_LIST_DIR}/xnnpack/ApplyYnnpackPatch.cmake"
+  )
+endif()
+
 OverridableFetchContent_Declare(
   xnnpack
   GIT_REPOSITORY https://github.com/google/XNNPACK
@@ -27,6 +40,7 @@ OverridableFetchContent_Declare(
   GIT_PROGRESS TRUE
   PREFIX "${CMAKE_BINARY_DIR}"
   SOURCE_DIR "${CMAKE_BINARY_DIR}/xnnpack"
+  ${_XNNPACK_PATCH_COMMAND}
 )
 OverridableFetchContent_GetProperties(xnnpack)
 if(NOT xnnpack_POPULATED)

--- a/tensorflow/lite/tools/cmake/modules/xnnpack/ApplyYnnpackPatch.cmake
+++ b/tensorflow/lite/tools/cmake/modules/xnnpack/ApplyYnnpackPatch.cmake
@@ -1,0 +1,48 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(_YNNPACK_PATCH
+  "${CMAKE_CURRENT_LIST_DIR}/../../../../../../third_party/xla/third_party/xnnpack/ynn_reduce_broadcast.patch"
+)
+get_filename_component(XNNPACK_SOURCE_DIR "${XNNPACK_SOURCE_DIR}" REALPATH)
+get_filename_component(_XNNPACK_PARENT_DIR "${XNNPACK_SOURCE_DIR}" DIRECTORY)
+# An archive may be extracted inside another Git checkout. Stop discovery at
+# its parent so git apply does not silently skip paths outside that checkout's
+# current subdirectory. A Git checkout of XNNPACK itself is still supported.
+set(_YNNPACK_GIT
+  "${CMAKE_COMMAND}" -E env "GIT_CEILING_DIRECTORIES=${_XNNPACK_PARENT_DIR}"
+  "${GIT_EXECUTABLE}"
+)
+
+# Toggling YNNPACK off and on can rerun FetchContent's patch step. Accept only
+# a fully applied patch; partial or incompatible contents must still fail.
+execute_process(
+  COMMAND ${_YNNPACK_GIT} apply --reverse --check "${_YNNPACK_PATCH}"
+  WORKING_DIRECTORY "${XNNPACK_SOURCE_DIR}"
+  RESULT_VARIABLE _YNNPACK_PATCH_APPLIED
+  OUTPUT_QUIET ERROR_QUIET
+)
+if(_YNNPACK_PATCH_APPLIED EQUAL 0)
+  return()
+endif()
+
+execute_process(
+  COMMAND ${_YNNPACK_GIT} apply "${_YNNPACK_PATCH}"
+  WORKING_DIRECTORY "${XNNPACK_SOURCE_DIR}"
+  RESULT_VARIABLE _YNNPACK_PATCH_RESULT
+  ERROR_VARIABLE _YNNPACK_PATCH_ERROR
+)
+if(NOT _YNNPACK_PATCH_RESULT EQUAL 0)
+  message(FATAL_ERROR "Failed to apply YNNPACK reduction patch: ${_YNNPACK_PATCH_ERROR}")
+endif()

--- a/third_party/xla/third_party/xnnpack/BUILD
+++ b/third_party/xla/third_party/xnnpack/BUILD
@@ -1,3 +1,6 @@
 licenses(["notice"])
 
-exports_files(["cl_clang.patch"])
+exports_files([
+    "cl_clang.patch",
+    "ynn_reduce_broadcast.patch",
+])

--- a/third_party/xla/third_party/xnnpack/workspace.bzl
+++ b/third_party/xla/third_party/xnnpack/workspace.bzl
@@ -23,6 +23,7 @@ def repo():
         name = "XNNPACK",
         sha256 = "6ebde53e2dc0af6d16e3e2f46f6e9428a76f4356c2e177c5f558c0b4c5cf9e83",
         strip_prefix = "XNNPACK-8388bd78690515166d59f1b28e593a455a41d580",
+        patch_file = ["//third_party/xnnpack:ynn_reduce_broadcast.patch"],
         urls = tf_mirror_urls("https://github.com/google/XNNPACK/archive/8388bd78690515166d59f1b28e593a455a41d580.zip"),
     )
     # LINT.ThenChange(//tensorflow/lite/tools/cmake/modules/xnnpack.cmake)

--- a/third_party/xla/third_party/xnnpack/ynn_reduce_broadcast.patch
+++ b/third_party/xla/third_party/xnnpack/ynn_reduce_broadcast.patch
@@ -1,0 +1,186 @@
+diff --git a/ynnpack/subgraph/reduce.cc b/ynnpack/subgraph/reduce.cc
+--- a/ynnpack/subgraph/reduce.cc
++++ b/ynnpack/subgraph/reduce.cc
+@@ -77,7 +77,9 @@
+     bool init_output = true;
+     if (op.keep_dims) {
+       int r_dim = 0;
+-      for (int i = 0; i < a.rank && r_dim < reduction_bounds.rank; ++i) {
++      // Slinky can omit trailing broadcast dimensions from a. They still
++      // index distinct partial results, so visit all reduction dimensions.
++      for (int i = 0; r_dim < reduction_bounds.rank; ++i) {
+         if (op.k_dims[i]) {
+           const slinky::dim& r_dim_i = reduction_bounds.dim(r_dim++);
+           if (c.dim(i).stride() == 0) {
+diff --git a/ynnpack/subgraph/test/BUILD b/ynnpack/subgraph/test/BUILD
+--- a/ynnpack/subgraph/test/BUILD
++++ b/ynnpack/subgraph/test/BUILD
+@@ -186,6 +186,19 @@
+     linkopts = ynn_binary_linkopts(),
+     malloc = ynn_binary_malloc(),
+     deps = TEST_DEPS + ["//ynnpack/subgraph"],
++)
++
++cc_test(
++    name = "reduce",
++    srcs = ["reduce.cc"],
++    linkopts = ynn_binary_linkopts(),
++    malloc = ynn_binary_malloc(),
++    deps = TEST_DEPS + [
++        "//ynnpack/subgraph",
++        "@slinky//slinky/base:thread_pool_impl",
++        "@slinky//slinky/builder",
++        "@slinky//slinky/runtime",
++    ],
+ )
+ 
+ [cc_test(
+@@ -206,7 +219,6 @@
+     "gather",
+     "get_tensor_shape",
+     "iota",
+-    "reduce",
+     "reduce_dot",
+     "runtime",
+     "split_dim",
+diff --git a/ynnpack/subgraph/test/reduce.cc b/ynnpack/subgraph/test/reduce.cc
+--- a/ynnpack/subgraph/test/reduce.cc
++++ b/ynnpack/subgraph/test/reduce.cc
+@@ -2,6 +2,8 @@
+ //
+ // This source code is licensed under the BSD-style license found in the
+ // LICENSE file in the root directory of this source tree.
++
++#include <gtest/gtest.h>
+ 
+ #include <algorithm>
+ #include <cassert>
+@@ -9,12 +11,17 @@
+ #include <cstddef>
+ #include <cstdint>
+ #include <functional>
++#include <memory>
+ #include <random>
+ #include <tuple>
+ #include <type_traits>
++#include <utility>
+ #include <vector>
+ 
+-#include <gtest/gtest.h>
++#include "slinky/base/thread_pool_impl.h"
++#include "slinky/builder/pipeline.h"
++#include "slinky/runtime/buffer.h"
++#include "slinky/runtime/evaluate.h"
+ #include "ynnpack/base/arch.h"  // IWYU pragma: keep
+ #include "ynnpack/base/base.h"
+ #include "ynnpack/base/bfloat16.h"
+@@ -26,12 +33,109 @@
+ #include "ynnpack/base/to_string.h"
+ #include "ynnpack/base/type.h"
+ #include "ynnpack/include/ynnpack.h"
++#include "ynnpack/subgraph/runtime.h"
+ #include "ynnpack/subgraph/test/scheduler.h"
+ #include "ynnpack/subgraph/test/subgraph_builder.h"
+ 
+ using ynn::to_string;  // NOLINT(misc-unused-using-decls)
+ 
+ namespace ynn {
++
++namespace {
++
++TEST(Reduce, BroadcastPartialReduction) {
++  slinky::thread_pool_impl pool(4);
++  ynn_subgraph_t subgraph_ptr = nullptr;
++  ASSERT_EQ(ynn_create_subgraph(2, 0, &subgraph_ptr), ynn_status_success);
++  std::unique_ptr<ynn_subgraph, decltype(&ynn_delete_subgraph)> subgraph(
++      subgraph_ptr, ynn_delete_subgraph);
++  uint32_t input_id = 0, output_id = 1;
++  const size_t input_dims[] = {1024};
++  ASSERT_EQ(
++      ynn_define_tensor(subgraph.get(), ynn_type_fp32, 1, input_dims, nullptr,
++                        YNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id),
++      ynn_status_success);
++  ASSERT_EQ(
++      ynn_define_tensor(subgraph.get(), ynn_type_fp32, 0, nullptr, nullptr,
++                        YNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id),
++      ynn_status_success);
++  uint32_t expanded = YNN_INVALID_VALUE_ID;
++  const int32_t expand_axes[] = {0, 2};
++  ASSERT_EQ(ynn_define_static_expand_dims(subgraph.get(), 2, expand_axes,
++                                          input_id, &expanded, 0),
++            ynn_status_success);
++  uint32_t broadcast = YNN_INVALID_VALUE_ID;
++  const size_t output_dims[] = {2, 1024, 1024};
++  ASSERT_EQ(ynn_define_static_broadcast(subgraph.get(), 3, output_dims,
++                                        expanded, &broadcast, 0),
++            ynn_status_success);
++  const int32_t axes[] = {0, 1, 2};
++  ASSERT_EQ(ynn_define_reduce(subgraph.get(), ynn_reduce_sum, 3, axes,
++                              broadcast, YNN_INVALID_VALUE_ID, &output_id, 0),
++            ynn_status_success);
++
++  ynn_runtime_t runtime_ptr = nullptr;
++  ASSERT_EQ(ynn_create_runtime(subgraph.get(),
++                               reinterpret_cast<ynn_threadpool_t>(&pool), 0,
++                               &runtime_ptr),
++            ynn_status_success);
++  std::unique_ptr<ynn_runtime, decltype(&ynn_delete_runtime)> runtime(
++      runtime_ptr, ynn_delete_runtime);
++  ASSERT_EQ(ynn_reshape_runtime(runtime.get()), ynn_status_success);
++  // Invoke the partial reduction for the first tile directly. Slinky drops
++  // the trailing singleton broadcast dimension of this tile's input, but
++  // the partial output still has two entries in that dimension. The call
++  // must leave every other tile's output untouched, regardless of scheduling.
++  bool tested_partial = false;
++  for (const slinky::func& func : runtime->funcs) {
++    if (func.outputs().size() != 2 || func.outputs()[0].buffer->rank() != 3) {
++      continue;
++    }
++    std::vector<float> tile_data(32, 1.0f);
++    slinky::buffer<float, 3> tile(2);
++    tile.raw_buffer::base = tile_data.data();
++    tile.mutable_dim(0) = slinky::dim(0, 1023, 0);
++    tile.mutable_dim(1) = slinky::dim(0, 31, sizeof(float));
++    float zero = 0.0f;
++    slinky::buffer<float, 3> init(0);
++    init.raw_buffer::base = &zero;
++    std::vector<float> partial_data(64, -1.0f);
++    slinky::buffer<float, 3> partial({1, 32, 2});
++    partial.raw_buffer::base = partial_data.data();
++    slinky::buffer<void, 3> bounds(3, 0);
++    bounds.mutable_dim(0) = slinky::dim(0, 1023, 0, 1024);
++    bounds.mutable_dim(1) = slinky::dim(0, 31, 0, 32);
++    bounds.mutable_dim(2) = slinky::dim(0, 0, 0, 1);
++    slinky::eval_context context;
++    auto bind = [&](slinky::var sym, const slinky::raw_buffer* buffer) {
++      context.reserve(sym.id + 1);
++      context.set(sym, reinterpret_cast<slinky::index_t>(buffer));
++    };
++    bind(func.inputs()[0].buffer->sym(), &tile);
++    bind(func.inputs()[1].buffer->sym(), &init);
++    bind(func.outputs()[0].buffer->sym(), &partial);
++    bind(func.outputs()[1].buffer->sym(), &bounds);
++    ASSERT_EQ(slinky::evaluate(func.make_call(), context), 0);
++    for (size_t i = 0; i < partial_data.size(); ++i) {
++      EXPECT_EQ(partial_data[i], i == 0 ? 32768.0f : -1.0f) << i;
++    }
++    tested_partial = true;
++  }
++  ASSERT_TRUE(tested_partial);
++
++  std::vector<float> input(1024, 1.0f);
++  float output = 0.0f;
++  ASSERT_EQ(ynn_set_external_value_data(runtime.get(), 0, input.data()),
++            ynn_status_success);
++  ASSERT_EQ(ynn_set_external_value_data(runtime.get(), 1, &output),
++            ynn_status_success);
++  for (int i = 0; i < 100; ++i) {
++    ASSERT_EQ(ynn_invoke_runtime(runtime.get()), ynn_status_success);
++    EXPECT_EQ(output, 2097152.0f);
++  }
++}
++
++}  // namespace
+ 
+ // We only test reduce up to this rank. The reduce implementation has no special
+ // cases for more than one or two dimensions, so this should be plenty of


### PR DESCRIPTION
## Summary of Changes
- Fix YNNPACK partial-output cropping when Slinky omits trailing singleton broadcast dimensions.
- Preserve the existing dependency versions and parallel execution.
- Apply the dependency patch through Bazel and YNNPACK-enabled TFLite CMake builds.
- Make CMake patch application idempotent and handle builds inside enclosing Git repositories.

## Justification
Fixes #126812.

The cropping loop used the input buffer's physical rank, which can be lower than the reduction bounds' rank. This left some tasks writing another task's partial output, producing incorrect, nondeterministic sums under XLA CPU.

The fix processes every reduction bound rather than stopping at the input's physical rank.

## Kind of Contribution
Bug fix and regression tests.

## Unit Tests
Added `Reduce.BroadcastPartialReduction`:
- A deterministic sentinel check verifies that a reduction tile leaves other tiles' outputs untouched.
- The assertion fails without the production fix and passes with it.

## Execution Tests
- Native pinned YNNPACK reduction suite: 45/45 passed.
- Repeated regression: 1,000 correct multithreaded original-shape graph calls.
- CMake smoke checks passed for disabled builds without Git, repeated configuration, option toggling, enclosing Git repositories, and rejection of partial/incompatible patches.
- Google C++ formatting checks passed.

## Validation Limitations
Full TensorFlow/Bazel builds were blocked before compilation by storage errors during LLVM extraction. Validation used native generic YNNPACK kernels; rebuilt-TensorFlow, ISA-specific, and full TFLite integration checks remain outstanding.
