### PR TITLE
Set the slim model's weights file unbuffered before it is open, and report a failed open

### DIFF
--- a/tensorflow/compiler/mlir/lite/python/slim_model_importer.cc
+++ b/tensorflow/compiler/mlir/lite/python/slim_model_importer.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -307,9 +308,21 @@ absl::StatusOr<OwningOpRef<ModuleOp>> LoadSlimModel(
       llvm::StringRef(model_dir.data(), model_dir.size()));
   llvm::sys::path::append(weights_path_buf, "params.bin");
   std::string weights_path = std::string(weights_path_buf.str());
-  std::ifstream weights_file(weights_path, std::ios::binary);
-  if (weights_file) {
-    weights_file.rdbuf()->pubsetbuf(nullptr, 0);
+  std::ifstream weights_file;
+  // Unbuffered, so that the 1GB reads below land straight in the destination
+  // rather than passing through a stream buffer on the way. setbuf has that
+  // effect only before the file is open, which is why this comes first.
+  weights_file.rdbuf()->pubsetbuf(nullptr, 0);
+  weights_file.open(weights_path, std::ios::binary);
+  if (!weights_file) {
+    // A model that ships no weights is not an error, but a weights file that
+    // is there and will not open is: injecting nothing would hand back a
+    // module whose arguments are still unbound.
+    if (llvm::sys::fs::exists(weights_path)) {
+      return absl::InternalError(absl::StrCat("Failed to open weights file '",
+                                              weights_path, "'"));
+    }
+  } else {
     weights_file.seekg(0, std::ios::end);
     std::streampos end_pos = weights_file.tellg();
     if (end_pos < 0) {


### PR DESCRIPTION
Two follow-ups to ddbc4742a30, which replaced this file's POSIX reads with `std::ifstream` and fixed the Windows build.

## `setbuf` after `open` does nothing reliable

```c++
std::ifstream weights_file(weights_path, std::ios::binary);
if (weights_file) {
  weights_file.rdbuf()->pubsetbuf(nullptr, 0);
```

`basic_filebuf::setbuf` is specified to change the buffer only while the stream has none yet; once the file is open the effect is unspecified, and an implementation may ignore the call entirely. The intent reads clearly from the parent commit, which is about peak memory during weight injection: the 1GB reads should land in the destination rather than passing through a stream buffer on the way. That only holds if the call comes first, so this opens the stream in two steps and sets the buffer before `open()`.

## A weights file that will not open is now reported

Before ddbc4742a30:

```c++
int weights_fd = open(weights_path.c_str(), O_RDONLY);
if (weights_fd < 0) {
  if (errno != ENOENT) {
    return absl::InternalError(...);
  }
}
```

A missing `params.bin` was fine, any other `errno` was an error. `if (weights_file)` does not draw that line: a file that exists and will not open, for lack of permission or through an I/O error, takes the same path as one that is not there, and `LoadSlimModel` returns a module whose arguments are still unbound instead of saying what went wrong.

`llvm::sys::fs::exists` restores the distinction portably, and `@llvm-project//llvm:Support` is already a dependency of this target, so this adds none.

## Checked

```
$ bazel build //tensorflow/compiler/mlir/lite/python:slim_model_importer
INFO: Build completed successfully, 1254 total actions
```

Built on macOS/arm64. `slim_model_importer_test` asserts on no error text, and neither change alters the success path.

This started as #127111, which fixed the same Windows break with LLVM's portable file API before ddbc4742a30 landed. That one is superseded and can be closed.

Drafted with assistance from Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
