### PR TITLE
fix(math): correct xdivy gradient w.r.t. x at x=0

### DIFF
--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -821,9 +821,10 @@ def _XDivyGrad(op: ops.Operation, grad):
   sy = array_ops.shape(y)
   rx, ry = gen_array_ops.broadcast_gradient_args(sx, sy)
   with ops.control_dependencies([grad]):
-    not_zero_x = math_ops.cast(
-        math_ops.not_equal(x, math_ops.cast(0., dtype=x.dtype)), dtype=x.dtype)
-    partial_x = gen_math_ops.xdivy(not_zero_x, y)
+    # The gradient of xdivy w.r.t. x is 1 / y for all x (including x=0),
+    # because d/dx (x / y) = 1 / y. The zero-mask should only apply to
+    # the forward value, not the derivative w.r.t. x.
+    partial_x = math_ops.reciprocal(y)
     partial_y = gen_math_ops.xdivy(math_ops.negative(x), y**2)
     return (array_ops.reshape(math_ops.reduce_sum(partial_x * grad, rx), sx),
             array_ops.reshape(math_ops.reduce_sum(partial_y * grad, ry), sy))

--- a/tensorflow/python/ops/math_grad_test.py
+++ b/tensorflow/python/ops/math_grad_test.py
@@ -670,12 +670,16 @@ class XdivyTest(test.TestCase):
   @test_util.run_deprecated_v1
   def testZeroXGrad(self):
     for dtype in [dtypes.float16, dtypes.float32, dtypes.float64]:
-      x = constant_op.constant(0., dtype=dtype)
-      y = constant_op.constant(3.1, dtype=dtype)
-      xdivy_xgrad, xdivy_ygrad = self._xdivy_gradients(x, y)
-      zero = self.evaluate(x)
-      self.assertAllClose(zero, xdivy_xgrad)
-      self.assertAllClose(zero, xdivy_ygrad)
+      for y_val in [3.1, 0.0]:
+        x = constant_op.constant(0.0, dtype=dtype)
+        y = constant_op.constant(y_val, dtype=dtype)
+        xdivy_xgrad, xdivy_ygrad = self._xdivy_gradients(x, y)
+        # Gradient w.r.t. x at x=0 should be 1 / y, not 0.
+        # d/dx (x / y) = 1 / y for all x including x=0.
+        expected_xgrad = self.evaluate(1 / y)
+        zero = self.evaluate(x)
+        self.assertAllClose(expected_xgrad, xdivy_xgrad)
+        self.assertAllClose(zero, xdivy_ygrad)
 
   @test_util.run_deprecated_v1
   def testZeroYGrad(self):
@@ -692,9 +696,19 @@ class XdivyTest(test.TestCase):
       x = constant_op.constant(0., dtype=dtype)
       y = constant_op.constant(0., dtype=dtype)
       xdivy_xgrad, xdivy_ygrad = self._xdivy_gradients(x, y)
+      # Gradient w.r.t. x at x=0, y=0 is 1 / 0 = inf.
+      self.assertAllClose(np.inf, xdivy_xgrad)
       zero = self.evaluate(x)
-      self.assertAllClose(zero, xdivy_xgrad)
       self.assertAllClose(zero, xdivy_ygrad)
+
+  def testZeroNumeratorTapeGrad(self):
+    x = constant_op.constant(0.0, dtype=dtypes.float64)
+    y = constant_op.constant(2.0, dtype=dtypes.float64)
+    with backprop.GradientTape() as tape:
+      tape.watch(x)
+      z = math_ops.xdivy(x, y)
+    grad = tape.gradient(z, x)
+    self.assertAllClose(0.5, self.evaluate(grad))
 
 
 @test_util.run_all_in_graph_and_eager_modes


### PR DESCRIPTION
Fixes #127238
Fixes #127240

### Description
The gradient of `xdivy(x, y)` w.r.t. `x` should be `1 / y` for all `x` (including `x=0`), because `d/dx (x / y) = 1 / y`. Previously, `_XDivyGrad` in `tensorflow/python/ops/math_grad.py` applied an erroneous zero-mask `not_zero_x` which dropped numerator derivative terms when `x = 0`, also causing nested autodiff through `tf.math.xlogy` to lose mixed second-derivative terms.

This change removes the zero-mask on `partial_x` in `_XDivyGrad` and replaces it with `math_ops.reciprocal(y)`, matching the mathematical behavior and convention established for `_XLogyGrad` in #119869.

### Verification
- Updated `XdivyTest` in `tensorflow/python/ops/math_grad_test.py` (`testZeroXGrad` and `testZeroXYGrad`, plus added `testZeroNumeratorTapeGrad`). All unit tests pass.
- Verified standalone reproducers for #127238 and #127240; both produce exact expected derivatives.
