### PR TITLE
Reject invalid input_sizes in the oneDNN conv backprop-input kernel instead of aborting

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -362,6 +362,26 @@ class MklConvCustomBackpropInputOp
       // Allow operator-specific sanity checking of shapes.
       ValidateMklShapes(src_mkl_shape, filter_mkl_shape, diff_dst_mkl_shape);
 
+      // This class backs Conv2D, Conv3D and depthwise backprop-input (see the
+      // registrations at the bottom of this file), so the expected element
+      // count follows the rank of out_backprop, already checked above. Only
+      // the two-value case is validated below; every other count would reach
+      // MakeInputTfShape unchecked and could build a shape of the wrong rank.
+      // IsVector is checked first because dim_size(0) is not defined on a
+      // rank-0 tensor.
+      OP_REQUIRES(context, TensorShapeUtils::IsVector(src_tensor.shape()),
+                  absl::InvalidArgumentError(absl::StrCat(
+                      this->type_string(),
+                      ": input_sizes input must be 1-dim, not ",
+                      src_tensor.dims())));
+      OP_REQUIRES(context,
+                  src_tensor.dim_size(0) == diff_dst_tensor.dims() ||
+                      src_tensor.dim_size(0) == 2,
+                  absl::InvalidArgumentError(absl::StrCat(
+                      this->type_string(), " requires input_sizes to contain ",
+                      diff_dst_tensor.dims(), " values or 2 values, but got: ",
+                      src_tensor.dim_size(0))));
+
       // Allow operator-specific generation of shapes.
       // E.g., ConvBackpropFilter gets filter as filter_sizes. It is a
       // tensor containing shape of filter. So filter.shape() is not

--- a/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
@@ -3197,6 +3197,56 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
             dilations=[1, 1, 1, 1])
         self.evaluate(t)
 
+  @test_util.run_v2_only
+  def testConv2DBackpropInputInvalidInputSizesRaiseError(self):
+    # The oneDNN kernel validated input_sizes only when it held two values.
+    # Any other count reached MakeInputTfShape unchecked and aborted the
+    # process on a CHECK instead of raising. Eager only: in graph mode the
+    # shape function rejects these before the kernel is reached.
+    filters = constant_op.constant(
+        0.1, shape=[3, 3, 3, 3], dtype=dtypes.float32)
+    out_backprop = constant_op.constant(
+        0.1, shape=[1, 4, 4, 3], dtype=dtypes.float32)
+
+    with self.assertRaisesRegex(
+        errors_impl.InvalidArgumentError,
+        "input_sizes to contain 4 values or 2 values"):
+      self.evaluate(
+          gen_nn_ops.conv2d_backprop_input(
+              input_sizes=constant_op.constant(
+                  [8, 8, 3], shape=[3], dtype=dtypes.int32),
+              filter=filters,
+              out_backprop=out_backprop,
+              strides=[1, 2, 2, 1],
+              padding="SAME"))
+
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "input_sizes input must be 1-dim"):
+      self.evaluate(
+          gen_nn_ops.conv2d_backprop_input(
+              input_sizes=constant_op.constant(8, dtype=dtypes.int32),
+              filter=filters,
+              out_backprop=out_backprop,
+              strides=[1, 2, 2, 1],
+              padding="SAME"))
+
+    # Control case. The same kernel class also backs Conv3DBackpropInputV2,
+    # whose input_sizes holds five values, so the guard has to follow the rank
+    # of out_backprop rather than assume four.
+    filters_3d = constant_op.constant(
+        0.1, shape=[3, 3, 3, 3, 3], dtype=dtypes.float32)
+    out_backprop_3d = constant_op.constant(
+        0.1, shape=[1, 4, 4, 4, 3], dtype=dtypes.float32)
+    self.assertAllEqual(
+        self.evaluate(
+            gen_nn_ops.conv3d_backprop_input_v2(
+                input_sizes=constant_op.constant(
+                    [1, 8, 8, 8, 3], shape=[5], dtype=dtypes.int32),
+                filter=filters_3d,
+                out_backprop=out_backprop_3d,
+                strides=[1, 2, 2, 2, 1],
+                padding="SAME")).shape, [1, 8, 8, 8, 3])
+
 
 @test_util.run_all_without_tensor_float_32("Avoid TF32 conv on GPU")
 class DepthwiseConv2DTest(test.TestCase):


### PR DESCRIPTION
## Problem

`tf.raw_ops.Conv2DBackpropInput` terminates the process instead of raising when `input_sizes` has
an element count other than 4 or 2, on CPU builds with oneDNN enabled.

```python
tf.raw_ops.Conv2DBackpropInput(
    input_sizes=[8, 8, 3],                      # 3 values
    filter=tf.random.normal([3, 3, 3, 3]),
    out_backprop=tf.random.normal([1, 4, 4, 3]),
    strides=[1, 2, 2, 1], padding="SAME")
```

```
F tensor_format.h:428] Check failed: index >= 0 && index < num_total_dims
  Invalid index from the dimension: 3, 0, C
```

A rank-0 `input_sizes` aborts too. With `TF_ENABLE_ONEDNN_OPTS=0` both cases raise
`InvalidArgumentError`, so the stock kernels are already correct and only the oneDNN path aborts.
oneDNN is on by default in released CPU wheels.

## Relationship to #125511

I found this through #125511, which reports the abort through `tf.nn.conv2d_transpose`. That path
is already fixed on master: `conv2d_transpose_v2` gained an `output_shape` element-count check in
2146a338d34 and 177713ebad2, and `conv2d_transpose_test.py` covers it. The issue's own repro no
longer reproduces on master.

The kernel hole those commits shadowed is still open, because `tf.raw_ops.Conv2DBackpropInput` does
not go through the Python wrapper. This PR closes that hole. I have not used a closing keyword,
since this does not fix everything #125511 describes.

## Root cause

`MklConvCustomBackpropInputOp::Compute` dispatches on the element count:

```cpp
if (src_tensor.dim_size(0) == 2) {
  OP_REQUIRES_OK(context, Conv2DBackpropComputeInputShape(...));
} else {
  src_tf_shape = MakeInputTfShape(context, src_tensor);
}
```

Only the two-value case is validated. Every other count reaches `MakeInputTfShape`, which builds a
`TensorShape` from whatever it was given, so three values produce a rank-3 shape that later reaches
`GetTensorDim(..., 'C')` and fails the CHECK. Both stock kernels in `conv_grad_input_ops.h` call
`Conv2DBackpropComputeInputShape` unconditionally, and that helper rejects any count but 4 and 2.

This class template is not Conv2D only. It backs six registrations at
`mkl_conv_grad_input_ops.cc:669-699` on master: `_MklConv2DBackpropInput`,
`_MklConv3DBackpropInputV2`, `_MklDepthwiseConv2dNativeBackpropInput` and their three
`_MklNative` twins. The valid element
count therefore differs per op: 4 for the Conv2D and depthwise ops, 5 for `Conv3DBackpropInputV2`.

## Fix

Two `OP_REQUIRES` checks before the dispatch.

The count check follows `diff_dst_tensor.dims()`, which `Compute` has already constrained to 4 or 5
a few lines above. That gives 4-or-2 for the Conv2D and depthwise ops and 5-or-2 for Conv3D,
without introducing any new state and without hardcoding a rank the shared template does not have.

`IsVector` is checked first because `Tensor::dim_size` is only DCHECK-guarded, so reading
`dim_size(0)` on a rank-0 tensor is undefined in an optimized build.

Both messages carry `type_string()` so they name the op that actually ran, rather than hardcoding
`Conv2DBackpropInput` in a kernel shared by three op types. All six registrations are `_Mkl`
prefixed, so that name differs from the stock one. The wording after the op name is taken from
`conv_grad_shape_utils.cc`, so for `Conv2DBackpropInput` the message tail is byte-identical with
oneDNN on and off. The stock Conv3D and depthwise kernels reject a bad count elsewhere and word
it differently (`input tensor must have 5 dimensions` and `DepthwiseConv2DBackpropInput: input
must be 4-dimensional`), so for those two ops the convention is shared but the text is not.

## Why not call the shared helper unconditionally

That was my first approach, and it is wrong twice over.

It would reject `Conv3DBackpropInputV2` outright, since the helper is Conv2D-specific and allows
only 4 or 2. Measured on 2.21.0 with oneDNN on, `input_sizes=[1, 8, 8, 8, 3]` returns shape
`(1, 8, 8, 8, 3)` today.

It would also delete a working oneDNN feature. `MakeInputTfShape` routes through
`HandleDynamicShape`, which substitutes the batch size when `input_sizes[0]` is -1. The shared
helper calls `TensorShapeUtils::MakeShape`, which rejects a negative dimension. Measured with
`input_sizes=[-1, 8, 8, 3]`:

| | result |
|---|---|
| oneDNN on | returns shape `(1, 8, 8, 3)` |
| oneDNN off | `InvalidArgumentError: Dimension -1 must be >= 0` |

The additive guard leaves every currently-accepted count reaching exactly the code it reaches today.

## Test

`conv_ops_test.py` gains one case next to the existing
`testConv2DBackpropInputInvalidOutBackpropRaiseError`, which already builds `input_sizes` by hand
for this op. It covers the three-element and rank-0 inputs, and then asserts as a control that a
valid five-element `Conv3DBackpropInputV2` still returns `(1, 8, 8, 8, 3)`, so the guard cannot
pass by rejecting everything.

It is eager only. In graph mode the shape function raises `ValueError` at trace time, in both
oneDNN modes, so a graph-mode assertion would pass without ever reaching the kernel.

## Reachability

`DefaultOneDnnPolicy` in `core/util/port.cc` returns true for Google-internal builds and for
Windows x86, and on Linux only when the CPU reports AVX512-VNNI, AVX512-BF16, AVX-VNNI, one of the
AMX features, or ARM Neoverse V1. So the test covers the patched kernel deterministically on
internal presubmit and on Windows, and CPU-dependently on public Linux CI. Where oneDNN is off, the
same assertions pass against the stock kernel, so the test degrades to a duplicate rather than a
flake.

## Out of scope

`MakeInputTfShape` still contains a raw `CHECK_EQ` and a `TF_CHECK_OK` (on master, lines 594 and
610). The first becomes unreachable for these ops, the second is still reachable through negative
dimension values. Observed, not fixed here.

## Verification

I did not build locally, so the C++ has not been compiled and the new test has not run against a
patched build. Runtime verification is left to the presubmit CI, which builds and runs
`//tensorflow/python/kernel_tests/nn_ops:conv_ops_test`.

Checked against the released 2.21.0 wheel, whose `mkl_conv_grad_input_ops.cc` matches master at the
dispatch shown above:

- Both aborts reproduce, with the exit code and CHECK text quoted at the top.
- The new test body, run verbatim with oneDNN on, aborts the process, so it fails on the unfixed
  kernel. Run with oneDNN off, all three assertions pass: both regexes were matched against the
  real message with `re.search`, and the Conv3D control returned `(1, 8, 8, 8, 3)`.
- The `[-1, 8, 8, 3]` and `[1, 8, 8, 8, 3]` results quoted above are measured pre-fix baselines.
  The guard admits both counts unchanged, so those paths are untouched by inspection, not by
  execution.
