### PR TITLE
Fix memory safety vulnerabilities in the TFLite GPU delegate model builder

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/BUILD
+++ b/tensorflow/lite/delegates/gpu/common/BUILD
@@ -287,12 +287,15 @@ cc_test(
     srcs = ["model_builder_test.cc"],
     deps = [
         ":data_type",
+        ":model",
         ":model_builder",
+        ":object_reader",
         ":shape",
         ":tensor",
         "//tensorflow/lite:framework",
         "//tensorflow/lite:kernel_api",
         "//tensorflow/lite/core/c:common",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/types:span",
@@ -366,6 +369,18 @@ cc_library(
         "@FP16",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "object_reader_test",
+    srcs = ["object_reader_test.cc"],
+    deps = [
+        ":model",
+        ":object_reader",
+        "//tensorflow/lite/core/c:private_common",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/tensorflow/lite/delegates/gpu/common/model_builder.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder.cc
@@ -2785,6 +2785,15 @@ class TransposeOperationParser : public TFLiteOperationParser {
     TransposeAttributes attr;
     Tensor<Linear, DataType::INT32> perm;
     RETURN_IF_ERROR(reader->ReadTensor(1, &perm));
+    // Entries index `index_to_axis` below, so each one must be a valid axis of
+    // the permutation itself.
+    const int32_t perm_size = static_cast<int32_t>(perm.data.size());
+    for (const int32_t axis_index : perm.data) {
+      if (axis_index < 0 || axis_index >= perm_size) {
+        return absl::InvalidArgumentError(
+            "Permutation for transpose is invalid.");
+      }
+    }
     std::map<Axis, int> axis_to_index = {{Axis::BATCH, 0},
                                          {Axis::HEIGHT, 1},
                                          {Axis::WIDTH, 2},
@@ -2942,7 +2951,9 @@ class BatchToSpaceOperationParser : public TFLiteOperationParser {
     Tensor<HW, DataType::INT32> crop;
     RETURN_IF_ERROR(reader->ReadTensor(2, &crop));
     auto crop_shape = crop.shape;
-    if (crop_shape.h != 2 && crop_shape.w != 2) {
+    // Both dimensions must be 2: `crop.data[3]` is read below,
+    // so a 2x1 tensor would run off the end of the buffer.
+    if (crop_shape.h != 2 || crop_shape.w != 2) {
       return absl::InternalError("Space has to be HxW.");
     }
 
@@ -2985,7 +2996,9 @@ class SpaceToBatchOperationParser : public TFLiteOperationParser {
     RETURN_IF_ERROR(reader->ReadTensor(2, &padding));
     auto padding_shape = padding.shape;
 
-    if (padding_shape.h != 2 && padding_shape.w != 2) {
+    // Both dimensions must be 2: `padding.data[3]` is read below,
+    // so a 2x1 tensor would run off the end of the buffer.
+    if (padding_shape.h != 2 || padding_shape.w != 2) {
       return absl::InternalError("Space has to be HxW.");
     }
 

--- a/tensorflow/lite/delegates/gpu/common/model_builder_helper.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder_helper.cc
@@ -257,12 +257,45 @@ void ConvertFloat16ToFloat32(size_t num_elements, const uint16_t* src,
 
 template <>
 absl::Status CreateVectorCopyData<float>(const TfLiteTensor& src, float* dst) {
+  // Every branch below consumes exactly NumElements() source elements (`dst` is
+  // allocated by the caller from NumElements() as well), so the source buffer
+  // must be large enough for the shape the tensor declares. A malformed model
+  // can declare a shape that disagrees with `bytes`, which would make the
+  // copies/dequantizations below read out of bounds.
+  int64_t element_size = 0;
   switch (src.type) {
     case kTfLiteFloat32:
-      std::memcpy(dst, src.data.f, src.bytes);
+      element_size = sizeof(float);
+      break;
+    case kTfLiteInt32:
+      element_size = sizeof(int32_t);
+      break;
+    case kTfLiteFloat16:
+      element_size = sizeof(uint16_t);
+      break;
+    case kTfLiteInt8:
+      element_size = sizeof(int8_t);
+      break;
+    case kTfLiteUInt8:
+      element_size = sizeof(uint8_t);
+      break;
+    default:
+      return absl::InvalidArgumentError(
+          "Unsupported data type for float32 tensor");
+  }
+  const int64_t num_elements = NumElements(&src);
+  const int64_t required_bytes = num_elements * element_size;
+  if (static_cast<int64_t>(src.bytes) < required_bytes) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Input data size ", src.bytes, " is smaller than the ",
+                     required_bytes, " bytes required by the tensor shape"));
+  }
+  switch (src.type) {
+    case kTfLiteFloat32:
+      std::memcpy(dst, src.data.f, static_cast<size_t>(required_bytes));
       return absl::OkStatus();
     case kTfLiteFloat16:
-      ConvertFloat16ToFloat32(NumElements(&src),
+      ConvertFloat16ToFloat32(static_cast<size_t>(num_elements),
                               reinterpret_cast<uint16_t const*>(src.data.f16),
                               dst);
       return absl::OkStatus();

--- a/tensorflow/lite/delegates/gpu/common/model_builder_helper_test.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder_helper_test.cc
@@ -43,6 +43,44 @@ TEST(ModelBuilderHelperTest, CreateVectorCopyDataDifferentSize) {
   TfLiteIntArrayFree(tflite_tensor.dims);
 }
 
+TEST(ModelBuilderHelperTest, CreateVectorCopyDataFloatBytesLargerThanShape) {
+  // Callers size the destination using the tensor shape, so the float copy
+  // must not write more elements than the shape describes even when the
+  // source buffer reports a larger byte count.
+  float src_data[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+  TfLiteTensor tflite_tensor = {};
+  tflite_tensor.type = kTfLiteFloat32;
+  tflite_tensor.data.f = src_data;
+  tflite_tensor.dims = TfLiteIntArrayCreate(1);
+  tflite_tensor.dims->data[0] = 1;
+  tflite_tensor.bytes = sizeof(src_data);
+
+  constexpr float kSentinel = -1.0f;
+  float dst[4] = {kSentinel, kSentinel, kSentinel, kSentinel};
+  ASSERT_OK(CreateVectorCopyData(tflite_tensor, dst));
+  EXPECT_EQ(dst[0], 1.0f);
+  EXPECT_EQ(dst[1], kSentinel);
+  EXPECT_EQ(dst[2], kSentinel);
+  EXPECT_EQ(dst[3], kSentinel);
+
+  TfLiteIntArrayFree(tflite_tensor.dims);
+}
+
+TEST(ModelBuilderHelperTest, CreateVectorCopyDataFloatBytesSmallerThanShape) {
+  float src_data[1] = {1.0f};
+  TfLiteTensor tflite_tensor = {};
+  tflite_tensor.type = kTfLiteFloat32;
+  tflite_tensor.data.f = src_data;
+  tflite_tensor.dims = TfLiteIntArrayCreate(1);
+  tflite_tensor.dims->data[0] = 4;
+  tflite_tensor.bytes = sizeof(src_data);
+
+  float dst[4];
+  ASSERT_NOT_OK(CreateVectorCopyData(tflite_tensor, dst));
+
+  TfLiteIntArrayFree(tflite_tensor.dims);
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace tflite

--- a/tensorflow/lite/delegates/gpu/common/model_builder_test.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder_test.cc
@@ -26,6 +26,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/types/span.h"
@@ -33,7 +34,9 @@ limitations under the License.
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/core/subgraph.h"
 #include "tensorflow/lite/delegates/gpu/common/data_type.h"
+#include "tensorflow/lite/delegates/gpu/common/model.h"
 #include "tensorflow/lite/delegates/gpu/common/model_builder_internal.h"
+#include "tensorflow/lite/delegates/gpu/common/object_reader.h"
 #include "tensorflow/lite/delegates/gpu/common/shape.h"
 #include "tensorflow/lite/delegates/gpu/common/tensor.h"
 #include "tensorflow/lite/interpreter.h"
@@ -2903,6 +2906,73 @@ TEST(TileOperationParserTest, TestIsSupported) {
       parser
           ->IsSupported(context.get(), context->node(), context->registration())
           .ok());
+}
+
+// Replaces a stub tensor with a constant INT32 tensor of the given shape.
+// `data` must outlive the parse call that reads the tensor.
+void SetConstInt32Tensor(TfLiteTensor* tensor, const std::vector<int>& dims,
+                         int32_t* data) {
+  TfLiteIntArrayFree(tensor->dims);
+  tensor->dims = TfLiteIntArrayCreate(static_cast<int>(dims.size()));
+  int num_elements = 1;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    tensor->dims->data[i] = dims[i];
+    num_elements *= dims[i];
+  }
+  tensor->type = kTfLiteInt32;
+  tensor->data.i32 = data;
+  tensor->bytes = num_elements * sizeof(int32_t);
+  tensor->allocation_type = kTfLiteMmapRo;
+}
+
+// Parses the node of `context` with the parser registered for its op.
+absl::Status ParseNode(StubTfLiteContext* context) {
+  auto parser = NewOperationParser(context->registration());
+  GraphFloat32 graph;
+  absl::flat_hash_map<int, Value*> tensor_to_value;
+  ObjectReader reader(&graph, context, context->node(), &tensor_to_value);
+  return parser->Parse(context->node(), context->registration(), &graph,
+                       &reader);
+}
+
+TEST(TransposeOperationParserTest, ParseRejectsAxisOutOfRange) {
+  auto context = std::make_unique<StubTfLiteContext>(kTfLiteBuiltinTranspose,
+                                                     /*op_version=*/1,
+                                                     /*num_inputs=*/2);
+  int32_t perm_data[2] = {0, 2};
+  SetConstInt32Tensor(context->tensor(2), {2}, perm_data);
+
+  EXPECT_FALSE(ParseNode(context.get()).ok());
+}
+
+TEST(TransposeOperationParserTest, ParseRejectsNegativeAxis) {
+  auto context = std::make_unique<StubTfLiteContext>(kTfLiteBuiltinTranspose,
+                                                     /*op_version=*/1,
+                                                     /*num_inputs=*/2);
+  int32_t perm_data[3] = {0, -1, 2};
+  SetConstInt32Tensor(context->tensor(2), {3}, perm_data);
+
+  EXPECT_FALSE(ParseNode(context.get()).ok());
+}
+
+TEST(TransposeOperationParserTest, ParseRejectsAxisOutOfRangeForRank4) {
+  auto context = std::make_unique<StubTfLiteContext>(kTfLiteBuiltinTranspose,
+                                                     /*op_version=*/1,
+                                                     /*num_inputs=*/2);
+  int32_t perm_data[4] = {0, 1, 2, 4};
+  SetConstInt32Tensor(context->tensor(2), {4}, perm_data);
+
+  EXPECT_FALSE(ParseNode(context.get()).ok());
+}
+
+TEST(TransposeOperationParserTest, ParseAcceptsValidPermutation) {
+  auto context = std::make_unique<StubTfLiteContext>(kTfLiteBuiltinTranspose,
+                                                     /*op_version=*/1,
+                                                     /*num_inputs=*/2);
+  int32_t perm_data[3] = {0, 2, 1};
+  SetConstInt32Tensor(context->tensor(2), {3}, perm_data);
+
+  EXPECT_TRUE(ParseNode(context.get()).ok());
 }
 
 TEST(TransposeConvBuiltinOperationParserTest, TestIsSupported) {

--- a/tensorflow/lite/delegates/gpu/common/object_reader.cc
+++ b/tensorflow/lite/delegates/gpu/common/object_reader.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/lite/delegates/gpu/common/object_reader.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 
@@ -221,15 +222,27 @@ absl::Status ObjectReader::AddUpdate(const Node* node, uint32_t idx) {
 }
 
 TfLiteTensor* ObjectReader::GetInputTensor(int index) const {
-  return index >= 0 && index < node_->inputs->size
-             ? context_->tensors + node_->inputs->data[index]
-             : nullptr;
+  if (index < 0 || index >= node_->inputs->size) {
+    return nullptr;
+  }
+  const int tensor_id = node_->inputs->data[index];
+  if (tensor_id < 0 ||
+      static_cast<size_t>(tensor_id) >= context_->tensors_size) {
+    return nullptr;
+  }
+  return context_->tensors + tensor_id;
 }
 
 TfLiteTensor* ObjectReader::GetOutputTensor(int index) const {
-  return index >= 0 && index < node_->outputs->size
-             ? context_->tensors + node_->outputs->data[index]
-             : nullptr;
+  if (index < 0 || index >= node_->outputs->size) {
+    return nullptr;
+  }
+  const int tensor_id = node_->outputs->data[index];
+  if (tensor_id < 0 ||
+      static_cast<size_t>(tensor_id) >= context_->tensors_size) {
+    return nullptr;
+  }
+  return context_->tensors + tensor_id;
 }
 
 absl::Status ObjectReader::VerifyInputsConstsOutputs(const TfLiteNode* node,

--- a/tensorflow/lite/delegates/gpu/common/object_reader_test.cc
+++ b/tensorflow/lite/delegates/gpu/common/object_reader_test.cc
@@ -1,0 +1,82 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/delegates/gpu/common/object_reader.h"
+
+#include <gtest/gtest.h>
+
+#include "absl/container/flat_hash_map.h"
+#include "tensorflow/lite/core/c/common.h"
+#include "tensorflow/lite/delegates/gpu/common/model.h"
+
+namespace tflite {
+namespace gpu {
+namespace {
+
+TEST(ObjectReaderTest, GetInputTensorHandlesOptionalAndOutOfRange) {
+  TfLiteTensor tensors[2] = {};
+  TfLiteContext context = {};
+  context.tensors = tensors;
+  context.tensors_size = 2;
+
+  TfLiteNode node = {};
+  node.inputs = TfLiteIntArrayCreate(3);
+  node.inputs->data[0] = 1;
+  node.inputs->data[1] = kTfLiteOptionalTensor;
+  node.inputs->data[2] = 7;
+  node.outputs = TfLiteIntArrayCreate(0);
+
+  GraphFloat32 graph;
+  absl::flat_hash_map<int, Value*> tensor_to_value;
+  ObjectReader reader(&graph, &context, &node, &tensor_to_value);
+
+  EXPECT_EQ(reader.GetInputTensor(0), &tensors[1]);
+  EXPECT_EQ(reader.GetInputTensor(1), nullptr);
+  EXPECT_EQ(reader.GetInputTensor(2), nullptr);
+  EXPECT_EQ(reader.GetInputTensor(3), nullptr);
+
+  TfLiteIntArrayFree(node.inputs);
+  TfLiteIntArrayFree(node.outputs);
+}
+
+TEST(ObjectReaderTest, GetOutputTensorHandlesOptionalAndOutOfRange) {
+  TfLiteTensor tensors[2] = {};
+  TfLiteContext context = {};
+  context.tensors = tensors;
+  context.tensors_size = 2;
+
+  TfLiteNode node = {};
+  node.inputs = TfLiteIntArrayCreate(0);
+  node.outputs = TfLiteIntArrayCreate(3);
+  node.outputs->data[0] = 0;
+  node.outputs->data[1] = kTfLiteOptionalTensor;
+  node.outputs->data[2] = 7;
+
+  GraphFloat32 graph;
+  absl::flat_hash_map<int, Value*> tensor_to_value;
+  ObjectReader reader(&graph, &context, &node, &tensor_to_value);
+
+  EXPECT_EQ(reader.GetOutputTensor(0), &tensors[0]);
+  EXPECT_EQ(reader.GetOutputTensor(1), nullptr);
+  EXPECT_EQ(reader.GetOutputTensor(2), nullptr);
+  EXPECT_EQ(reader.GetOutputTensor(3), nullptr);
+
+  TfLiteIntArrayFree(node.inputs);
+  TfLiteIntArrayFree(node.outputs);
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace tflite


### PR DESCRIPTION
Fixes four out-of-bounds accesses that a malformed model can trigger while the GPU delegate builds its graph.

1. `CreateVectorCopyData<float>` copied `src.bytes` into a destination that the caller sized from `NumElements()`, so a tensor whose declared byte count exceeds its shape overflowed the destination buffer; the length check now covers every supported source type.
2. `ObjectReader::GetInputTensor`/`GetOutputTensor` added `kTfLiteOptionalTensor` (-1) to `context->tensors`, handing callers a pointer before the start of the array that they then dereferenced.
3.  `TransposeOperationParser::Parse` used the permutation entries as indices into `index_to_axis` without validating them, so an entry outside `[0, rank)` read past the end of that table.
4. `BatchToSpaceOperationParser::Parse` and `SpaceToBatchOperationParser::Parse` rejected the crop/padding shape with `&&` instead of `||`, letting a 2x1 tensor through before reading `data[3]`.

see chromium issue: https://issues.chromium.org/issues/500050511